### PR TITLE
feat: add tracker claim safety helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ future work.
 - explicit live GitHub write commands exist for ProjectV2 status updates,
   workpad comments, follow-up issue creation, and adding issues to a project when
   not in fixture mode.
+- GitHub Project v2 status writes skip same-state mutations, and tracker claim
+  helpers distinguish claimable `Todo`/`Rework`, already active
+  `In Progress`, and externally changed states.
 - dry-run dispatch planning sorts by priority and respects global/state
   concurrency limits.
 - Issue Quality Gate classifies executable versus underspecified issue bodies.
@@ -149,6 +152,7 @@ claim reconciliation, resume state, and PR automation exist.
 - real issue claiming, state transitions, and reconciliation.
 - wiring runtime-state persistence into the run loop and resume flow.
 - workspace-per-issue branch and PR automation.
+- polling-runtime wiring for the existing claim/reconciliation helpers.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.
 - live token/rate-limit accounting beyond the current snapshot counters.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -11,7 +11,7 @@ unattended live GitHub Project v2 execution yet.
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
 | Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
-| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. Bounded `run-loop` can coordinate existing primitives, and auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Full claim reconciliation is not implemented yet. |
+| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. Bounded `run-loop` can coordinate existing primitives; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Project field setup after creation is not implemented yet. |
@@ -42,6 +42,7 @@ Project v2 issues:
      create/update one marker workpad comment, create follow-up issues, and add
      issues to the configured project.
    - Mutating commands require `--write`.
+   - Same-state status updates are treated as no-ops before mutation.
    - PR linking currently uses an issue comment/autolink strategy instead of a
      first-class relationship.
    - Remaining work: idempotency checks around project-item addition and richer
@@ -49,6 +50,8 @@ Project v2 issues:
 
 3. Dispatch safety.
    - Enforce assignee filter from live GitHub issue assignees.
+   - Reuse tracker claim helpers to claim only `Todo` / `Rework`, resume active
+     `In Progress`, and stop/replan on externally changed states.
    - Revalidate issue state immediately before dispatch.
    - Keep GitHub-specific fields out of `orchestrator`.
 - Current explicit `gate-apply` can record quality-gate assumptions or
@@ -138,6 +141,7 @@ operator use and ready for the future orchestrator loop.
 Acceptance:
 
 - updates ProjectV2 Status through option IDs.
+- treats same-state status writes as no-ops.
 - creates/reuses `<!-- jade-symphony-workpad -->` issue comments.
 - records gate assumptions or missing context before dispatch or clarification.
 - keeps write methods inside the GitHub adapter.

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -124,6 +124,9 @@ GitHub Project v2 adapter:
 - supports ProjectV2 status option lookup and update by option ID.
 - supports workpad upsert through issue comments with
   `<!-- jade-symphony-workpad -->`.
