### PR TITLE
feat: record run-loop handoff plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ one-issue-one-PR automation are still future work.
 - `run-once` can execute the conservative Claude Code subprocess backend when a
   workflow explicitly sets `agent.backend: claude-code`.
 - `run-loop` can re-read tracker state per iteration, select dispatchable work,
-  print dry-run claim/run/workpad/handoff actions, use tracker claim helpers to
+  print dry-run claim/run/workpad/handoff actions, surface deterministic
+  workspace/branch/PR handoff plans, use tracker claim helpers to
   claim/resume/skip externally changed issues, and in explicit `--write` mode
-  run one issue at a time and stop main-agent completion at `Agent Review`;
+  run one issue at a time, record planned handoff evidence, and stop main-agent
+  completion at `Agent Review`;
   unbounded write mode sleeps on idle polls using the workflow polling interval.
 
 ## Dry-Run Only
@@ -167,8 +169,8 @@ claim reconciliation, resume state, and PR automation exist.
 - richer issue claiming, state transition, and reconciliation safety beyond the
   current claim helper and runtime-state wiring.
 - full runtime-state resume reconciliation after interruption.
-- workspace-per-issue branch and PR automation beyond the current planning
-  primitive.
+- workspace-per-issue branch and PR automation beyond current handoff planning
+  and workpad evidence.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.
 - live token/rate-limit accounting beyond the current snapshot counters.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -16,8 +16,8 @@ yet.
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
-| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes and idle polling exists. Write-mode `run-loop` persists active issue runtime state during execution and clears it after terminal handoff/block transitions. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, and workspace/branch/PR handoff planning exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
+| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
@@ -93,9 +93,9 @@ Project v2 issues:
    - Runtime state writes exist for claim/resume, backend result evidence, and
      final transition intent; full resume reconciliation after interruption
      remains pending.
-   - workspace/branch/PR handoff planning exists, but the runtime still needs
-     live worktree creation, branch checkout, push, PR creation, and PR link
-     recording.
+   - workspace/branch/PR handoff planning is recorded by `run-loop`, but the
+     runtime still needs live worktree creation, branch checkout, push, PR
+     creation, and PR link recording.
    - continuation retry after normal active-state exits.
    - exponential backoff for failures.
    - stall detection.
@@ -216,14 +216,16 @@ Acceptance:
 
 ### 6. Wire Workspace Branch And PR Handoff Into Run-Loop
 
-Goal: connect the current handoff planning primitive to controlled runtime
-mutation without mixing multiple issue scopes in one branch.
+Goal: connect handoff planning evidence to controlled runtime mutation without
+mixing multiple issue scopes in one branch.
 
 Acceptance:
 
+- records the planned workspace key, workspace path, branch, and PR title in
+  `run-loop` dry-run output and workpad evidence.
+- refuses branches that appear to belong to a different issue.
 - creates or reuses one isolated git worktree per issue.
 - checks out the planned issue branch from the configured base branch.
-- refuses branches that appear to belong to a different issue.
 - pushes the issue branch after local completion.
 - creates one PR with a handoff body and records the PR link in the workpad.
 - keeps main implementation completion at `Agent Review`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum
 use jade_symphony::agent::backend_from_config;
 use jade_symphony::config::RuntimeConfig;
 use jade_symphony::event_log::{EventLog, EventRecord};
+use jade_symphony::handoff::{plan_issue_handoff, HandoffError, IssueHandoffPlan};
 use jade_symphony::issue_forge::{
     discover_candidates, draft_from_template, repair_markdown, validate_markdown,
 };
@@ -28,6 +29,8 @@ use jade_symphony::tracker::{
 };
 use jade_symphony::workflow::WorkflowDefinition;
 use jade_symphony::workspace::{prepare_workspace, run_after_run, run_before_run};
