### PR TITLE
feat: add claude subprocess backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ future work.
   dry-run backend, and append JSONL events.
 - `run-once` can execute the conservative Codex subprocess backend when a
   workflow explicitly sets `agent.backend: codex`.
+- `run-once` can execute the conservative Claude Code subprocess backend when a
+  workflow explicitly sets `agent.backend: claude-code`.
 - `run-loop` can re-read tracker state per iteration, select dispatchable work,
   print dry-run claim/run/workpad/handoff actions, and in explicit `--write`
   mode run one issue at a time and stop main-agent completion at
@@ -87,6 +89,7 @@ cargo run -- plan-dispatch examples/dry-run-workflow.md
 cargo run -- status examples/dry-run-workflow.md
 cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-once examples/codex-subprocess-workflow.md
+cargo run -- run-once examples/claude-subprocess-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
 cargo run -- plan examples/linear-fixture-workflow.md
 cargo run -- gate examples/dry-run-workflow.md '#3'
@@ -98,10 +101,10 @@ cargo run -- forge-validate --title "Repaired Forge issue" --file examples/fixtu
 cargo run -- forge-draft --title "Implement read-only Project v2 adapter" --goal "Load Project v2 issues into TrackerIssue records."
 ```
 
-`run-once` defaults to dry-run examples, but the Codex subprocess fixture shows
-the controlled real-backend path without invoking a live Codex service. It
-writes `JADE_SYMPHONY_PROMPT.md` into the prepared workspace and appends JSONL
-events for the selected workflow.
+`run-once` defaults to dry-run examples, but the Codex and Claude subprocess
+fixtures show controlled real-backend paths without invoking live hosted
+services. They write `JADE_SYMPHONY_PROMPT.md` into the prepared workspace and
+append JSONL events for the selected workflow.
 
 Live GitHub write commands are explicit and require a non-fixture workflow plus
 `gh` authentication:
@@ -129,7 +132,7 @@ claim reconciliation, resume state, and PR automation exist.
 - linked PR attachment/linking as a first-class relationship.
 - Linear live adapter credential-gated smoke coverage.
 - Codex app-server transport.
-- Claude Code backend.
+- Claude Code full protocol transport beyond the subprocess fixture path.
 - dynamic tool registry such as `linear_graphql`.
 - runtime workflow reload and long-running worker supervision.
 - web/API observability surface.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -17,7 +17,7 @@ unattended live GitHub Project v2 execution yet.
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, and repair against Markdown/input. Live tracker issue creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a bounded CLI `run-loop` skeleton exist. No long-running worker supervision, retry timers, runtime resume, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, and safe cleanup helpers exist. Runtime reconciliation cleanup is not wired yet. |
-| Agent backends | Dry-run backend and a conservative Codex subprocess backend exist. Claude Code remains a trait-preserving stub. Full Codex app-server protocol parity is not implemented yet. |
+| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. No web/API surface yet. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
@@ -74,9 +74,9 @@ Project v2 issues:
    - Preserve fixture mode for credential-free development.
 
 6. Live agent execution.
-   - Harden the Codex subprocess backend, then implement full app-server
-     protocol transport.
-   - Keep Claude Code as a peer backend path, even if still delayed.
+   - Harden the Codex and Claude Code subprocess backends, then implement full
+     protocol transports.
+   - Keep Claude Code as a peer backend path.
    - Normalize session IDs, completion, failures, token usage, and rate-limit
      events.
    - Ensure external command execution happens only inside the prepared
@@ -166,6 +166,19 @@ Acceptance:
 - launches configured Codex command in workspace cwd.
 - starts session and runs a turn.
 - extracts thread/turn/session IDs.
+- emits normalized backend events.
+- handles failures without stalling the orchestrator.
+- keeps live tests credential/tool gated.
+
+### 4b. Implement Full Claude Code Protocol Backend
+
+Goal: evolve the conservative Claude Code subprocess path into the configured
+Claude Code protocol flow while preserving the normalized backend interface.
+
+Acceptance:
+
+- launches configured Claude Code command in workspace cwd.
+- starts a session or equivalent turn.
 - emits normalized backend events.
 - handles failures without stalling the orchestrator.
 - keeps live tests credential/tool gated.

--- a/examples/claude-subprocess-workflow.md
+++ b/examples/claude-subprocess-workflow.md
@@ -1,0 +1,35 @@
+---
+tracker:
+  kind: github_project_v2
+  owner: Alive24
+  repo: jade-symphony
+  project_owner: Alive24
+  project_number: 9
+  fixture_path: fixtures/dry-run-issues.json
+  status_field: Status
+  state_map:
+    todo: Todo
+    rework: Rework
+    done: Done
+  active_states:
+    - Todo
+    - Rework
+  terminal_states:
+    - Done
+workspace:
+  root: /tmp/jade-symphony-claude-subprocess-workspaces
+agent:
+  backend: claude-code
+  max_concurrent_agents: 1
+  max_turns: 1
+  max_retry_backoff_ms: 300000
+claude:
+  command: "cat > claude-subprocess-output.md"
+  turn_timeout_ms: 1000
+observability:
+  logs_root: log
+---
+
+You are running a safe Claude Code fixture task for {{ issue.identifier }}.
+
+Title: {{ issue.title }}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -132,7 +132,7 @@ impl AgentBackend for CodexBackend {
     }
 
     fn run(&self, prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
-        run_subprocess_backend(prepared, "codex-subprocess")
+        run_subprocess_backend(prepared, "codex-subprocess", "Codex subprocess")
     }
 
     fn stop(&self, _reason: &str) -> Result<(), AgentError> {
@@ -159,39 +159,33 @@ impl AgentBackend for ClaudeCodeBackend {
         config: &RuntimeConfig,
     ) -> Result<PreparedRun, AgentError> {
         Ok(PreparedRun {
-            backend: format!("claude-code:{}", config.claude.command),
+            backend: self.name().into(),
             workspace,
             prompt: rendered_prompt,
-            command: None,
-            timeout_ms: 0,
+            command: Some(config.claude.command.clone()),
+            timeout_ms: config.claude.turn_timeout_ms,
             approval_policy: None,
             sandbox: None,
         })
     }
 
-    fn run(&self, _prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
-        Err(AgentError::Unavailable(
-            "Claude Code backend is preserved as a peer backend but delayed".into(),
-        ))
+    fn run(&self, prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
+        run_subprocess_backend(prepared, "claude-code-subprocess", "Claude Code subprocess")
     }
 
     fn stop(&self, _reason: &str) -> Result<(), AgentError> {
         Ok(())
     }
 
-    fn summarize(&self, _events: &[AgentEvent]) -> AgentSummary {
-        AgentSummary {
-            backend: self.name().into(),
-            success: false,
-            session_id: None,
-            message: "Claude Code backend not executed".into(),
-        }
+    fn summarize(&self, events: &[AgentEvent]) -> AgentSummary {
+        summarize_events(self.name(), events)
     }
 }
 
 fn run_subprocess_backend(
     prepared: PreparedRun,
     session_id: &str,
+    completion_subject: &str,
 ) -> Result<Vec<AgentEvent>, AgentError> {
     let mut events = vec![AgentEvent::SessionStarted {
         backend: prepared.backend.clone(),
@@ -265,13 +259,13 @@ fn run_subprocess_backend(
                 events.push(AgentEvent::Completed {
                     backend: prepared.backend,
                     session_id: Some(session_id.into()),
-                    summary: "Codex subprocess completed successfully.".into(),
+                    summary: format!("{completion_subject} completed successfully."),
                 });
             } else {
                 events.push(AgentEvent::Failed {
                     backend: prepared.backend,
                     error: format!(
-                        "Codex subprocess exited with status {}",
+                        "{completion_subject} exited with status {}",
                         output.status.code().unwrap_or(-1)
                     ),
                 });
@@ -284,7 +278,10 @@ fn run_subprocess_backend(
             let _ = child.wait();
             events.push(AgentEvent::Failed {
                 backend: prepared.backend,
-                error: format!("Codex subprocess timed out after {}ms", prepared.timeout_ms),
+                error: format!(
+                    "{completion_subject} timed out after {}ms",
+                    prepared.timeout_ms
+                ),
             });
             return Ok(events);
         }
@@ -356,6 +353,17 @@ mod tests {
         RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md")).unwrap()
     }
 
+    fn claude_config(command: &str, timeout_ms: u64) -> RuntimeConfig {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            &format!(
+                "---\nagent:\n  backend: claude-code\nclaude:\n  command: {command:?}\n  turn_timeout_ms: {timeout_ms}\n---\nPrompt"
+            ),
+        )
+        .unwrap();
+        RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md")).unwrap()
+    }
+
     #[test]
     fn codex_backend_runs_subprocess_in_workspace() {
         let temp = tempfile::tempdir().unwrap();
@@ -398,6 +406,63 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let config = codex_config("sleep 1", 10);
         let backend = CodexBackend;
+        let prepared = backend
+            .prepare(temp.path().to_path_buf(), "prompt".into(), &config)
+            .unwrap();
+        let events = backend.run(prepared).unwrap();
+        let summary = backend.summarize(&events);
+
+        assert!(!summary.success);
+        assert!(summary.message.contains("timed out"));
+    }
+
+    #[test]
+    fn claude_code_backend_runs_subprocess_in_workspace() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = claude_config("cat > claude-subprocess-output.md", 5_000);
+        let backend = ClaudeCodeBackend;
+        let prepared = backend
+            .prepare(temp.path().to_path_buf(), "hello claude".into(), &config)
+            .unwrap();
+        let events = backend.run(prepared).unwrap();
+        let summary = backend.summarize(&events);
+
+        assert!(summary.success);
+        assert_eq!(summary.backend, "claude-code");
+        assert_eq!(
+            summary.session_id.as_deref(),
+            Some("claude-code-subprocess")
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("claude-subprocess-output.md")).unwrap(),
+            "hello claude"
+        );
+    }
+
+    #[test]
+    fn claude_code_backend_reports_subprocess_failure() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = claude_config("echo claude-nope >&2; exit 9", 5_000);
+        let backend = ClaudeCodeBackend;
+        let prepared = backend
+            .prepare(temp.path().to_path_buf(), "prompt".into(), &config)
+            .unwrap();
+        let events = backend.run(prepared).unwrap();
+        let summary = backend.summarize(&events);
+
+        assert!(!summary.success);
+        assert!(summary.message.contains("status 9"));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Message { text, .. } if text.contains("claude-nope")
+        )));
+    }
+
+    #[test]
+    fn claude_code_backend_reports_timeout() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = claude_config("sleep 1", 10);
+        let backend = ClaudeCodeBackend;
         let prepared = backend
             .prepare(temp.path().to_path_buf(), "prompt".into(), &config)
             .unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,7 @@ pub struct CodexConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClaudeConfig {
     pub command: String,
+    pub turn_timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -210,6 +211,7 @@ impl RuntimeConfig {
         let claude = ClaudeConfig {
             command: get_string(root.get("claude"), "command")
                 .unwrap_or_else(|| "claude".to_string()),
+            turn_timeout_ms: get_u64(root.get("claude"), "turn_timeout_ms").unwrap_or(3_600_000),
         };
         let review = ReviewConfig {
             backend: get_string(root.get("review"), "backend")


### PR DESCRIPTION
## Summary
- Adds a conservative Claude Code subprocess backend behind the existing `AgentBackend` abstraction.
- Reuses the workspace-bound subprocess contract: prompt file, stdin prompt, stdout/stderr capture, normalized completion/failure/timeout events.
- Adds `claude.turn_timeout_ms`, a safe fixture workflow, tests, and docs.
- Keeps full Claude Code protocol/app-server parity explicitly out of scope.

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- run-once examples/claude-subprocess-workflow.md

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #27
