### PR TITLE
feat: add runtime state persistence foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ future work.
 - terminal status output reports polling state, planned running/skipped/retrying
   issues, token counters, event-log path, gate details, and integration gaps.
 - JSONL event-log primitives exist.
+- runtime state helpers can write, read, and clear a tracker-neutral
+  `runtime/runtime-state.json` file under the configured logs root.
 - `run-once` can prepare one dry-run workspace, render a prompt file, run the
   dry-run backend, and append JSONL events.
 - `run-once` can execute the conservative Codex subprocess backend when a
@@ -138,7 +140,7 @@ claim reconciliation, resume state, and PR automation exist.
 
 - continuous live polling loop beyond bounded `run-loop` iterations.
 - real issue claiming, state transitions, and reconciliation.
-- runtime state persistence and resume.
+- wiring runtime-state persistence into the run loop and resume flow.
 - workspace-per-issue branch and PR automation.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -19,7 +19,7 @@ unattended live GitHub Project v2 execution yet.
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, and safe cleanup helpers exist. Runtime reconciliation cleanup is not wired yet. |
 | Agent backends | Dry-run backend and a conservative Codex subprocess backend exist. Claude Code remains a trait-preserving stub. Full Codex app-server protocol parity is not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
-| Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. No web/API surface yet. |
+| Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state file helpers exist under `logs_root/runtime`, but loop wiring is still pending. No web/API surface yet. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
 
 ## Before Executing GitHub Project Issues
@@ -85,7 +85,8 @@ Project v2 issues:
 7. Long-running orchestration.
    - Continuous poll loop beyond bounded `run-loop` iterations.
    - claimed/running/retry state ownership.
-   - runtime state persistence and resume.
+   - Wire runtime state reads/writes into each claim, backend run, transition,
+     and resume point.
    - continuation retry after normal active-state exits.
    - exponential backoff for failures.
    - stall detection.
@@ -153,8 +154,8 @@ Acceptance:
   the existing workpad/state adapter operations.
 - keeps terminal status snapshots linked to the active event log and integration
   gaps.
-- persists active issue, workspace, backend session, attempt count, and last
-  transition for resume.
+- uses the runtime state file model to resume active issue, workspace, branch,
+  backend session, attempt count, last event, and last transition.
 
 ### 4. Implement Full Codex App-Server Backend
 

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -161,6 +161,9 @@ Initial observability:
 - JSONL event log.
 - runtime snapshot model with running, retrying, skipped, polling, token,
   event-log path, and integration-gap fields.
+- runtime state file model under `logs_root/runtime` for active issue,
+  workspace, branch, backend session, attempt count, last event, and last
+  transition.
 - terminal/status renderer for operator-readable snapshots.
 - run summary data model.
 
@@ -218,6 +221,7 @@ duplication, and tracker-write repair flows without changing orchestrator shape.
 | Workspace lifecycle hooks with timeout/remote SSH parity | `SPEC.md`, `elixir/lib/symphony_elixir/workspace.ex`, `SPEC.md Appendix A` | Partial | Local hooks now support timeout handling, stdout/stderr capture, `before_remove`, and safe cleanup; remote workers are deferred. | Add SSH worker trait and runtime reconciliation cleanup wiring. |
 | Runtime workflow reload with last-known-good config | `SPEC.md`, `elixir/lib/symphony_elixir/workflow_store.ex` | Delayed | CLI dry-run starts from a single load. | Add file watcher/polling store and reload tests. |
 | Retry timers, stall detection, and worker supervision | `SPEC.md`, `elixir/lib/symphony_elixir/orchestrator.ex` | Partial | Initial orchestrator creates deterministic dispatch plans and retry metadata only. | Add async runtime worker lifecycle, timers, continuation retry, and stall restart tests. |
+| Runtime state persistence and resume wiring | `SPEC.md`, `elixir/lib/symphony_elixir/orchestrator.ex` | Partial | Tracker-neutral state model and file helpers exist, but the run loop does not yet write each transition or resume from it. | Wire runtime state into claim, workspace preparation, backend session start, event logging, handoff, and interruption recovery. |
 | Token/rate-limit accounting | `elixir/docs/token_accounting.md`, `elixir/lib/symphony_elixir/orchestrator.ex` | Data model only | Needs live backend event stream. | Integrate after Codex app-server client, preserving absolute-total accounting. |
 | `linear_graphql` dynamic tool | `elixir/lib/symphony_elixir/codex/dynamic_tool.ex` | Delayed | Linear adapter is not first concrete tracker. | Add backend dynamic-tool registry and Linear client implementation. |
 | Operator runtime status surface | `SPEC.md`, `elixir/lib/symphony_elixir/status_dashboard.ex` | Partial | Terminal rendering now exposes polling, running/retrying/skipped categories, gate details, token counters, event-log path, and integration gaps; it is still fed by the dispatch-plan snapshot rather than a live worker runtime. | Wire the same snapshot model into the future polling runtime and reconciliation loop. |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod orchestrator;
 pub mod prompt;
 pub mod quality_gate;
 pub mod review;