+- treats same-state status updates as adapter-local no-ops and exposes
+  tracker-level claim decisions for `Todo`/`Rework`, active `In Progress`, and
+  externally changed states.
 - supports linked PR lookup/linking, follow-up issue creation, and project item
   addition.
 - if GitHub credentials or network access are unavailable, dry-run fixtures remain

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -48,6 +48,30 @@ pub enum TrackerError {
     NotImplemented(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClaimDecision {
+    AlreadyInProgress,
+    Claimable,
+    StopAndReplan { current_state: String },
+}
+
+pub fn claim_decision(issue: &TrackerIssue, config: &RuntimeConfig) -> ClaimDecision {
+    let state = tracker_state_key(&issue.state);
+    let state_map = &config.tracker.state_map;
+
+    if state == tracker_state_key(&state_map.in_progress) {
+        ClaimDecision::AlreadyInProgress
+    } else if state == tracker_state_key(&state_map.todo)
+        || state == tracker_state_key(&state_map.rework)
+    {
+        ClaimDecision::Claimable
+    } else {
+        ClaimDecision::StopAndReplan {
+            current_state: issue.state.clone(),
+        }
+    }
+}
+
 pub fn adapter_from_config(config: &RuntimeConfig) -> Box<dyn TrackerAdapter> {
     match config.tracker.kind.as_str() {
         "memory" => Box::new(MemoryTracker::from_config(config)),
@@ -192,7 +216,7 @@ fn issue_matches_assignee_filter(issue: &TrackerIssue, filter: &AssigneeFilter) 
 fn status_is_mapped(status: &str, config: &RuntimeConfig) -> bool {
     mapped_status_names(config)
         .iter()
-        .any(|mapped| normalize_state(mapped) == normalize_state(status))
+        .any(|mapped| tracker_state_key(mapped) == tracker_state_key(status))
 }
 
 fn mapped_status_names(config: &RuntimeConfig) -> Vec<&str> {
@@ -372,13 +396,17 @@ impl GithubProjectV2GhClient {
 
     fn set_state(&self, issue_ref: &str, normalized_state: &str) -> Result<(), TrackerError> {
         let issue = self.resolve_issue(issue_ref)?;
+        let option_name = self.state_option_name(normalized_state)?;
+        if !status_update_required(&issue, &option_name) {
+            return Ok(());
+        }
+
         let item_id = issue.item_id.ok_or_else(|| {
             TrackerError::IntegrationUnavailable(format!(
                 "issue {issue_ref} has no ProjectV2 item id"
             ))
         })?;
         let metadata = self.project_metadata()?;
-        let option_name = self.state_option_name(normalized_state)?;
         let option_id = metadata
             .status_options
             .iter()
@@ -1081,6 +1109,18 @@ fn ensure_workpad_marker(markdown: &str, marker: &str) -> String {
     } else {
         format!("{marker}\n{markdown}")
     }
+}
+
+fn status_update_required(issue: &TrackerIssue, target_state: &str) -> bool {
+    tracker_state_key(&issue.state) != tracker_state_key(target_state)
+}
+
+fn tracker_state_key(state: &str) -> String {
+    normalize_state(state)
+        .replace('_', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn duplicate_workpad_body(_marker: &str) -> String {
@@ -2393,6 +2433,54 @@ Prompt
     }
 
     #[test]
+    fn claim_decision_identifies_claimable_active_and_external_states() {
+        let config = github_config(
+            r#"---
+tracker:
+  kind: github_project_v2
+  owner: Alive24
+  repo: jade-symphony
+  project_owner: Alive24
+  project_number: 9
+---
+Prompt
+"#,
+        );
+
+        assert_eq!(
+            claim_decision(&issue("Todo"), &config),
+            ClaimDecision::Claimable
+        );
+        assert_eq!(
+            claim_decision(&issue("Rework"), &config),
+            ClaimDecision::Claimable
+        );
+        assert_eq!(
+            claim_decision(&issue("In Progress"), &config),
+            ClaimDecision::AlreadyInProgress
+        );
+        assert_eq!(
+            claim_decision(&issue("Agent Review"), &config),
+            ClaimDecision::StopAndReplan {
+                current_state: "Agent Review".into()
+            }
+        );
+    }
+
+    #[test]
+    fn status_update_required_skips_same_mapped_state() {
+        assert!(!status_update_required(
+            &issue("In Progress"),
+            "in_progress"
+        ));
+        assert!(!status_update_required(
+            &issue("Agent Review"),
+            "Agent Review"
+        ));
+        assert!(status_update_required(&issue("Todo"), "In Progress"));
+    }
+
+    #[test]
     fn parses_linear_issue_payload_into_normalized_tracker_issue() {
         let response = serde_json::json!({
             "data": {
@@ -2502,12 +2590,12 @@ Prompt
 
     #[test]
     fn prepends_workpad_marker_once() {
-        let body = ensure_workpad_marker("## Workpad", "<!-- jade-symphony-workpad -->");
+        let marker = "<!-- jade-symphony-workpad -->";
+        let body = ensure_workpad_marker("## Workpad", marker);
         assert!(body.starts_with("<!-- jade-symphony-workpad -->"));
-        assert_eq!(
-            ensure_workpad_marker(&body, "<!-- jade-symphony-workpad -->"),
-            body
-        );
+        let body = ensure_workpad_marker(&body, marker);
+        let body = ensure_workpad_marker(&body, marker);
+        assert_eq!(body.matches(marker).count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add tracker claim decision primitives for claimable, active, and externally changed issue states.
- Skip GitHub Project v2 same-state status writes before issuing mutations.
- Strengthen workpad marker idempotency coverage and update dogfood docs honestly.

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #15.
