### PR TITLE
feat: add idle run-loop polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ links.
 
 It does **not** yet fully autonomously execute GitHub Project v2 issues,
 run Codex/Claude through the final app-server flow, or supervise long-running
-workers. A bounded `run-loop` skeleton now exists, but full claim
-reconciliation, runtime resume, and one-issue-one-PR automation are still
-future work.
+workers. A `run-loop` skeleton now exists and can idle-poll in unbounded
+write mode, but full claim reconciliation, runtime resume, and
+one-issue-one-PR automation are still future work.
 
 ## What Works Now
 
@@ -65,7 +65,8 @@ future work.
 - `run-loop` can re-read tracker state per iteration, select dispatchable work,
   print dry-run claim/run/workpad/handoff actions, and in explicit `--write`
   mode run one issue at a time and stop main-agent completion at
-  `Agent Review`.
+  `Agent Review`; unbounded write mode sleeps on idle polls using the workflow
+  polling interval.
 
 ## Dry-Run Only
 
@@ -135,7 +136,7 @@ cargo run -- review-fake path/to/WORKFLOW.md '#123' --outcome pass --write
 `review-once` / `review-fake` are independent Review Agent commands: a passing
 review can move `Agent Review` to `Human Review`, confirmed findings move to
 `Rework`, and failed or inconclusive reviews do not advance to `Human Review`.
-These commands are adapter operations plus the first bounded runtime-loop
+These commands are adapter operations plus the first runtime-loop
 skeleton, not full autonomous orchestration. Use write mode carefully until
 claim reconciliation, resume state, and PR automation exist.
 
@@ -152,7 +153,7 @@ claim reconciliation, resume state, and PR automation exist.
 
 ## Not Implemented Yet
 
-- continuous live polling loop beyond bounded `run-loop` iterations.
+- long-running worker supervision beyond idle polling in `run-loop`.
 - real issue claiming, state transitions, and reconciliation.
 - wiring runtime-state persistence into the run loop and resume flow.
 - workspace-per-issue branch and PR automation beyond the current planning
@@ -182,7 +183,8 @@ This path can read ProjectV2 items and normalize GitHub Issue content for
 planning. Explicit `--write` commands can update ProjectV2 status, write workpad
 comments, create follow-up issues, and add issues to the project. PR linking uses
 an issue comment/autolink strategy rather than a first-class relationship. Jade
-Symphony still cannot poll continuously, reconcile state, or run agents.
+Symphony can idle-poll in unbounded write mode, but still cannot fully reconcile
+state or supervise live agents.
 
 ## Development Commands
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -1,8 +1,9 @@
 # Dogfood Readiness
 
 Status: dry-run dogfood baseline with read-only GitHub Project v2 loading through
-the `gh` CLI and a bounded `run-loop` skeleton. Jade Symphony is not ready for
-unattended live GitHub Project v2 execution yet.
+the `gh` CLI and a `run-loop` skeleton that can idle-poll in unbounded write
+mode. Jade Symphony is not ready for unattended live GitHub Project v2 execution
+yet.
 
 ## Current Capability Status
 
@@ -11,11 +12,11 @@ unattended live GitHub Project v2 execution yet.
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
 | Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
-| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. Bounded `run-loop` can coordinate existing primitives; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
+| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives and idle-poll in unbounded write mode; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Project field setup after creation is not implemented yet. |
-| Orchestrator | Deterministic dispatch planning and a bounded CLI `run-loop` skeleton exist. No long-running worker supervision, retry timers, runtime resume, or full state reconciliation yet. |
+| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes and idle polling exists. No long-running worker supervision, retry timers, runtime resume, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, and workspace/branch/PR handoff planning exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
@@ -86,7 +87,8 @@ Project v2 issues:
      workspace.
 
 7. Long-running orchestration.
-   - Continuous poll loop beyond bounded `run-loop` iterations.
+   - Continuous idle polling exists for unbounded write mode; full active worker
+     supervision is still pending.
    - claimed/running/retry state ownership.
    - Wire runtime state reads/writes into each claim, backend run, transition,
      and resume point.
