### PR TITLE
feat: add workspace PR handoff planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ future work.
 - workspace identifiers are sanitized; local workspace paths stay under the
   configured root; hooks support timeouts, stdout/stderr capture,
   `before_remove`, and safe cleanup helpers.
+- workspace/branch/PR handoff planning can derive a deterministic issue
+  workspace key, branch name, and PR handoff body, and can detect an existing
+  branch that appears to belong to a different issue.
 - terminal status output reports polling state, planned running/skipped/retrying
   issues, token counters, event-log path, gate details, and integration gaps.
 - JSONL event-log primitives exist.
@@ -139,6 +142,7 @@ claim reconciliation, resume state, and PR automation exist.
 ## Stubbed
 
 - linked PR attachment/linking as a first-class relationship.
+- live git worktree creation and `gh pr create` from the runtime loop.
 - Linear live adapter credential-gated smoke coverage.
 - Codex app-server transport.
 - Claude Code full protocol transport beyond the subprocess fixture path.
@@ -151,7 +155,8 @@ claim reconciliation, resume state, and PR automation exist.
 - continuous live polling loop beyond bounded `run-loop` iterations.
 - real issue claiming, state transitions, and reconciliation.
 - wiring runtime-state persistence into the run loop and resume flow.
-- workspace-per-issue branch and PR automation.
+- workspace-per-issue branch and PR automation beyond the current planning
+  primitive.
 - polling-runtime wiring for the existing claim/reconciliation helpers.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -16,7 +16,7 @@ unattended live GitHub Project v2 execution yet.
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a bounded CLI `run-loop` skeleton exist. No long-running worker supervision, retry timers, runtime resume, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, and safe cleanup helpers exist. Runtime reconciliation cleanup is not wired yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, and workspace/branch/PR handoff planning exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state file helpers exist under `logs_root/runtime`, but loop wiring is still pending. No web/API surface yet. |
@@ -90,6 +90,9 @@ Project v2 issues:
    - claimed/running/retry state ownership.
    - Wire runtime state reads/writes into each claim, backend run, transition,
      and resume point.
+   - workspace/branch/PR handoff planning exists, but the runtime still needs
+     live worktree creation, branch checkout, push, PR creation, and PR link
+     recording.
    - continuation retry after normal active-state exits.
    - exponential backoff for failures.
    - stall detection.
@@ -207,7 +210,21 @@ Acceptance:
 - terminal cleanup is tied to tracker reconciliation.
 - path escape tests cover symlink and non-directory cases.
 
-### 6. Add Agent Review Gate
+### 6. Wire Workspace Branch And PR Handoff Into Run-Loop
+
+Goal: connect the current handoff planning primitive to controlled runtime
+mutation without mixing multiple issue scopes in one branch.
+
+Acceptance:
+
+- creates or reuses one isolated git worktree per issue.
+- checks out the planned issue branch from the configured base branch.
+- refuses branches that appear to belong to a different issue.
+- pushes the issue branch after local completion.
+- creates one PR with a handoff body and records the PR link in the workpad.
+- keeps main implementation completion at `Agent Review`.
+
+### 7. Add Agent Review Gate
 
 Goal: make `Agent Review` a real state before `Human Review`.
 
@@ -224,7 +241,7 @@ Acceptance:
 - failed, timed out, inconclusive, or unavailable reviews must not set
   `Human Review`.
 
-### 7. Add Linear Credential-Gated Smoke Tests
+### 8. Add Linear Credential-Gated Smoke Tests
 
 Goal: prove the Linear adapter against a real workspace without making local
 development depend on credentials.
@@ -254,4 +271,4 @@ GitHub Project v2 execution is hardened.
 manual live Project v2 reads and explicit tracker writes through `gh`. It still
 uses the `dry-run` backend by default. `run-loop --write` is available only as a
 bounded skeleton and should not be treated as full autonomous agent execution
