### PR TITLE
feat: add forge tracker create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ future work.
 - Issue Quality Gate classifies executable versus underspecified issue bodies.
 - Issue Forge can discover local candidates from intent, ask one focused
   clarification question, draft from the quality template, validate Markdown,
-  and repair rough Markdown into an executable issue contract shape.
+  repair rough Markdown into an executable issue contract shape, and create a
+  tracker issue from a quality-gated contract with explicit `--write`.
 - basic strict prompt rendering supports known `issue.*` fields, `attempt`, and
   simple `{% if %}` / `{% else %}` blocks.
 - workspace identifiers are sanitized; local workspace paths stay under the
@@ -96,6 +97,7 @@ cargo run -- forge-discuss --title "Thin Forge issue" --file examples/fixtures/t
 cargo run -- forge-repair --title "Thin Forge issue" --file examples/fixtures/thin-issue.md
 cargo run -- forge-validate --title "Repaired Forge issue" --file examples/fixtures/repaired-issue.md
 cargo run -- forge-draft --title "Implement read-only Project v2 adapter" --goal "Load Project v2 issues into TrackerIssue records."
+cargo run -- forge-create --workflow path/to/WORKFLOW.md --title "Follow-up title" --file path/to/issue.md --add-to-project --write
 ```
 
 `run-once` defaults to dry-run examples, but the Codex subprocess fixture shows
@@ -144,7 +146,7 @@ claim reconciliation, resume state, and PR automation exist.
 - terminal workspace cleanup tied to tracker state.
 - live token/rate-limit accounting beyond the current snapshot counters.
 - persistent Agent Review worker supervision and reconciliation.
-- Issue Forge tracker writes.
+- Issue Forge Project field setup after issue creation.
 - automated Issue Quality Gate application inside the polling runtime.
 - full Liquid-compatible prompt renderer.
 - credential-gated integration tests.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -14,7 +14,7 @@ unattended live GitHub Project v2 execution yet.
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. Bounded `run-loop` can coordinate existing primitives, but full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
-| Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, and repair against Markdown/input. Live tracker issue creation is not implemented yet. |
+| Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a bounded CLI `run-loop` skeleton exist. No long-running worker supervision, retry timers, runtime resume, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, and safe cleanup helpers exist. Runtime reconciliation cleanup is not wired yet. |
 | Agent backends | Dry-run backend and a conservative Codex subprocess backend exist. Claude Code remains a trait-preserving stub. Full Codex app-server protocol parity is not implemented yet. |
@@ -104,6 +104,12 @@ Project v2 issues:
    - Fixture tests for pagination, status option cache, malformed payloads, and
      permission failures.
    - Dry-run fixtures remain available for local development without credentials.
+
+10. Issue Forge tracker completion.
+   - `forge-create` can create a tracker issue and optionally add it to the
+     configured project through the normalized adapter.
+   - Remaining work: set normalized initial state/capability fields through a
+     tracker-neutral field operation or tracker-specific adapter method.
 
 ## Recommended Next GitHub Issues
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             println!("{}", report.repaired_markdown);
             Ok(())
         }
+        Command::ForgeCreate {
+            workflow_path,
+            title,
+            markdown,
+            add_to_project,
+            write,
+        } => forge_create(workflow_path, title, markdown, add_to_project, write),
         Command::Help => {
             println!("{}", usage());
             Ok(())
@@ -244,6 +251,49 @@ fn create_follow_up(
     })?;
     println!("create_follow_up=ok issue_id={issue_id}");
     Ok(())
+}
+
+fn forge_create(
+    workflow_path: PathBuf,
+    title: String,
+    markdown: String,
+    add_to_project: bool,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    require_write_intent(write)?;
+    let report = validate_forge_create_contract(&title, &markdown).inspect_err(|_message| {
+        let report = validate_markdown(&title, &markdown);
+        print_forge_validation(&report);
+    })?;
+
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let issue_id = adapter.create_follow_up_issue(FollowUpIssueInput {
+        title: report.title,
+        body: markdown,
+        project_id: None,
+        related_issue_ref: None,
+        blocked_by_issue_ref: None,
+    })?;
+
+    if add_to_project {
+        adapter.add_issue_to_project(&issue_id)?;
+    }
+
+    println!("forge_create=ok issue_id={issue_id} added_to_project={add_to_project}");
+    Ok(())
+}
+
+fn validate_forge_create_contract(
+    title: &str,
+    markdown: &str,
+) -> Result<jade_symphony::issue_forge::ForgeValidationReport, String> {
+    let report = validate_markdown(title, markdown);
+    if report.decision.is_dispatchable() {
+        Ok(report)
+    } else {
+        Err("issue forge validation failed; tracker issue was not created".into())
+    }
 }
 
 fn add_to_project(
@@ -759,6 +809,13 @@ enum Command {
         title: String,
         markdown: String,
     },
+    ForgeCreate {
+        workflow_path: PathBuf,
+        title: String,
+        markdown: String,
+        add_to_project: bool,
+        write: bool,
+    },
     Help,
 }
 
@@ -818,6 +875,7 @@ impl Command {
                 parse_forge_markdown_command(&args[1..], ForgeCommandKind::Validate)
             }
             "forge-repair" => parse_forge_markdown_command(&args[1..], ForgeCommandKind::Repair),
+            "forge-create" => parse_forge_create(&args[1..]),
             command if command.starts_with('-') => Err(usage()),
             workflow_path => Ok(Self::Plan {
                 workflow_path: PathBuf::from(workflow_path),
@@ -1013,6 +1071,57 @@ fn parse_add_to_project(args: &[String]) -> Result<Command, String> {
     Ok(Command::AddToProject {
         workflow_path: PathBuf::from(&args[0]),
         issue_id: args[1].clone(),
+        write,
+    })
+}
+
+fn parse_forge_create(args: &[String]) -> Result<Command, String> {
+    let mut workflow_path = None;
+    let mut title = None;
+    let mut body = None;
+    let mut file = None;
+    let mut add_to_project = false;
+    let mut write = false;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "--write" => {
+                write = true;
+                index += 1;
+            }
+            "--dry-run" => {
+                index += 1;
+            }
+            "--add-to-project" => {
+                add_to_project = true;
+                index += 1;
+            }
+            "--workflow" if index + 1 < args.len() => {
+                workflow_path = Some(PathBuf::from(&args[index + 1]));
+                index += 2;
+            }
+            "--title" if index + 1 < args.len() => {
+                title = Some(args[index + 1].clone());
+                index += 2;
+            }
+            "--body" if index + 1 < args.len() => {
+                body = Some(args[index + 1].clone());
+                index += 2;
+            }
+            "--file" if index + 1 < args.len() => {
+                file = Some(PathBuf::from(&args[index + 1]));
+                index += 2;
+            }
+            _ => return Err(usage()),
+        }
+    }
+
+    Ok(Command::ForgeCreate {
+        workflow_path: workflow_path.ok_or_else(usage)?,
+        title: title.ok_or_else(usage)?,
+        markdown: read_source_arg(body, file)?,
+        add_to_project,
         write,
     })
 }
@@ -1229,6 +1338,7 @@ fn usage() -> String {
         "  jade-symphony forge-draft --title <title> --goal <goal>",
         "  jade-symphony forge-validate --title <title> (--file <markdown-file> | --body <markdown>)",
         "  jade-symphony forge-repair --title <title> (--file <markdown-file> | --body <markdown>)",
+        "  jade-symphony forge-create --workflow <path-to-WORKFLOW.md> --title <title> (--file <markdown-file> | --body <markdown>) [--add-to-project] --write",
         "",
         "Compatibility: `jade-symphony <path-to-WORKFLOW.md>` is treated as `plan`.",
     ]
@@ -1238,6 +1348,28 @@ fn usage() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn forge_contract() -> String {
+        [
+            "## Issue Goal",
+            "Create a validated tracker issue.",
+            "## Why Now",
+            "Now.",
+            "## Issue Context",
+            "Context.",
+            "## Non-Negotiable Guardrails",
+            "- Guard.",
+            "## Scope",
+            "Scope.",
+            "## Canonical References",
+            "### Target Repository / Package",
+            "- Alive24/jade-symphony",
+            "## Verification",
+            "### Completion Criteria",
+            "- Pass.",
+        ]
+        .join("\n")
+    }
 
     #[test]
     fn parses_run_loop_flags() {
@@ -1294,5 +1426,84 @@ mod tests {
         .unwrap_err();
 
         assert!(error.contains("Usage:"));
+    }
+
+    #[test]
+    fn parses_forge_create_flags() {
+        let command = Command::parse(vec![
+            "forge-create".into(),
+            "--workflow".into(),
+            "examples/dry-run-workflow.md".into(),
+            "--title".into(),
+            "Create issue".into(),
+            "--body".into(),
+            forge_contract(),
+            "--add-to-project".into(),
+            "--write".into(),
+        ])
+        .unwrap();
+
+        let Command::ForgeCreate {
+            workflow_path,
+            title,
+            markdown,
+            add_to_project,
+            write,
+        } = command
+        else {
+            panic!("expected forge-create command");
+        };
+
+        assert_eq!(workflow_path, PathBuf::from("examples/dry-run-workflow.md"));
+        assert_eq!(title, "Create issue");
+        assert!(markdown.contains("## Issue Goal"));
+        assert!(add_to_project);
+        assert!(write);
+    }
+
+    #[test]
+    fn rejects_forge_create_with_both_body_and_file() {
+        let error = Command::parse(vec![
+            "forge-create".into(),
+            "--workflow".into(),
+            "WORKFLOW.md".into(),
+            "--title".into(),
+            "Create issue".into(),
+            "--body".into(),
+            forge_contract(),
+            "--file".into(),
+            "issue.md".into(),
+        ])
+        .unwrap_err();
+
+        assert!(error.contains("Usage:"));
+    }
+
+    #[test]
+    fn validates_forge_create_contract_before_tracker_write() {
+        assert!(validate_forge_create_contract("Create issue", &forge_contract()).is_ok());
+
+        let error = validate_forge_create_contract("Thin issue", "make it better").unwrap_err();
+        assert!(error.contains("tracker issue was not created"));
+    }
+
+    #[test]
+    fn forge_create_can_use_memory_tracker_adapter() {
+        let temp = tempfile::tempdir().unwrap();
+        let workflow_path = temp.path().join("WORKFLOW.md");
+        std::fs::write(
+            &workflow_path,
+            "---\ntracker:\n  kind: memory\nobservability:\n  logs_root: log\n---\nPrompt",
+        )
+        .unwrap();
+
+        forge_create(
+            workflow_path,
+            "Create issue".into(),
+            forge_contract(),
+            true,
+            true,
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- Adds `forge-create` for quality-gated tracker issue creation through the normalized tracker adapter.
- Requires explicit `--write` and refuses non-dispatchable Issue Forge Markdown before tracker mutation.
- Supports optional `--add-to-project` through the existing adapter boundary.
- Updates README and dogfood readiness docs with the remaining Project field setup limitation.

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #25