@@ -270,5 +272,5 @@ GitHub Project v2 execution is hardened.
 `examples/github-project-workflow.md` is a non-fixture workflow template for
 manual live Project v2 reads and explicit tracker writes through `gh`. It still
 uses the `dry-run` backend by default. `run-loop --write` is available only as a
-bounded skeleton and should not be treated as full autonomous agent execution
+runtime skeleton and should not be treated as full autonomous agent execution
 until claim reconciliation, runtime resume, and live PR automation wiring exist.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 use jade_symphony::agent::backend_from_config;
 use jade_symphony::config::RuntimeConfig;
@@ -585,8 +587,19 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
 
         let Some(issue) = plan.selected.first().cloned() else {
             println!("{}", render_snapshot(&plan.snapshot));
-            println!("run_loop=stopped reason=no_dispatchable_issue iterations={iterations}");
-            break;
+            match no_dispatch_action(&options, limit, config.polling.interval_ms) {
+                NoDispatchAction::Stop { reason } => {
+                    println!("run_loop=stopped reason={reason} iterations={iterations}");
+                    break;
+                }
+                NoDispatchAction::SleepAndContinue { delay_ms } => {
+                    println!(
+                        "run_loop_idle action=sleep delay_ms={delay_ms} iterations={iterations}"
+                    );
+                    thread::sleep(Duration::from_millis(delay_ms));
+                    continue;
+                }
+            }
         };
 
         let decision = evaluate_issue(&issue);
@@ -656,6 +669,28 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NoDispatchAction {
+    Stop { reason: &'static str },
+    SleepAndContinue { delay_ms: u64 },
+}
+
+fn no_dispatch_action(
+    options: &RunLoopOptions,
+    limit: Option<usize>,
+    poll_interval_ms: u64,
+) -> NoDispatchAction {
+    if !options.write || limit.is_some() {
+        return NoDispatchAction::Stop {
+            reason: "no_dispatchable_issue",
+        };
+    }
+
+    NoDispatchAction::SleepAndContinue {
+        delay_ms: poll_interval_ms,
+    }
 }
 
 fn handle_run_loop_gate_failure(
@@ -1505,5 +1540,54 @@ mod tests {
             true,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn no_dispatch_stops_for_dry_run_even_without_limit() {
+        let options = RunLoopOptions {
+            workflow_path: PathBuf::from("WORKFLOW.md"),
+            max_iterations: None,
+            once: false,
+            write: false,
+        };
+
+        assert_eq!(
+            no_dispatch_action(&options, options.iteration_limit(), 250),
+            NoDispatchAction::Stop {
+                reason: "no_dispatchable_issue"
+            }
+        );
+    }
+
+    #[test]
+    fn no_dispatch_stops_for_bounded_write_loop() {
+        let options = RunLoopOptions {
+            workflow_path: PathBuf::from("WORKFLOW.md"),
+            max_iterations: Some(2),
+            once: false,
+            write: true,
+        };
+
+        assert_eq!(
+            no_dispatch_action(&options, options.iteration_limit(), 250),
+            NoDispatchAction::Stop {
+                reason: "no_dispatchable_issue"
+            }
+        );
+    }
+
+    #[test]
+    fn no_dispatch_sleeps_for_unbounded_write_loop() {
+        let options = RunLoopOptions {
+            workflow_path: PathBuf::from("WORKFLOW.md"),
+            max_iterations: None,
+            once: false,
+            write: true,
+        };
+
+        assert_eq!(
+            no_dispatch_action(&options, options.iteration_limit(), 250),
+            NoDispatchAction::SleepAndContinue { delay_ms: 250 }
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds an explicit no-dispatch decision helper for `run-loop`.
- Keeps dry-run, `--once`, and `--max-iterations` finite when no work is selected.
- Lets unbounded `--write` runs sleep for the configured polling interval and continue polling while idle.
- Updates README and dogfood readiness docs without claiming full autonomous orchestration.

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #23