+
+const DEFAULT_RUN_LOOP_BASE_BRANCH: &str = "main";
 
 fn main() {
     if let Err(error) = run() {
@@ -529,7 +532,16 @@ fn execute_issue_once(
     config: &RuntimeConfig,
     issue: &TrackerIssue,
 ) -> Result<IssueExecutionResult, Box<dyn std::error::Error>> {
-    let workspace = prepare_workspace(&config.workspace.root, &issue.identifier, &config.hooks)?;
+    execute_issue_once_with_workspace_key(workflow, config, issue, &issue.identifier)
+}
+
+fn execute_issue_once_with_workspace_key(
+    workflow: &WorkflowDefinition,
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+    workspace_key: &str,
+) -> Result<IssueExecutionResult, Box<dyn std::error::Error>> {
+    let workspace = prepare_workspace(&config.workspace.root, workspace_key, &config.hooks)?;
     run_before_run(&workspace.path, &config.hooks)?;
 
     let prompt = render_prompt(&workflow.prompt_template, issue, None)?;
@@ -623,8 +635,16 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             if options.write { "write" } else { "dry-run" }
         );
 
+        let handoff = match run_loop_handoff_plan(&config, &issue) {
+            Ok(handoff) => handoff,
+            Err(error) => {
+                handle_run_loop_handoff_failure(adapter.as_ref(), &issue, &error, &options)?;
+                continue;
+            }
+        };
+
         if !options.write {
-            print_run_loop_dry_run_actions(&issue);
+            print_run_loop_dry_run_actions(&issue, &handoff);
             if limit.is_none() {
                 println!(
                     "run_loop=stopped reason=dry_run_would_repeat_without_mutation iterations={iterations}"
@@ -642,6 +662,14 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             handle_run_loop_gate_failure(adapter.as_ref(), &latest, &latest_gate, &options)?;
             continue;
         }
+
+        let handoff = match run_loop_handoff_plan(&config, &latest) {
+            Ok(handoff) => handoff,
+            Err(error) => {
+                handle_run_loop_handoff_failure(adapter.as_ref(), &latest, &error, &options)?;
+                continue;
+            }
+        };
 
         let existing_runtime_state = load_runtime_state(&config)?;
         if let Some(state) = &existing_runtime_state {
@@ -687,7 +715,12 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             latest.identifier
         );
 
-        let result = execute_issue_once(&workflow, &config, &latest)?;
+        let result = execute_issue_once_with_workspace_key(
+            &workflow,
+            &config,
+            &latest,
+            &handoff.workspace_key,
+        )?;
         runtime_state = run_loop_runtime_state_with_result(runtime_state, &result);
         save_runtime_state(&config, &runtime_state)?;
         println!(
@@ -696,7 +729,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             runtime_state.last_event.as_deref().unwrap_or("unknown")
         );
 
-        let workpad = run_loop_handoff_workpad(&latest, &result);
+        let workpad = run_loop_handoff_workpad(&latest, &result, &handoff);
         adapter.upsert_workpad(&latest.identifier, &workpad)?;
 
         if result.success {
@@ -835,6 +868,13 @@ fn run_loop_runtime_state_with_transition(
     state
 }
 
+fn run_loop_handoff_plan(
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+) -> Result<IssueHandoffPlan, HandoffError> {
+    plan_issue_handoff(&config.workspace.root, issue, DEFAULT_RUN_LOOP_BASE_BRANCH)
+}
+
 fn handle_run_loop_gate_failure(
     adapter: &dyn jade_symphony::tracker::TrackerAdapter,
     issue: &TrackerIssue,
@@ -862,7 +902,34 @@ fn handle_run_loop_gate_failure(
     Ok(())
 }
 
-fn print_run_loop_dry_run_actions(issue: &TrackerIssue) {
+fn handle_run_loop_handoff_failure(
+    adapter: &dyn jade_symphony::tracker::TrackerAdapter,
+    issue: &TrackerIssue,
+    error: &HandoffError,
+    options: &RunLoopOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "run_loop_handoff=failed issue={} error={}",
+        issue.identifier, error
+    );
+    let workpad = run_loop_handoff_failure_workpad(issue, error);
+    if options.write {
+        adapter.upsert_workpad(&issue.identifier, &workpad)?;
+        adapter.set_state(&issue.identifier, "need_human_input")?;
+    } else {
+        println!(
+            "run_loop_dry_run action=workpad issue={} reason=handoff_plan_failed",
+            issue.identifier
+        );
+        println!(
+            "run_loop_dry_run action=set_state issue={} target_state=need_human_input",
+            issue.identifier
+        );
+    }
+    Ok(())
+}
+
+fn print_run_loop_dry_run_actions(issue: &TrackerIssue, handoff: &IssueHandoffPlan) {
     if normalize_state(&issue.state) != "in progress" {
         println!(
             "run_loop_dry_run action=claim issue={} target_state=in_progress",
@@ -871,6 +938,14 @@ fn print_run_loop_dry_run_actions(issue: &TrackerIssue) {
     } else {
         println!("run_loop_dry_run action=resume issue={}", issue.identifier);
     }
+    println!(
+        "run_loop_dry_run action=handoff_plan issue={} workspace_key={} workspace_path={} branch={} pr_title={:?}",
+        issue.identifier,
+        handoff.workspace_key,
+        handoff.workspace_path.display(),
+        handoff.branch_name,
+        handoff.pull_request.title
+    );
     println!(
         "run_loop_dry_run action=run issue={} backend=configured",
         issue.identifier
@@ -885,7 +960,11 @@ fn print_run_loop_dry_run_actions(issue: &TrackerIssue) {
     );
 }
 
-fn run_loop_handoff_workpad(issue: &TrackerIssue, result: &IssueExecutionResult) -> String {
+fn run_loop_handoff_workpad(
+    issue: &TrackerIssue,
+    result: &IssueExecutionResult,
+    handoff: &IssueHandoffPlan,
+) -> String {
     [
         "## Jade Symphony Workpad".to_string(),
         String::new(),
@@ -903,9 +982,35 @@ fn run_loop_handoff_workpad(issue: &TrackerIssue, result: &IssueExecutionResult)
         ),
         format!("- Message: {}", result.message),
         String::new(),
+        "### Planned Handoff".to_string(),
+        format!("- Workspace key: `{}`", handoff.workspace_key),
+        format!("- Workspace path: `{}`", handoff.workspace_path.display()),
+        format!("- Branch: `{}`", handoff.branch_name),
+        format!("- PR title: `{}`", handoff.pull_request.title),
+        format!("- PR base branch: `{}`", handoff.pull_request.base_branch),
+        "- PR creation is planned evidence only in this slice.".to_string(),
+        String::new(),
         "### Main-Agent Boundary".to_string(),
         "- Locally complete main-agent work stops at `Agent Review`.".to_string(),
         "- `Human Review` is reserved for independent Review Agent pass evidence.".to_string(),
+    ]
+    .join("\n")
+}
+
+fn run_loop_handoff_failure_workpad(issue: &TrackerIssue, error: &HandoffError) -> String {
+    [
+        "## Jade Symphony Workpad".to_string(),
+        String::new(),
+        "### Context".to_string(),
+        format!("- Issue: {} {}", issue.identifier, issue.title),
+        "- Source: `jade-symphony run-loop`".to_string(),
+        String::new(),
+        "### Handoff Planning Blocker".to_string(),
+        format!("- Error: `{}`", error),
+        "- Backend execution was skipped before claim/run to avoid mixing issue scope.".to_string(),
+        String::new(),
+        "### Required Human Decision".to_string(),
+        "- Confirm the correct branch/workspace ownership before retrying.".to_string(),
     ]
     .join("\n")
 }
@@ -1721,6 +1826,72 @@ mod tests {
                 reason: "main agent completed".into(),
             })
         );
+    }
+
+    #[test]
+    fn run_loop_handoff_plan_uses_issue_workspace_and_branch_plan() {
+        let config = test_config();
+        let issue = tracker_issue("In Progress");
+
+        let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+
+        assert_eq!(
+            handoff.workspace_key,
+            "issue-29-wire-runtime-state-persistence-into-run-loop"
+        );
+        assert!(handoff
+            .workspace_path
+            .ends_with("issue-29-wire-runtime-state-persistence-into-run-loop"));
+        assert_eq!(
+            handoff.branch_name,
+            "feature/issue-29-wire-runtime-state-persistence-into-run-loop"
+        );
+        assert_eq!(
+            handoff.pull_request.title,
+            "#29: Wire runtime state persistence into run-loop"
+        );
+        assert_eq!(handoff.pull_request.base_branch, "main");
+    }
+
+    #[test]
+    fn run_loop_handoff_plan_rejects_branch_for_different_issue() {
+        let config = test_config();
+        let mut issue = tracker_issue("In Progress");
+        issue.branch_name = Some("feature/issue-99-other-work".into());
+
+        let error = run_loop_handoff_plan(&config, &issue).unwrap_err();
+
+        assert!(matches!(
+            error,
+            HandoffError::BranchIssueMismatch {
+                expected_issue,
+                found_issue,
+                ..
+            } if expected_issue == "29" && found_issue == "99"
+        ));
+    }
+
+    #[test]
+    fn run_loop_handoff_workpad_records_planned_pr_evidence() {
+        let config = test_config();
+        let issue = tracker_issue("In Progress");
+        let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+        let result = IssueExecutionResult {
+            workspace_path: handoff.workspace_path.clone(),
+            backend: "dry-run".into(),
+            success: true,
+            session_id: Some("session-33".into()),
+            message: "ok".into(),
+        };
+
+        let workpad = run_loop_handoff_workpad(&issue, &result, &handoff);
+
+        assert!(workpad.contains("### Planned Handoff"));
+        assert!(workpad
+            .contains("Workspace key: `issue-29-wire-runtime-state-persistence-into-run-loop`"));
+        assert!(workpad
+            .contains("Branch: `feature/issue-29-wire-runtime-state-persistence-into-run-loop`"));
+        assert!(workpad.contains("PR title: `#29: Wire runtime state persistence into run-loop`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wires `run-loop` to plan deterministic workspace, branch, and PR handoff evidence for selected issues.
- Prints handoff-plan details in dry-run mode and records planned handoff details in write-mode workpad evidence.
- Stops safely on branch/issue mismatch before claim/backend execution.

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run`

## Handoff

Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #33