-until claim reconciliation, runtime resume, and PR automation exist.
+until claim reconciliation, runtime resume, and live PR automation wiring exist.

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -1,0 +1,324 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::model::TrackerIssue;
+use crate::workspace::safe_identifier;
+
+const DEFAULT_BRANCH_PREFIX: &str = "feature";
+const TITLE_SLUG_LIMIT: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueHandoffPlan {
+    pub issue_ref: String,
+    pub issue_title: String,
+    pub workspace_key: String,
+    pub workspace_path: PathBuf,
+    pub branch_name: String,
+    pub pull_request: PullRequestHandoffPlan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestHandoffPlan {
+    pub title: String,
+    pub head_branch: String,
+    pub base_branch: String,
+    pub issue_ref: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum HandoffError {
+    #[error("branch {branch_name} appears to belong to issue #{found_issue}, expected #{expected_issue}")]
+    BranchIssueMismatch {
+        branch_name: String,
+        expected_issue: String,
+        found_issue: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BranchIssueCheck {
+    Matches { issue_number: String },
+    Mismatch { expected: String, found: String },
+    Unknown,
+}
+
+pub fn plan_issue_handoff(
+    workspace_root: &Path,
+    issue: &TrackerIssue,
+    base_branch: &str,
+) -> Result<IssueHandoffPlan, HandoffError> {
+    if let Some(existing_branch) = issue.branch_name.as_deref() {
+        guard_branch_for_issue(existing_branch, &issue.identifier)?;
+    }
+
+    let branch_name = branch_name_for_issue(&issue.identifier, &issue.title);
+    let workspace_key = workspace_key_for_issue(&issue.identifier, &issue.title);
+    let workspace_path = workspace_root.join(&workspace_key);
+    let pull_request =
+        PullRequestHandoffPlan::new(&issue.identifier, &issue.title, &branch_name, base_branch);
+
+    Ok(IssueHandoffPlan {
+        issue_ref: issue.identifier.clone(),
+        issue_title: issue.title.clone(),
+        workspace_key,
+        workspace_path,
+        branch_name,
+        pull_request,
+    })
+}
+
+pub fn workspace_key_for_issue(issue_identifier: &str, title: &str) -> String {
+    safe_identifier(&format!(
+        "{}-{}",
+        issue_slug(issue_identifier),
+        title_slug(title)
+    ))
+}
+
+pub fn branch_name_for_issue(issue_identifier: &str, title: &str) -> String {
+    format!(
+        "{}/{}-{}",
+        DEFAULT_BRANCH_PREFIX,
+        issue_slug(issue_identifier),
+        title_slug(title)
+    )
+}
+
+pub fn guard_branch_for_issue(
+    branch_name: &str,
+    issue_identifier: &str,
+) -> Result<BranchIssueCheck, HandoffError> {
+    match check_branch_issue(branch_name, issue_identifier) {
+        BranchIssueCheck::Mismatch { expected, found } => Err(HandoffError::BranchIssueMismatch {
+            branch_name: branch_name.into(),
+            expected_issue: expected,
+            found_issue: found,
+        }),
+        check => Ok(check),
+    }
+}
+
+pub fn check_branch_issue(branch_name: &str, issue_identifier: &str) -> BranchIssueCheck {
+    let expected = issue_number(issue_identifier);
+    let found = branch_issue_number(branch_name);
+
+    match (expected, found) {
+        (Some(expected), Some(found)) if expected == found => BranchIssueCheck::Matches {
+            issue_number: found,
+        },
+        (Some(expected), Some(found)) => BranchIssueCheck::Mismatch { expected, found },
+        _ => BranchIssueCheck::Unknown,
+    }
+}
+
+pub fn branch_issue_number(branch_name: &str) -> Option<String> {
+    let tokens: Vec<_> = branch_name
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|token| !token.is_empty())
+        .collect();
+
+    for (index, token) in tokens.iter().enumerate() {
+        if token.eq_ignore_ascii_case("issue") {
+            if let Some(next) = tokens.get(index + 1).and_then(|value| digits_only(value)) {
+                return Some(next);
+            }
+        }
+
+        let normalized = token.to_ascii_lowercase();
+        if let Some(suffix) = normalized.strip_prefix("issue").and_then(digits_only) {
+            return Some(suffix);
+        }
+    }
+
+    None
+}
+
+pub fn issue_number(issue_identifier: &str) -> Option<String> {
+    issue_identifier
+        .split(|ch: char| !ch.is_ascii_digit())
+        .find_map(digits_only)
+}
+
+impl PullRequestHandoffPlan {
+    pub fn new(issue_ref: &str, issue_title: &str, head_branch: &str, base_branch: &str) -> Self {
+        let title = format!("{}: {}", issue_ref.trim(), issue_title.trim());
+        let body = render_pull_request_body(issue_ref, issue_title);
+
+        Self {
+            title,
+            head_branch: head_branch.into(),
+            base_branch: base_branch.into(),
+            issue_ref: issue_ref.into(),
+            body,
+        }
+    }
+}
+
+fn render_pull_request_body(issue_ref: &str, issue_title: &str) -> String {
+    format!(
+        "\
+## Summary
+- Implements {issue_ref}: {issue_title}.
+
+## Verification
+- cargo test
+- cargo fmt --check
+- cargo clippy --all-targets --all-features -- -D warnings
+
+## Handoff
+Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.
+
+Closes {issue_ref}
+"
+    )
+}
+
+fn issue_slug(issue_identifier: &str) -> String {
+    issue_number(issue_identifier)
+        .map(|number| format!("issue-{number}"))
+        .unwrap_or_else(|| title_slug(issue_identifier))
+}
+
+fn title_slug(title: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_was_dash = false;
+
+    for ch in title.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            previous_was_dash = false;
+        } else if !previous_was_dash && !slug.is_empty() {
+            slug.push('-');
+            previous_was_dash = true;
+        }
+
+        if slug.len() >= TITLE_SLUG_LIMIT {
+            break;
+        }
+    }
+
+    let slug = slug.trim_matches('-');
+    if slug.is_empty() {
+        "untitled".into()
+    } else {
+        slug.into()
+    }
+}
+
+fn digits_only(value: &str) -> Option<String> {
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_digit())
+        .then(|| value.to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn issue() -> TrackerIssue {
+        TrackerIssue {
+            tracker_kind: "github_project_v2".into(),
+            id: "I_21".into(),
+            item_id: Some("PVTI_21".into()),
+            identifier: "#21".into(),
+            title: "Add workspace branch and PR handoff planning foundation".into(),
+            description: None,
+            url: None,
+            state: "In Progress".into(),
+            labels: Vec::new(),
+            assignees: Vec::new(),
+            priority: None,
+            branch_name: None,
+            linked_pull_requests: Vec::new(),
+            blocked_by: Vec::new(),
+            project_fields: Default::default(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    #[test]
+    fn creates_deterministic_workspace_and_branch_plan() {
+        let plan = plan_issue_handoff(Path::new("/tmp/jade-workspaces"), &issue(), "main").unwrap();
+
+        assert_eq!(
+            plan.workspace_key,
+            "issue-21-add-workspace-branch-and-pr-handoff-planning-foundation"
+        );
+        assert_eq!(
+            plan.workspace_path,
+            PathBuf::from(
+                "/tmp/jade-workspaces/issue-21-add-workspace-branch-and-pr-handoff-planning-foundation"
+            )
+        );
+        assert_eq!(
+            plan.branch_name,
+            "feature/issue-21-add-workspace-branch-and-pr-handoff-planning-foundation"
+        );
+        assert_eq!(plan.pull_request.head_branch, plan.branch_name);
+        assert_eq!(plan.pull_request.base_branch, "main");
+    }
+
+    #[test]
+    fn detects_matching_and_mismatched_issue_branches() {
+        assert_eq!(
+            check_branch_issue("feature/issue-21-workspace", "#21"),
+            BranchIssueCheck::Matches {
+                issue_number: "21".into()
+            }
+        );
+        assert_eq!(
+            check_branch_issue("feature/issue-20-auth", "#21"),
+            BranchIssueCheck::Mismatch {
+                expected: "21".into(),
+                found: "20".into()
+            }
+        );
+        assert_eq!(
+            check_branch_issue("feature/workspace-planning", "#21"),
+            BranchIssueCheck::Unknown
+        );
+        assert_eq!(
+            check_branch_issue("feature/ISSUE21-workspace", "#21"),
+            BranchIssueCheck::Matches {
+                issue_number: "21".into()
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_existing_branch_for_different_issue() {
+        let mut issue = issue();
+        issue.branch_name = Some("feature/issue-20-auth".into());
+
+        let err = plan_issue_handoff(Path::new("/tmp/workspaces"), &issue, "main").unwrap_err();
+
+        assert_eq!(
+            err,
+            HandoffError::BranchIssueMismatch {
+                branch_name: "feature/issue-20-auth".into(),
+                expected_issue: "21".into(),
+                found_issue: "20".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn renders_pull_request_handoff_body() {
+        let pr =
+            PullRequestHandoffPlan::new("#21", "Add handoff planning", "feature/issue-21", "main");
+
+        assert_eq!(pr.title, "#21: Add handoff planning");
+        assert!(pr.body.contains("Implements #21: Add handoff planning."));
+        assert!(pr
+            .body
+            .contains("cargo clippy --all-targets --all-features -- -D warnings"));
+        assert!(pr.body.contains("stops at Agent Review"));
+        assert!(pr.body.contains("Closes #21"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod config;
 pub mod event_log;
+pub mod handoff;
 pub mod issue_forge;
 pub mod model;
 pub mod orchestrator;


### PR DESCRIPTION
## Summary
- Adds a tracker-neutral handoff planning module for issue workspace keys, branch names, and PR handoff bodies.
- Adds issue-branch mismatch guardrails so a branch that appears to belong to another issue can be rejected.
- Updates README and dogfood readiness docs to describe the planning primitive without claiming live PR automation.

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #21
