### PR TITLE
feat: use claim helpers in run loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ one-issue-one-PR automation are still future work.
 - `run-once` can execute the conservative Claude Code subprocess backend when a
   workflow explicitly sets `agent.backend: claude-code`.
 - `run-loop` can re-read tracker state per iteration, select dispatchable work,
-  print dry-run claim/run/workpad/handoff actions, and in explicit `--write`
-  mode run one issue at a time and stop main-agent completion at
-  `Agent Review`; unbounded write mode sleeps on idle polls using the workflow
-  polling interval.
+  print dry-run claim/run/workpad/handoff actions, use tracker claim helpers to
+  claim/resume/skip externally changed issues, and in explicit `--write` mode
+  run one issue at a time and stop main-agent completion at `Agent Review`;
+  unbounded write mode sleeps on idle polls using the workflow polling interval.
 
 ## Dry-Run Only
 
@@ -156,11 +156,11 @@ claim reconciliation, resume state, and PR automation exist.
 ## Not Implemented Yet
 
 - long-running worker supervision beyond idle polling in `run-loop`.
-- real issue claiming, state transitions, and reconciliation.
+- richer issue claiming, state transition, and reconciliation safety beyond the
+  current claim helper wiring.
 - wiring runtime-state persistence into the run loop and resume flow.
 - workspace-per-issue branch and PR automation beyond the current planning
   primitive.
-- polling-runtime wiring for the existing claim/reconciliation helpers.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.
 - live token/rate-limit accounting beyond the current snapshot counters.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -12,7 +12,7 @@ yet.
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
 | Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
-| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives and idle-poll in unbounded write mode; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
+| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Project field setup after creation is not implemented yet. |
@@ -51,8 +51,8 @@ Project v2 issues:
 
 3. Dispatch safety.
    - Enforce assignee filter from live GitHub issue assignees.
-   - Reuse tracker claim helpers to claim only `Todo` / `Rework`, resume active
-     `In Progress`, and stop/replan on externally changed states.
+   - `run-loop` reuses tracker claim helpers to claim only `Todo` / `Rework`,
+     resume active `In Progress`, and stop/replan on externally changed states.
    - Revalidate issue state immediately before dispatch.
    - Keep GitHub-specific fields out of `orchestrator`.
 - Current explicit `gate-apply` can record quality-gate assumptions or

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,9 @@ use jade_symphony::review::{
     GeminiCliReviewBackend, ReviewBackend, ReviewJob, ReviewRequest,
 };
 use jade_symphony::status_surface::render_snapshot;
-use jade_symphony::tracker::{adapter_from_config, FollowUpIssueInput};
+use jade_symphony::tracker::{
+    adapter_from_config, claim_decision, ClaimDecision, FollowUpIssueInput,
+};
 use jade_symphony::workflow::WorkflowDefinition;
 use jade_symphony::workspace::{prepare_workspace, run_after_run, run_before_run};
 
@@ -637,14 +639,24 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
-        if normalize_state(&latest.state) != "in progress" {
-            adapter.set_state(&latest.identifier, "in_progress")?;
-            println!(
-                "run_loop_action=claim issue={} target_state=in_progress",
-                latest.identifier
-            );
-        } else {
-            println!("run_loop_action=resume issue={}", latest.identifier);
+        match run_loop_claim_action(&latest, &config) {
+            RunLoopClaimAction::Claim => {
+                adapter.set_state(&latest.identifier, "in_progress")?;
+                println!(
+                    "run_loop_action=claim issue={} target_state=in_progress",
+                    latest.identifier
+                );
+            }
+            RunLoopClaimAction::Resume => {
+                println!("run_loop_action=resume issue={}", latest.identifier);
+            }
+            RunLoopClaimAction::StopAndReplan { current_state } => {
+                println!(
+                    "run_loop_action=skip issue={} reason=external_state_change current_state={:?}",
+                    latest.identifier, current_state
+                );
+                continue;
+            }
         }
 
         let result = execute_issue_once(&workflow, &config, &latest)?;
@@ -676,6 +688,23 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
 enum NoDispatchAction {
     Stop { reason: &'static str },
     SleepAndContinue { delay_ms: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RunLoopClaimAction {
+    Claim,
+    Resume,
+    StopAndReplan { current_state: String },
+}
+
+fn run_loop_claim_action(issue: &TrackerIssue, config: &RuntimeConfig) -> RunLoopClaimAction {
+    match claim_decision(issue, config) {
+        ClaimDecision::Claimable => RunLoopClaimAction::Claim,
+        ClaimDecision::AlreadyInProgress => RunLoopClaimAction::Resume,
+        ClaimDecision::StopAndReplan { current_state } => {
+            RunLoopClaimAction::StopAndReplan { current_state }
+        }
+    }
 }
 
 fn no_dispatch_action(
@@ -1341,6 +1370,37 @@ mod tests {
         Command::parse(args.iter().map(|arg| arg.to_string()).collect()).unwrap()
     }
 
+    fn test_config() -> RuntimeConfig {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\n---\nPrompt",
+        )
+        .unwrap();
+        RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap()
+    }
+
+    fn tracker_issue(state: &str) -> TrackerIssue {
+        TrackerIssue {
+            tracker_kind: "memory".into(),
+            id: "ISSUE_31".into(),
+            item_id: None,
+            identifier: "#31".into(),
+            title: "Wire run-loop to tracker claim helpers".into(),
+            description: None,
+            url: None,
+            state: state.into(),
+            labels: Vec::new(),
+            assignees: Vec::new(),
+            priority: None,
+            branch_name: None,
+            linked_pull_requests: Vec::new(),
+            blocked_by: Vec::new(),
+            project_fields: Default::default(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
     #[test]
     fn clap_parser_preserves_default_plan_compatibility() {
         assert_eq!(
@@ -1473,6 +1533,30 @@ mod tests {
         .unwrap_err();
 
         assert!(error.contains("Usage:"));
+    }
+
+    #[test]
+    fn run_loop_claim_action_uses_tracker_claim_decision() {
+        let config = test_config();
+
+        assert_eq!(
+            run_loop_claim_action(&tracker_issue("Todo"), &config),
+            RunLoopClaimAction::Claim
+        );
+        assert_eq!(
+            run_loop_claim_action(&tracker_issue("Rework"), &config),
+            RunLoopClaimAction::Claim
+        );
+        assert_eq!(
+            run_loop_claim_action(&tracker_issue("In Progress"), &config),
+            RunLoopClaimAction::Resume
+        );
+        assert_eq!(
+            run_loop_claim_action(&tracker_issue("Agent Review"), &config),
+            RunLoopClaimAction::StopAndReplan {
+                current_state: "Agent Review".into()
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wires write-mode `run-loop` to use `claim_decision` before claiming work.
- Claims only claimable `Todo` / `Rework` issues, resumes `In Progress`, and skips externally changed states without mutation.
- Updates README and dogfood readiness docs to reflect claim-helper runtime wiring.

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Handoff

Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #31
