### PR TITLE
feat: add bounded run-loop skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ checks, backend abstractions, workspace safety helpers, event-log primitives,
 and an operator-readable status snapshot with event-log and integration-gap
 links.
 
-It does **not** yet autonomously execute GitHub Project v2 issues, run
-Codex/Claude, or supervise long-running workers. Some explicit GitHub tracker
-write commands exist for operator use, but they are not wired into a live
-orchestration loop yet.
+It does **not** yet fully autonomously execute GitHub Project v2 issues,
+run Codex/Claude through the final app-server flow, or supervise long-running
+workers. A bounded `run-loop` skeleton now exists, but full claim
+reconciliation, runtime resume, and one-issue-one-PR automation are still
+future work.
 
 ## What Works Now
 
@@ -48,6 +49,10 @@ orchestration loop yet.
   dry-run backend, and append JSONL events.
 - `run-once` can execute the conservative Codex subprocess backend when a
   workflow explicitly sets `agent.backend: codex`.
+- `run-loop` can re-read tracker state per iteration, select dispatchable work,
+  print dry-run claim/run/workpad/handoff actions, and in explicit `--write`
+  mode run one issue at a time and stop main-agent completion at
+  `Agent Review`.
 
 ## Dry-Run Only
 
@@ -82,6 +87,7 @@ cargo run -- plan-dispatch examples/dry-run-workflow.md
 cargo run -- status examples/dry-run-workflow.md
 cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-once examples/codex-subprocess-workflow.md
+cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
 cargo run -- plan examples/linear-fixture-workflow.md
 cargo run -- gate examples/dry-run-workflow.md '#3'
 cargo run -- forge-discover --intent "Add Issue Forge validate and repair commands"
@@ -114,8 +120,9 @@ cargo run -- review-fake path/to/WORKFLOW.md '#123' --outcome pass --write
 `review-once` / `review-fake` are independent Review Agent commands: a passing
 review can move `Agent Review` to `Human Review`, confirmed findings move to
 `Rework`, and failed or inconclusive reviews do not advance to `Human Review`.
-These commands are adapter operations, not autonomous orchestration. Use them
-carefully until the polling runtime and reconciliation loop exists.
+These commands are adapter operations plus the first bounded runtime-loop
+skeleton, not full autonomous orchestration. Use write mode carefully until
+claim reconciliation, resume state, and PR automation exist.
 
 ## Stubbed
 
@@ -129,8 +136,10 @@ carefully until the polling runtime and reconciliation loop exists.
 
 ## Not Implemented Yet
 
-- live polling loop.
+- continuous live polling loop beyond bounded `run-loop` iterations.
 - real issue claiming, state transitions, and reconciliation.
+- runtime state persistence and resume.
+- workspace-per-issue branch and PR automation.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.
 - live token/rate-limit accounting beyond the current snapshot counters.
@@ -170,6 +179,7 @@ Dry-run dispatch:
 ```bash
 cargo run -- plan examples/dry-run-workflow.md
 cargo run -- run-once examples/dry-run-workflow.md
+cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
 ```
 
 The dry-run workflow uses:

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -1,8 +1,8 @@
 # Dogfood Readiness
 
 Status: dry-run dogfood baseline with read-only GitHub Project v2 loading through
-the `gh` CLI. Jade Symphony is not ready to execute live GitHub Project v2 issues
-yet.
+the `gh` CLI and a bounded `run-loop` skeleton. Jade Symphony is not ready for
+unattended live GitHub Project v2 execution yet.
 
 ## Current Capability Status
 
@@ -11,11 +11,11 @@ yet.
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
 | Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
-| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. No autonomous orchestration loop yet. |
+| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. Bounded `run-loop` can coordinate existing primitives, but full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, and repair against Markdown/input. Live tracker issue creation is not implemented yet. |
-| Orchestrator | Deterministic dispatch planning exists. No long-running poll loop, worker supervision, retry timers, or state reconciliation yet. |
+| Orchestrator | Deterministic dispatch planning and a bounded CLI `run-loop` skeleton exist. No long-running worker supervision, retry timers, runtime resume, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, and safe cleanup helpers exist. Runtime reconciliation cleanup is not wired yet. |
 | Agent backends | Dry-run backend and a conservative Codex subprocess backend exist. Claude Code remains a trait-preserving stub. Full Codex app-server protocol parity is not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
@@ -83,8 +83,9 @@ Project v2 issues:
      workspace.
 
 7. Long-running orchestration.
-   - Poll loop.
+   - Continuous poll loop beyond bounded `run-loop` iterations.
    - claimed/running/retry state ownership.
+   - runtime state persistence and resume.
    - continuation retry after normal active-state exits.
    - exponential backoff for failures.
    - stall detection.
@@ -138,8 +139,8 @@ Acceptance:
 
 ### 3. Turn Dispatch Plan Into Polling Runtime
 
-Goal: evolve `Orchestrator::plan_dispatch` into a long-running runtime while
-preserving deterministic planning tests.
+Goal: evolve the bounded `run-loop` skeleton and `Orchestrator::plan_dispatch`
+into a long-running runtime while preserving deterministic planning tests.
 
 Acceptance:
 
@@ -152,6 +153,8 @@ Acceptance:
   the existing workpad/state adapter operations.
 - keeps terminal status snapshots linked to the active event log and integration
   gaps.
+- persists active issue, workspace, backend session, attempt count, and last
+  transition for resume.
 
 ### 4. Implement Full Codex App-Server Backend
 
@@ -213,14 +216,17 @@ Acceptance:
 
 ```bash
 cargo run -- examples/dry-run-workflow.md
+cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
 ```
 
-This command should remain credential-free and deterministic. It is the local
-smoke test for dispatch planning until live GitHub Project v2 integration exists.
+These commands should remain credential-free and deterministic. They are the
+local smoke tests for dispatch planning and bounded loop behavior until live
+GitHub Project v2 execution is hardened.
 
 ## Live Project Template
 
 `examples/github-project-workflow.md` is a non-fixture workflow template for
 manual live Project v2 reads and explicit tracker writes through `gh`. It still
