### PR TITLE
feat: initialize project status on add

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ cargo run -- review-once path/to/WORKFLOW.md '#123' --write
 cargo run -- review-fake path/to/WORKFLOW.md '#123' --outcome pass --write
 ```
 
+`add-to-project` initializes the configured ProjectV2 `Status` field to the
+workflow's mapped `Todo` option so newly added issues are visible to the
+normalized tracker state machine. Arbitrary Project field setup, such as
+Capability, is still a follow-up.
+
 `set-state` is a main-implementation-agent command and refuses `Human Review`.
 `review-once` / `review-fake` are independent Review Agent commands: a passing
 review can move `Agent Review` to `Human Review`, confirmed findings move to
@@ -186,8 +191,9 @@ cargo run -- plan path/to/WORKFLOW.md
 
 This path can read ProjectV2 items and normalize GitHub Issue content for
 planning. Explicit `--write` commands can update ProjectV2 status, write workpad
-comments, create follow-up issues, and add issues to the project. PR linking uses
-an issue comment/autolink strategy rather than a first-class relationship. Jade
+comments, create follow-up issues, and add issues to the project with initial
+`Todo` status. PR linking uses an issue comment/autolink strategy rather than a
+first-class relationship. Jade
 Symphony can idle-poll in unbounded write mode, but still cannot fully reconcile
 state or supervise live agents.
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -12,10 +12,10 @@ yet.
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
 | Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
-| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
+| GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
-| Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Project field setup after creation is not implemented yet. |
+| Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes and idle polling exists. Write-mode `run-loop` persists active issue runtime state during execution and clears it after terminal handoff/block transitions. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, and workspace/branch/PR handoff planning exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
@@ -118,8 +118,9 @@ Project v2 issues:
 
 10. Issue Forge tracker completion.
    - `forge-create` can create a tracker issue and optionally add it to the
-     configured project through the normalized adapter.
-   - Remaining work: set normalized initial state/capability fields through a
+     configured project through the normalized adapter with initial `Todo`
+     status in GitHub ProjectV2 mode.
+   - Remaining work: set capability and arbitrary Project fields through a
      tracker-neutral field operation or tracker-specific adapter method.
 
 ## Recommended Next GitHub Issues

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -407,16 +407,8 @@ impl GithubProjectV2GhClient {
             ))
         })?;
         let metadata = self.project_metadata()?;
-        let option_id = metadata
-            .status_options
-            .iter()
-            .find_map(|(id, name)| (name == &option_name).then_some(id.clone()))
-            .ok_or_else(|| {
-                TrackerError::IntegrationUnavailable(format!(
-                    "status option {option_name:?} was not found in ProjectV2 field {}",
-                    self.config.tracker.status_field
-                ))
-            })?;
+        let option_id =
+            status_option_id(&metadata, &option_name, &self.config.tracker.status_field)?;
 
         self.graphql(
             GITHUB_UPDATE_PROJECT_ITEM_FIELD_MUTATION,
@@ -481,11 +473,24 @@ impl GithubProjectV2GhClient {
 
     fn add_issue_to_project(&self, issue_id: &str) -> Result<(), TrackerError> {
         let metadata = self.project_metadata()?;
-        self.graphql(
+        let option_name = self.state_option_name("todo")?;
+        let option_id =
+            status_option_id(&metadata, &option_name, &self.config.tracker.status_field)?;
+        let response = self.graphql(
             GITHUB_ADD_PROJECT_ITEM_MUTATION,
             &[
-                ("projectId", metadata.project_id),
+                ("projectId", metadata.project_id.clone()),
                 ("contentId", issue_id.to_string()),
+            ],
+        )?;
+        let item_id = project_item_id_from_add_response(&response)?;
+        self.graphql(
+            GITHUB_UPDATE_PROJECT_ITEM_FIELD_MUTATION,
+            &[
+                ("projectId", metadata.project_id),
+                ("itemId", item_id),
+                ("fieldId", metadata.status_field_id),
+                ("optionId", option_id),
             ],
         )?;
         Ok(())
@@ -1109,6 +1114,32 @@ fn ensure_workpad_marker(markdown: &str, marker: &str) -> String {
     } else {
         format!("{marker}\n{markdown}")
     }
+}
+
+fn status_option_id(
+    metadata: &ProjectMetadata,
+    option_name: &str,
+    status_field: &str,
+) -> Result<String, TrackerError> {
+    metadata
+        .status_options
+        .iter()
+        .find_map(|(id, name)| (name == option_name).then_some(id.clone()))
+        .ok_or_else(|| {
+            TrackerError::IntegrationUnavailable(format!(
+                "status option {option_name:?} was not found in ProjectV2 field {status_field}"
+            ))
+        })
+}
+
+fn project_item_id_from_add_response(response: &serde_json::Value) -> Result<String, TrackerError> {
+    response
+        .pointer("/data/addProjectV2ItemById/item/id")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            TrackerError::Payload("addProjectV2ItemById response missing item id".into())
+        })
 }
 
 fn status_update_required(issue: &TrackerIssue, target_state: &str) -> bool {
@@ -2430,6 +2461,43 @@ Prompt
                 ("OPT_DONE".into(), "Done".into())
             ]
         );
+    }
+
+    #[test]
+    fn resolves_project_status_option_id() {
+        let metadata = ProjectMetadata {
+            project_id: "PVT_1".into(),
+            status_field_id: "FIELD_STATUS".into(),
+            status_options: vec![
+                ("OPT_TODO".into(), "Todo".into()),
+                ("OPT_DONE".into(), "Done".into()),
+            ],
+        };
+
+        assert_eq!(
+            status_option_id(&metadata, "Todo", "Status").unwrap(),
+            "OPT_TODO"
+        );
+        assert!(status_option_id(&metadata, "Agent Review", "Status").is_err());
+    }
+
+    #[test]
+    fn parses_added_project_item_id() {
+        let response = serde_json::json!({
+            "data": {
+                "addProjectV2ItemById": {
+                    "item": {
+                        "id": "PVTI_35"
+                    }
+                }
+            }
+        });
+
+        assert_eq!(
+            project_item_id_from_add_response(&response).unwrap(),
+            "PVTI_35"
+        );
+        assert!(project_item_id_from_add_response(&serde_json::json!({"data": {}})).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Initializes GitHub ProjectV2 `Status` to the workflow-mapped `Todo` option after `addProjectV2ItemById`.
- Reuses the Project metadata/status option lookup for both `set-state` and add initialization.
- Documents that Capability and arbitrary Project field setup remain follow-up work.

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Handoff

Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #35
