### PR TITLE
fix: detect usable gh auth mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ future work.
 - normalized `TrackerIssue` records can be loaded from JSON fixtures.
 - GitHub Project v2 read-only issue loading can use the `gh` CLI when no fixture
   path is configured.
+- GitHub Project v2 integration-gap reporting distinguishes fixture mode,
+  env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth.
 - Linear tracker reads and explicit write operations are implemented behind the
   same adapter trait; fixture mode remains the credential-free path.
 - explicit live GitHub write commands exist for ProjectV2 status updates,
@@ -104,7 +106,7 @@ writes `JADE_SYMPHONY_PROMPT.md` into the prepared workspace and appends JSONL
 events for the selected workflow.
 
 Live GitHub write commands are explicit and require a non-fixture workflow plus
-`gh` authentication:
+usable GitHub auth through `GITHUB_TOKEN` / `GH_TOKEN` or `gh api graphql`:
 
 ```bash
 cargo run -- set-state path/to/WORKFLOW.md '#123' need_to_clarify --write

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -11,7 +11,7 @@ unattended live GitHub Project v2 execution yet.
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
 | Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
-| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. Bounded `run-loop` can coordinate existing primitives, but full claim reconciliation is not implemented yet. |
+| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. Bounded `run-loop` can coordinate existing primitives, and auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, and repair against Markdown/input. Live tracker issue creation is not implemented yet. |
@@ -97,7 +97,8 @@ Project v2 issues:
      failure events.
    - Runtime snapshot command exists for dry-run and live-read planning; an API
      endpoint is still needed.
-   - Clear integration-gap reporting when credentials are missing.
+   - Clear integration-gap reporting when credentials are missing or unusable
+     while avoiding false missing-token warnings when `gh api graphql` works.
 
 9. Integration profile.
    - Credential-gated GitHub Project v2 smoke test.

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -302,14 +302,12 @@ impl TrackerAdapter for GithubProjectV2Adapter {
             );
         }
 
-        if self.config.tracker.fixture_path.is_none() && !gh_available() {
-            gaps.push("GitHub Project v2 live reads require the `gh` CLI on PATH.".into());
-        }
-
-        if self.config.tracker.fixture_path.is_none() && self.config.tracker.api_key.is_none() {
-            gaps.push(
-                "GitHub token not detected in environment; `gh auth login` or GITHUB_TOKEN/GH_TOKEN is required for live reads.".into(),
-            );
+        if let Some(gap) = github_auth_gap(github_auth_mode(
+            &self.config,
+            gh_available(),
+            github_graphql_auth_smoke,
+        )) {
+            gaps.push(gap);
         }
 
         gaps.push("GitHub Project v2 PR linking uses an issue comment/autolink strategy; linked PR discovery currently reads closing PR references.".into());
@@ -705,6 +703,72 @@ fn gh_available() -> bool {
         .output()
         .map(|output| output.status.success())
         .unwrap_or(false)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GithubAuthMode {
+    Fixture,
+    EnvToken,
+    GhCli,
+    MissingGh,
+    Unauthenticated { reason: Option<String> },
+}
+
+fn github_auth_mode<F>(
+    config: &RuntimeConfig,
+    gh_installed: bool,
+    gh_auth_check: F,
+) -> GithubAuthMode
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    if config.tracker.fixture_path.is_some() {
+        return GithubAuthMode::Fixture;
+    }
+
+    if config.tracker.api_key.is_some() {
+        return GithubAuthMode::EnvToken;
+    }
+
+    if !gh_installed {
+        return GithubAuthMode::MissingGh;
+    }
+
+    match gh_auth_check() {
+        Ok(()) => GithubAuthMode::GhCli,
+        Err(error) => GithubAuthMode::Unauthenticated {
+            reason: Some(error),
+        },
+    }
+}
+
+fn github_graphql_auth_smoke() -> Result<(), String> {
+    run_gh_graphql(vec![
+        "api".into(),
+        "graphql".into(),
+        "-f".into(),
+        "query=query { viewer { login } }".into(),
+    ])
+    .map(|_| ())
+    .map_err(|error| error.to_string())
+}
+
+fn github_auth_gap(mode: GithubAuthMode) -> Option<String> {
+    match mode {
+        GithubAuthMode::Fixture | GithubAuthMode::EnvToken | GithubAuthMode::GhCli => None,
+        GithubAuthMode::MissingGh => {
+            Some("GitHub Project v2 live reads require the `gh` CLI on PATH.".into())
+        }
+        GithubAuthMode::Unauthenticated { reason } => {
+            let suffix = reason
+                .filter(|message| !message.is_empty())
+                .map(|message| format!(" Last auth check error: {message}"))
+                .unwrap_or_default();
+            Some(format!(
+                "GitHub Project v2 live reads require `gh auth login` or GITHUB_TOKEN/GH_TOKEN; no usable GitHub auth was detected.{suffix}"
+            ))
+        }
+    }
 }
 
 fn run_gh_graphql(args: Vec<String>) -> Result<serde_json::Value, TrackerError> {
@@ -2101,6 +2165,50 @@ mod tests {
         let found = tracker.fetch_issues_by_states(&["todo".into()]).unwrap();
         assert_eq!(found.len(), 1);
         assert_eq!(found[0].state, "Todo");
+    }
+
+    #[test]
+    fn github_auth_mode_distinguishes_fixture_env_token_and_gh_cli() {
+        let mut config = github_config(
+            "---\ntracker:\n  kind: github_project_v2\n  owner: Alive24\n  repo: jade-symphony\n  project_owner: Alive24\n  project_number: 1\n---\nPrompt",
+        );
+
+        config.tracker.fixture_path = Some(Path::new("issues.json").to_path_buf());
+        assert_eq!(
+            github_auth_mode(&config, false, || Err("unused".into())),
+            GithubAuthMode::Fixture
+        );
+
+        config.tracker.fixture_path = None;
+        config.tracker.api_key = Some("redacted".into());
+        assert_eq!(
+            github_auth_mode(&config, false, || Err("unused".into())),
+            GithubAuthMode::EnvToken
+        );
+
+        config.tracker.api_key = None;
+        assert_eq!(
+            github_auth_mode(&config, true, || Ok(())),
+            GithubAuthMode::GhCli
+        );
+    }
+
+    #[test]
+    fn github_auth_gap_only_reports_missing_or_invalid_live_auth() {
+        assert_eq!(github_auth_gap(GithubAuthMode::GhCli), None);
+        assert_eq!(github_auth_gap(GithubAuthMode::EnvToken), None);
+        assert_eq!(
+            github_auth_gap(GithubAuthMode::MissingGh).as_deref(),
+            Some("GitHub Project v2 live reads require the `gh` CLI on PATH.")
+        );
+
+        let gap = github_auth_gap(GithubAuthMode::Unauthenticated {
+            reason: Some("invalid token".into()),
+        })
+        .unwrap();
+        assert!(gap.contains("gh auth login"));
+        assert!(gap.contains("GITHUB_TOKEN/GH_TOKEN"));
+        assert!(gap.contains("invalid token"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add GitHub auth-mode detection for fixture, env-token, usable `gh api graphql`, missing `gh`, and unusable auth paths.
- Remove false missing-token integration-gap warnings when the `gh` GraphQL path works.
- Update README and dogfood readiness docs with the honest auth modes.

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- plan-dispatch examples/github-project-workflow.md`

Closes #19.