-uses the `dry-run` backend by default and should not be treated as autonomous
-agent execution.
+uses the `dry-run` backend by default. `run-loop --write` is available only as a
+bounded skeleton and should not be treated as full autonomous agent execution
+until claim reconciliation, runtime resume, and PR automation exist.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -359,7 +359,7 @@ mod tests {
     #[test]
     fn codex_backend_runs_subprocess_in_workspace() {
         let temp = tempfile::tempdir().unwrap();
-        let config = codex_config("cat > response.txt", 1_000);
+        let config = codex_config("cat > response.txt", 5_000);
         let backend = CodexBackend;
         let prepared = backend
             .prepare(temp.path().to_path_buf(), "hello prompt".into(), &config)
@@ -377,7 +377,7 @@ mod tests {
     #[test]
     fn codex_backend_reports_subprocess_failure() {
         let temp = tempfile::tempdir().unwrap();
-        let config = codex_config("echo nope >&2; exit 7", 1_000);
+        let config = codex_config("echo nope >&2; exit 7", 5_000);
         let backend = CodexBackend;
         let prepared = backend
             .prepare(temp.path().to_path_buf(), "prompt".into(), &config)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use jade_symphony::agent::backend_from_config;
 use jade_symphony::config::RuntimeConfig;
@@ -36,6 +36,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Command::Validate { workflow_path } => validate(workflow_path),
         Command::Inspect { workflow_path } => inspect(workflow_path),
         Command::RunOnce { workflow_path } => run_once(workflow_path),
+        Command::RunLoop { options } => run_loop(options),
         Command::SetState {
             workflow_path,
             issue_ref,
@@ -371,7 +372,7 @@ fn require_write_intent(write: bool) -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-fn load_config(workflow_path: &PathBuf) -> Result<RuntimeConfig, Box<dyn std::error::Error>> {
+fn load_config(workflow_path: &Path) -> Result<RuntimeConfig, Box<dyn std::error::Error>> {
     let workflow = WorkflowDefinition::load(workflow_path)?;
     let config = RuntimeConfig::from_workflow(&workflow, workflow_path)?;
     config.validate()?;
@@ -437,14 +438,46 @@ fn run_once(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
         return Ok(());
     };
 
+    let result = execute_issue_once(&workflow, &config, issue)?;
+
+    println!("run_once=completed");
+    println!("issue={} {}", issue.identifier, issue.title);
+    println!("workspace={}", result.workspace_path.display());
+    println!("backend={}", result.backend);
+    println!("success={}", result.success);
+    println!(
+        "event_log={}",
+        config
+            .observability
+            .logs_root
+            .join("jade-symphony.jsonl")
+            .display()
+    );
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IssueExecutionResult {
+    workspace_path: PathBuf,
+    backend: String,
+    success: bool,
+    session_id: Option<String>,
+    message: String,
+}
+
+fn execute_issue_once(
+    workflow: &WorkflowDefinition,
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+) -> Result<IssueExecutionResult, Box<dyn std::error::Error>> {
     let workspace = prepare_workspace(&config.workspace.root, &issue.identifier, &config.hooks)?;
     run_before_run(&workspace.path, &config.hooks)?;
 
     let prompt = render_prompt(&workflow.prompt_template, issue, None)?;
     std::fs::write(workspace.path.join("JADE_SYMPHONY_PROMPT.md"), &prompt)?;
 
-    let backend = backend_from_config(&config);
-    let prepared = backend.prepare(workspace.path.clone(), prompt, &config)?;
+    let backend = backend_from_config(config);
+    let prepared = backend.prepare(workspace.path.clone(), prompt, config)?;
     let events = backend.run(prepared)?;
     let summary = backend.summarize(&events);
     run_after_run(&workspace.path, &config.hooks);
@@ -460,20 +493,194 @@ fn run_once(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
         })?;
     }
 
-    println!("run_once=completed");
-    println!("issue={} {}", issue.identifier, issue.title);
-    println!("workspace={}", workspace.path.display());
-    println!("backend={}", summary.backend);
-    println!("success={}", summary.success);
-    println!(
-        "event_log={}",
-        config
-            .observability
-            .logs_root
-            .join("jade-symphony.jsonl")
-            .display()
-    );
+    Ok(IssueExecutionResult {
+        workspace_path: workspace.path,
+        backend: summary.backend,
+        success: summary.success,
+        session_id: summary.session_id,
+        message: summary.message,
+    })
+}
+
+fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
+    let limit = options.iteration_limit();
+    let mut iterations = 0usize;
+
+    loop {
+        if let Some(max) = limit {
+            if iterations >= max {
+                println!("run_loop=stopped reason=max_iterations iterations={iterations}");
+                break;
+            }
+        }
+
+        iterations += 1;
+        let workflow = WorkflowDefinition::load(&options.workflow_path)?;
+        let config = RuntimeConfig::from_workflow(&workflow, &options.workflow_path)?;
+        config.validate()?;
+        let adapter = adapter_from_config(&config);
+        let issues = adapter.list_dispatchable_issues()?;
+        let orchestrator = Orchestrator::new(config.clone());
+        let mut plan = orchestrator.plan_dispatch(issues);
+        plan.integration_gaps.extend(adapter.integration_gaps());
+        plan.snapshot.integration_gaps = plan.integration_gaps.clone();
+        plan.snapshot.event_log_path = Some(
+            config
+                .observability
+                .logs_root
+                .join("jade-symphony.jsonl")
+                .display()
+                .to_string(),
+        );
+
+        let Some(issue) = plan.selected.first().cloned() else {
+            println!("{}", render_snapshot(&plan.snapshot));
+            println!("run_loop=stopped reason=no_dispatchable_issue iterations={iterations}");
+            break;
+        };
+
+        let decision = evaluate_issue(&issue);
+        if !decision.is_dispatchable() {
+            handle_run_loop_gate_failure(adapter.as_ref(), &issue, &decision, &options)?;
+            continue;
+        }
+
+        println!(
+            "run_loop_iteration={} issue={} title={:?} mode={}",
+            iterations,
+            issue.identifier,
+            issue.title,
+            if options.write { "write" } else { "dry-run" }
+        );
+
+        if !options.write {
+            print_run_loop_dry_run_actions(&issue);
+            if limit.is_none() {
+                println!(
+                    "run_loop=stopped reason=dry_run_would_repeat_without_mutation iterations={iterations}"
+                );
+                break;
+            }
+            continue;
+        }
+
+        let latest = adapter
+            .get_issue(&issue.identifier)?
+            .ok_or_else(|| format!("issue disappeared before claim: {}", issue.identifier))?;
+        let latest_gate = evaluate_issue(&latest);
+        if !latest_gate.is_dispatchable() {
+            handle_run_loop_gate_failure(adapter.as_ref(), &latest, &latest_gate, &options)?;
+            continue;
+        }
+
+        if normalize_state(&latest.state) != "in progress" {
+            adapter.set_state(&latest.identifier, "in_progress")?;
+            println!(
+                "run_loop_action=claim issue={} target_state=in_progress",
+                latest.identifier
+            );
+        } else {
+            println!("run_loop_action=resume issue={}", latest.identifier);
+        }
+
+        let result = execute_issue_once(&workflow, &config, &latest)?;
+        let workpad = run_loop_handoff_workpad(&latest, &result);
+        adapter.upsert_workpad(&latest.identifier, &workpad)?;
+
+        if result.success {
+            if !transition_allowed_for_main_agent("agent_review") {
+                return Err("main implementation agent cannot set requested review state".into());
+            }
+            adapter.set_state(&latest.identifier, "agent_review")?;
+            println!(
+                "run_loop_action=handoff issue={} target_state=agent_review",
+                latest.identifier
+            );
+        } else {
+            adapter.set_state(&latest.identifier, "need_human_input")?;
+            println!(
+                "run_loop_action=blocked issue={} target_state=need_human_input",
+                latest.identifier
+            );
+        }
+    }
+
     Ok(())
+}
+
+fn handle_run_loop_gate_failure(
+    adapter: &dyn jade_symphony::tracker::TrackerAdapter,
+    issue: &TrackerIssue,
+    decision: &GateDecision,
+    options: &RunLoopOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "run_loop_gate=failed issue={} decision={:?}",
+        issue.identifier, decision.kind
+    );
+    if options.write {
+        adapter.upsert_workpad(&issue.identifier, &gate_workpad(issue, decision))?;
+        adapter.set_state(&issue.identifier, gate_target_state(decision))?;
+    } else {
+        println!(
+            "run_loop_dry_run action=workpad issue={} reason=quality_gate_failed",
+            issue.identifier
+        );
+        println!(
+            "run_loop_dry_run action=set_state issue={} target_state={}",
+            issue.identifier,
+            gate_target_state(decision)
+        );
+    }
+    Ok(())
+}
+
+fn print_run_loop_dry_run_actions(issue: &TrackerIssue) {
+    if normalize_state(&issue.state) != "in progress" {
+        println!(
+            "run_loop_dry_run action=claim issue={} target_state=in_progress",
+            issue.identifier
+        );
+    } else {
+        println!("run_loop_dry_run action=resume issue={}", issue.identifier);
+    }
+    println!(
+        "run_loop_dry_run action=run issue={} backend=configured",
+        issue.identifier
+    );
+    println!(
+        "run_loop_dry_run action=workpad issue={} evidence=run_summary",
+        issue.identifier
+    );
+    println!(
+        "run_loop_dry_run action=handoff issue={} target_state=agent_review",
+        issue.identifier
+    );
+}
+
+fn run_loop_handoff_workpad(issue: &TrackerIssue, result: &IssueExecutionResult) -> String {
+    [
+        "## Jade Symphony Workpad".to_string(),
+        String::new(),
+        "### Context".to_string(),
+        format!("- Issue: {} {}", issue.identifier, issue.title),
+        "- Source: `jade-symphony run-loop`".to_string(),
+        String::new(),
+        "### Run Evidence".to_string(),
+        format!("- Workspace: `{}`", result.workspace_path.display()),
+        format!("- Backend: `{}`", result.backend),
+        format!("- Success: `{}`", result.success),
+        format!(
+            "- Session: `{}`",
+            result.session_id.as_deref().unwrap_or("n/a")
+        ),
+        format!("- Message: {}", result.message),
+        String::new(),
+        "### Main-Agent Boundary".to_string(),
+        "- Locally complete main-agent work stops at `Agent Review`.".to_string(),
+        "- `Human Review` is reserved for independent Review Agent pass evidence.".to_string(),
+    ]
+    .join("\n")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -489,6 +696,9 @@ enum Command {
     },
     RunOnce {
         workflow_path: PathBuf,
+    },
+    RunLoop {
+        options: RunLoopOptions,
     },
     SetState {
         workflow_path: PathBuf,
@@ -552,6 +762,24 @@ enum Command {
     Help,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunLoopOptions {
+    workflow_path: PathBuf,
+    max_iterations: Option<usize>,
+    once: bool,
+    write: bool,
+}
+
+impl RunLoopOptions {
+    fn iteration_limit(&self) -> Option<usize> {
+        if self.once {
+            Some(1)
+        } else {
+            self.max_iterations
+        }
+    }
+}
+
 impl Command {
     fn parse(args: Vec<String>) -> Result<Self, String> {
         if args.is_empty() {
@@ -574,6 +802,7 @@ impl Command {
             "run-once" => Ok(Self::RunOnce {
                 workflow_path: workflow_arg(&args[1..]),
             }),
+            "run-loop" => parse_run_loop(&args[1..]),
             "set-state" => parse_set_state(&args[1..]),
             "workpad" => parse_workpad(&args[1..]),
             "create-follow-up" => parse_create_follow_up(&args[1..]),
@@ -658,6 +887,55 @@ fn parse_gate(args: &[String], apply: bool) -> Result<Command, String> {
         issue_ref: args[1].clone(),
         apply,
         write,
+    })
+}
+
+fn parse_run_loop(args: &[String]) -> Result<Command, String> {
+    let mut workflow_path = None;
+    let mut max_iterations = None;
+    let mut once = false;
+    let mut write = false;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--write" => {
+                write = true;
+                index += 1;
+            }
+            "--dry-run" => {
+                index += 1;
+            }
+            "--once" => {
+                once = true;
+                index += 1;
+            }
+            "--max-iterations" if index + 1 < args.len() => {
+                let value = args[index + 1].parse::<usize>().map_err(|_| usage())?;
+                if value == 0 {
+                    return Err(usage());
+                }
+                max_iterations = Some(value);
+                index += 2;
+            }
+            value if value.starts_with('-') => return Err(usage()),
+            value => {
+                if workflow_path.is_some() {
+                    return Err(usage());
+                }
+                workflow_path = Some(PathBuf::from(value));
+                index += 1;
+            }
+        }
+    }
+
+    Ok(Command::RunLoop {
+        options: RunLoopOptions {
+            workflow_path: workflow_path.unwrap_or_else(|| PathBuf::from("WORKFLOW.md")),
+            max_iterations,
+            once,
+            write,
+        },
     })
 }
 
@@ -937,6 +1215,7 @@ fn usage() -> String {
         "  jade-symphony validate-workflow [path-to-WORKFLOW.md]",
         "  jade-symphony inspect [path-to-WORKFLOW.md]",
         "  jade-symphony run-once [path-to-WORKFLOW.md]",
+        "  jade-symphony run-loop [path-to-WORKFLOW.md] [--max-iterations <n> | --once] [--dry-run | --write]",
         "  jade-symphony set-state <path-to-WORKFLOW.md> <issue-ref> <normalized-state> --write",
         "  jade-symphony workpad <path-to-WORKFLOW.md> <issue-ref> <markdown-file> --write",
         "  jade-symphony create-follow-up --workflow <path-to-WORKFLOW.md> --title <title> --body-file <markdown-file> --write",
@@ -954,4 +1233,66 @@ fn usage() -> String {
         "Compatibility: `jade-symphony <path-to-WORKFLOW.md>` is treated as `plan`.",
     ]
     .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_run_loop_flags() {
+        let command = Command::parse(vec![
+            "run-loop".into(),
+            "examples/dry-run-workflow.md".into(),
+            "--max-iterations".into(),
+            "3".into(),
+            "--dry-run".into(),
+        ])
+        .unwrap();
+
+        let Command::RunLoop { options } = command else {
+            panic!("expected run-loop command");
+        };
+
+        assert_eq!(
+            options.workflow_path,
+            PathBuf::from("examples/dry-run-workflow.md")
+        );
+        assert_eq!(options.max_iterations, Some(3));
+        assert!(!options.once);
+        assert!(!options.write);
+    }
+
+    #[test]
+    fn run_loop_once_overrides_max_iterations() {
+        let command = Command::parse(vec![
+            "run-loop".into(),
+            "WORKFLOW.md".into(),
+            "--max-iterations".into(),
+            "9".into(),
+            "--once".into(),
+            "--write".into(),
+        ])
+        .unwrap();
+
+        let Command::RunLoop { options } = command else {
+            panic!("expected run-loop command");
+        };
+
+        assert_eq!(options.iteration_limit(), Some(1));
+        assert!(options.write);
+    }
+
+    #[test]
+    fn rejects_zero_run_loop_iterations() {
+        let error = Command::parse(vec![
+            "run-loop".into(),
+            "WORKFLOW.md".into(),
+            "--max-iterations".into(),
+            "0".into(),
+        ])
+        .unwrap_err();
+
+        assert!(error.contains("Usage:"));
+    }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -270,7 +270,7 @@ mod tests {
             temp.path(),
             &HooksConfig {
                 before_run: Some("echo out; echo err >&2; exit 2".into()),
-                timeout_ms: 1_000,
+                timeout_ms: 5_000,
                 ..Default::default()
             },
         );
@@ -297,7 +297,7 @@ mod tests {
             temp.path(),
             "#cleanup",
             &HooksConfig {
-                timeout_ms: 1_000,
+                timeout_ms: 5_000,
                 ..Default::default()
             },
         )
@@ -307,7 +307,7 @@ mod tests {
             "#cleanup",
             &HooksConfig {
                 before_remove: Some("printf removed > ../removed.txt".into()),
-                timeout_ms: 1_000,
+                timeout_ms: 5_000,
                 ..Default::default()
             },
         )


### PR DESCRIPTION
## Summary

- Adds `jade-symphony run-loop <workflow>` with `--max-iterations`, `--once`, `--dry-run`, and `--write`.
- Reuses existing planning, quality gate, single-issue execution, workpad, and tracker state primitives.
- Keeps dry-run mode non-mutating and main-agent completion bounded to `Agent Review`.
- Updates README and dogfood readiness to describe this as a bounded skeleton, not full autonomous orchestration.

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run`

Closes #11