+pub mod runtime_state;
 pub mod status_surface;
 pub mod tracker;
 pub mod workflow;

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -1,0 +1,196 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::config::RuntimeConfig;
+
+pub const RUNTIME_STATE_FILE: &str = "runtime-state.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeState {
+    pub active_issue: Option<RuntimeIssueState>,
+    pub workspace_path: Option<PathBuf>,
+    pub branch_name: Option<String>,
+    pub backend: String,
+    pub backend_session_id: Option<String>,
+    pub attempt_count: u32,
+    pub last_event: Option<String>,
+    pub last_transition: Option<RuntimeTransition>,
+}
+
+impl RuntimeState {
+    pub fn active(issue: RuntimeIssueState, backend: impl Into<String>) -> Self {
+        Self {
+            active_issue: Some(issue),
+            workspace_path: None,
+            branch_name: None,
+            backend: backend.into(),
+            backend_session_id: None,
+            attempt_count: 1,
+            last_event: None,
+            last_transition: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeIssueState {
+    pub id: String,
+    pub identifier: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeTransition {
+    pub from: Option<String>,
+    pub to: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Error)]
+pub enum RuntimeStateError {
+    #[error("runtime state io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("runtime state serialization error: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+pub fn runtime_state_dir(config: &RuntimeConfig) -> PathBuf {
+    config.observability.logs_root.join("runtime")
+}
+
+pub fn runtime_state_path(config: &RuntimeConfig) -> PathBuf {
+    runtime_state_dir(config).join(RUNTIME_STATE_FILE)
+}
+
+pub fn load_runtime_state(
+    config: &RuntimeConfig,
+) -> Result<Option<RuntimeState>, RuntimeStateError> {
+    load_runtime_state_from_path(&runtime_state_path(config))
+}
+
+pub fn save_runtime_state(
+    config: &RuntimeConfig,
+    state: &RuntimeState,
+) -> Result<(), RuntimeStateError> {
+    save_runtime_state_to_path(&runtime_state_path(config), state)
+}
+
+pub fn clear_runtime_state(config: &RuntimeConfig) -> Result<(), RuntimeStateError> {
+    clear_runtime_state_at_path(&runtime_state_path(config))
+}
+
+pub fn load_runtime_state_from_path(
+    path: &Path,
+) -> Result<Option<RuntimeState>, RuntimeStateError> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn save_runtime_state_to_path(
+    path: &Path,
+    state: &RuntimeState,
+) -> Result<(), RuntimeStateError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = path.with_extension("json.tmp");
+    let content = serde_json::to_string_pretty(state)?;
+    fs::write(&temp_path, content)?;
+    fs::rename(temp_path, path)?;
+    Ok(())
+}
+
+pub fn clear_runtime_state_at_path(path: &Path) -> Result<(), RuntimeStateError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::WorkflowDefinition;
+
+    fn config_with_logs_root(root: &Path) -> RuntimeConfig {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            &format!(
+                "---\ntracker:\n  kind: memory\nobservability:\n  logs_root: {:?}\n---\nPrompt",
+                root.display().to_string()
+            ),
+        )
+        .unwrap();
+        RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap()
+    }
+
+    fn state() -> RuntimeState {
+        RuntimeState {
+            active_issue: Some(RuntimeIssueState {
+                id: "GHI_1".into(),
+                identifier: "#1".into(),
+            }),
+            workspace_path: Some(PathBuf::from("/tmp/jade/_1")),
+            branch_name: Some("feature-issue-1".into()),
+            backend: "dry-run".into(),
+            backend_session_id: Some("session".into()),
+            attempt_count: 2,
+            last_event: Some("Completed".into()),
+            last_transition: Some(RuntimeTransition {
+                from: Some("In Progress".into()),
+                to: "Agent Review".into(),
+                reason: "main agent completed".into(),
+            }),
+        }
+    }
+
+    #[test]
+    fn derives_runtime_state_path_from_logs_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = config_with_logs_root(temp.path());
+
+        assert_eq!(
+            runtime_state_path(&config),
+            temp.path().join("runtime").join(RUNTIME_STATE_FILE)
+        );
+    }
+
+    #[test]
+    fn missing_state_file_resumes_as_none() {
+        let temp = tempfile::tempdir().unwrap();
+        let loaded = load_runtime_state_from_path(&temp.path().join("missing.json")).unwrap();
+
+        assert_eq!(loaded, None);
+    }
+
+    #[test]
+    fn writes_and_reads_runtime_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("runtime").join(RUNTIME_STATE_FILE);
+        let state = state();
+
+        save_runtime_state_to_path(&path, &state).unwrap();
+        let loaded = load_runtime_state_from_path(&path).unwrap();
+
+        assert_eq!(loaded, Some(state));
+    }
+
+    #[test]
+    fn clear_runtime_state_is_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(RUNTIME_STATE_FILE);
+        save_runtime_state_to_path(&path, &state()).unwrap();
+
+        clear_runtime_state_at_path(&path).unwrap();
+        clear_runtime_state_at_path(&path).unwrap();
+
+        assert_eq!(load_runtime_state_from_path(&path).unwrap(), None);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a tracker-neutral runtime state model under `src/runtime_state.rs`.
- Persists active issue, workspace, branch, backend session, attempt count, last event, and last transition.
- Stores state at `logs_root/runtime/runtime-state.json`.
- Adds load/save/clear helpers with safe missing-file resume behavior.
- Updates README, dogfood readiness, and implementation notes to document the foundation and remaining run-loop wiring.

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #13
