### PR TITLE
feat: add interactive issue forge flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ one-issue-one-PR automation are still future work.
   clarification question, draft from the quality template, validate Markdown,
   repair rough Markdown into an executable issue contract shape, and create a
   tracker issue from a quality-gated contract with explicit `--write`.
+- Issue Forge also has a CLI-first interactive mode that selects a lightweight
+  issue skill/template (`runtime`, `tracker`, `backend`, `review`, `docs`, or
+  `integration-test`), emits one focused clarification question for thin intent,
+  and prints a quality-gated issue draft before any tracker write.
+- Issue Forge reflective mode can scan a local context file for conservative
+  follow-up signals and print quality-gated candidate issue drafts without
+  creating tracker issues.
 - basic strict prompt rendering supports known `issue.*` fields, `attempt`, and
   simple `{% if %}` / `{% else %}` blocks.
 - workspace identifiers are sanitized; local workspace paths stay under the
@@ -118,6 +125,8 @@ cargo run -- forge-discuss --title "Thin Forge issue" --file examples/fixtures/t
 cargo run -- forge-repair --title "Thin Forge issue" --file examples/fixtures/thin-issue.md
 cargo run -- forge-validate --title "Repaired Forge issue" --file examples/fixtures/repaired-issue.md
 cargo run -- forge-draft --title "Implement read-only Project v2 adapter" --goal "Load Project v2 issues into TrackerIssue records."
+cargo run -- forge-interactive --title "Add resume preflight" --intent "run-loop should inspect runtime state before claiming new work" --skill runtime
+cargo run -- forge-reflect --context-file docs/dogfood-readiness.md --limit 1
 cargo run -- forge-create --workflow path/to/WORKFLOW.md --title "Follow-up title" --file path/to/issue.md --add-to-project --write
 ```
 
@@ -139,6 +148,10 @@ cargo run -- review-once path/to/WORKFLOW.md '#123' --write
 cargo run -- review-fake path/to/WORKFLOW.md '#123' --outcome pass --write
 ```
 
+`forge-interactive` is dry-run by default. If it is used to create a tracker
+issue, it requires both `--write` and `--confirm-create`; `--workflow` is also
+required for that write path, and `--add-to-project` remains explicit.
+
 `add-to-project` initializes the configured ProjectV2 `Status` field to the
 workflow's mapped `Todo` option so newly added issues are visible to the
 normalized tracker state machine. Arbitrary Project field setup, such as
@@ -156,6 +169,8 @@ claim reconciliation, resume state, and PR automation exist.
 
 - linked PR attachment/linking as a first-class relationship.
 - live git worktree creation and `gh pr create` from the runtime loop.
+- rich interactive Issue Forge TUI; the current flow is CLI-first and
+  command-step based.
 - Linear live adapter credential-gated smoke coverage.
 - Codex app-server transport.
 - Claude Code full protocol transport beyond the subprocess fixture path.
@@ -176,6 +191,8 @@ claim reconciliation, resume state, and PR automation exist.
 - live token/rate-limit accounting beyond the current snapshot counters.
 - persistent Agent Review worker supervision and reconciliation.
 - Issue Forge Project field setup after issue creation.
+- autonomous Issue Forge issue creation from reflective mode without explicit
+  operator confirmation.
 - automated Issue Quality Gate application inside the polling runtime.
 - full Liquid-compatible prompt renderer.
 - credential-gated integration tests.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -15,7 +15,7 @@ yet.
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
-| Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
+| Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
@@ -120,8 +120,14 @@ Project v2 issues:
    - `forge-create` can create a tracker issue and optionally add it to the
      configured project through the normalized adapter with initial `Todo`
      status in GitHub ProjectV2 mode.
+   - `forge-interactive` can select a lightweight issue skill/template, ask a
+     focused clarification question for thin intent, and print a quality-gated
+     issue draft before any live tracker write.
+   - `forge-reflect` can scan local context for conservative follow-up signals
+     and print quality-gated draft candidates without creating live issues.
    - Remaining work: set capability and arbitrary Project fields through a
-     tracker-neutral field operation or tracker-specific adapter method.
+     tracker-neutral field operation or tracker-specific adapter method, plus a
+     richer TUI or multi-step conversation surface if CLI steps become too thin.
 
 ## Recommended Next GitHub Issues
 
@@ -259,6 +265,21 @@ Acceptance:
 - updates one disposable issue state through mapped workflow state names.
 - creates or updates a marker workpad comment.
 - records exact schema gaps for any unsupported Linear mutation shape.
+
+### 9. Expand Issue Forge Interaction Surface
+
+Goal: turn the current CLI-first interactive and reflective flows into a richer
+operator workflow only after the dry-run command-step path proves useful.
+
+Acceptance:
+
+- preserves the lightweight skill/template registry without product-specific
+  roadmap assumptions.
+- asks one focused clarification question at a time.
+- keeps tracker creation behind explicit write and confirmation flags.
+- can set tracker-neutral metadata fields such as Capability when the adapter
+  supports them.
+- remains fully testable in fixture mode.
 
 ## Dry-Run Dogfood Command
 

--- a/src/issue_forge.rs
+++ b/src/issue_forge.rs
@@ -50,6 +50,41 @@ pub struct RepairReport {
     pub repaired_markdown: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueForgeSkill {
+    pub key: String,
+    pub label: String,
+    pub description: String,
+    pub knowledge_sources: Vec<String>,
+    pub code_paths: Vec<String>,
+    pub guardrails: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InteractiveForgeInput {
+    pub title: String,
+    pub intent: String,
+    pub skill: Option<String>,
+    pub context: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InteractiveForgeReport {
+    pub selected_skill: IssueForgeSkill,
+    pub issue_markdown: String,
+    pub validation: ForgeValidationReport,
+    pub question: Option<ClarificationQuestion>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReflectiveForgeCandidate {
+    pub title: String,
+    pub skill: IssueForgeSkill,
+    pub rationale: String,
+    pub issue_markdown: String,
+    pub validation: ForgeValidationReport,
+}
+
 pub fn discover_candidates(intent: &str) -> Vec<IssueCandidate> {
     let title = title_from_intent(intent);
     let classification = if intent.split_whitespace().count() >= 5 {
@@ -64,6 +99,208 @@ pub fn discover_candidates(intent: &str) -> Vec<IssueCandidate> {
         rationale: "Derived from local operator intent; validate or repair before dispatch.".into(),
         follow_up_candidates: Vec::new(),
     }]
+}
+
+pub fn issue_skill_registry() -> Vec<IssueForgeSkill> {
+    vec![
+        IssueForgeSkill {
+            key: "runtime".into(),
+            label: "Runtime loop".into(),
+            description: "Run-loop, runtime state, polling, resume, and orchestration control."
+                .into(),
+            knowledge_sources: vec![
+                "docs/bootstrap/JADE_SYMPHONY_SPEC.md".into(),
+                "docs/bootstrap/JADE_WORKFLOW.md".into(),
+            ],
+            code_paths: vec![
+                "src/main.rs".into(),
+                "src/runtime_state.rs".into(),
+                "src/orchestrator.rs".into(),
+            ],
+            guardrails: vec![
+                "Main implementation work must stop at Agent Review.".into(),
+                "Preserve dry-run behavior and bounded-loop controls.".into(),
+            ],
+        },
+        IssueForgeSkill {
+            key: "tracker".into(),
+            label: "Tracker integration".into(),
+            description:
+                "GitHub Project v2, Linear, status transitions, workpads, and issue creation."
+                    .into(),
+            knowledge_sources: vec![
+                "docs/bootstrap/TRACKER_GITHUB_PROJECT_V2.md".into(),
+                "docs/bootstrap/JADE_WORKFLOW.md".into(),
+            ],
+            code_paths: vec!["src/tracker.rs".into(), "src/config.rs".into()],
+            guardrails: vec![
+                "Keep GitHub Project v2 and Linear behind the normalized tracker adapter.".into(),
+                "Do not mutate tracker state without explicit --write.".into(),
+            ],
+        },
+        IssueForgeSkill {
+            key: "backend".into(),
+            label: "Agent backend".into(),
+            description: "Codex, Claude Code, dry-run, and subprocess execution backends.".into(),
+            knowledge_sources: vec![
+                "docs/bootstrap/JADE_SYMPHONY_SPEC.md".into(),
+                "docs/bootstrap/references/openai-symphony/SPEC.md".into(),
+            ],
+            code_paths: vec!["src/agent.rs".into(), "src/prompt.rs".into()],
+            guardrails: vec![
+                "Keep Codex and Claude Code behind the normalized backend boundary.".into(),
+                "Keep dry-run backend safe for tests.".into(),
+            ],
+        },
+        IssueForgeSkill {
+            key: "review".into(),
+            label: "Agent Review".into(),
+            description:
+                "Review agent lifecycle, finding classification, and review-state ownership.".into(),
+            knowledge_sources: vec![
+                "docs/bootstrap/JADE_WORKFLOW.md".into(),
+                "docs/bootstrap/JADE_SYMPHONY_SPEC.md".into(),
+            ],
+            code_paths: vec!["src/review.rs".into(), "src/main.rs".into()],
+            guardrails: vec![
+                "Main implementation agent must never set Human Review.".into(),
+                "Failed, unavailable, or inconclusive review must not advance to Human Review."
+                    .into(),
+            ],
+        },
+        IssueForgeSkill {
+            key: "docs".into(),
+            label: "Docs and readiness".into(),
+            description: "README, dogfood readiness, workflow docs, and operator-facing examples."
+                .into(),
+            knowledge_sources: vec![
+                "README.md".into(),
+                "docs/dogfood-readiness.md".into(),
+                "docs/bootstrap/ISSUE_QUALITY_GATE_TEMPLATE.md".into(),
+            ],
+            code_paths: vec!["README.md".into(), "docs/dogfood-readiness.md".into()],
+            guardrails: vec![
+                "Keep docs honest about dry-run, stubbed, and live behavior.".into(),
+                "Do not claim full autonomous orchestration before controlled live proof.".into(),
+            ],
+        },
+        IssueForgeSkill {
+            key: "integration-test".into(),
+            label: "Integration test".into(),
+            description: "Credential-gated smoke tests, fixtures, and dry-run/live verification."
+                .into(),
+            knowledge_sources: vec![
+                "docs/bootstrap/JADE_SYMPHONY_SPEC.md".into(),
+                "docs/dogfood-readiness.md".into(),
+            ],
+            code_paths: vec!["examples/".into(), "tests/".into(), "src/tracker.rs".into()],
+            guardrails: vec![
+                "Keep live tests credential-gated and safe to skip locally.".into(),
+                "Preserve fixture-backed dry-run coverage.".into(),
+            ],
+        },
+    ]
+}
+
+pub fn find_issue_skill(key: &str) -> Option<IssueForgeSkill> {
+    let normalized = key.trim().to_lowercase();
+    issue_skill_registry()
+        .into_iter()
+        .find(|skill| skill.key == normalized)
+}
+
+pub fn select_issue_skill(intent: &str, explicit: Option<&str>) -> IssueForgeSkill {
+    if let Some(skill) = explicit.and_then(find_issue_skill) {
+        return skill;
+    }
+
+    let text = intent.to_lowercase();
+    let selected = if contains_any(
+        &text,
+        &[
+            "github", "project", "tracker", "linear", "status", "workpad",
+        ],
+    ) {
+        "tracker"
+    } else if contains_any(
+        &text,
+        &[
+            "backend",
+            "codex",
+            "claude",
+            "subprocess",
+            "agent execution",
+        ],
+    ) {
+        "backend"
+    } else if contains_any(
+        &text,
+        &[
+            "review",
+            "gemini",
+            "finding",
+            "human review",
+            "agent review",
+        ],
+    ) {
+        "review"
+    } else if contains_any(&text, &["readme", "docs", "documentation", "dogfood"]) {
+        "docs"
+    } else if contains_any(&text, &["test", "fixture", "smoke", "uat", "verification"]) {
+        "integration-test"
+    } else {
+        "runtime"
+    };
+
+    find_issue_skill(selected).expect("built-in issue forge skill exists")
+}
+
+pub fn interactive_forge(input: InteractiveForgeInput) -> InteractiveForgeReport {
+    let selected_skill = select_issue_skill(&input.intent, input.skill.as_deref());
+    let issue_markdown = issue_markdown_from_interactive_input(&input, &selected_skill);
+    let validation = validate_markdown(&input.title, &issue_markdown);
+    let question = focused_interactive_question(&input, &selected_skill, &validation);
+
+    InteractiveForgeReport {
+        selected_skill,
+        issue_markdown,
+        validation,
+        question,
+    }
+}
+
+pub fn reflective_candidates_from_context(
+    context: &str,
+    requested_skill: Option<&str>,
+    limit: usize,
+) -> Vec<ReflectiveForgeCandidate> {
+    context
+        .lines()
+        .map(str::trim)
+        .filter(|line| reflective_signal(line))
+        .take(limit)
+        .enumerate()
+        .map(|(index, line)| {
+            let title = reflective_title(line, index + 1);
+            let intent = reflective_intent(line);
+            let skill = select_issue_skill(&format!("{title} {intent}"), requested_skill);
+            let input = InteractiveForgeInput {
+                title: title.clone(),
+                intent,
+                skill: Some(skill.key.clone()),
+                context: Some(line.to_string()),
+            };
+            let report = interactive_forge(input);
+            ReflectiveForgeCandidate {
+                title,
+                skill,
+                rationale: "Derived from a conservative follow-up signal in the supplied context."
+                    .into(),
+                issue_markdown: report.issue_markdown,
+                validation: report.validation,
+            }
+        })
+        .collect()
 }
 
 pub fn next_clarification_question(decision: &GateDecision) -> Option<ClarificationQuestion> {
@@ -211,6 +448,224 @@ fn title_from_intent(intent: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ");
     format!("Issue candidate: {words}")
+}
+
+fn issue_markdown_from_interactive_input(
+    input: &InteractiveForgeInput,
+    skill: &IssueForgeSkill,
+) -> String {
+    let mut draft = draft_from_template(&input.title, input.intent.trim());
+    draft = draft.replace(
+        "## Why Now\n\nTBD",
+        "## Why Now\n\nThis follow-up is needed to continue turning Jade Symphony from a dry-run skeleton into a usable orchestration binary.",
+    );
+    draft = draft.replace(
+        "## Issue Context\n\nTBD",
+        &format_interactive_context(input, skill),
+    );
+    draft = draft.replace(
+        "### Decisions\n\n- TBD",
+        &format!(
+            "### Decisions\n\n- Use the `{}` Issue Forge skill as the starting contract shape.\n- Keep the implementation focused to this issue and create follow-ups for broader work.",
+            skill.key
+        ),
+    );
+    draft = draft.replace(
+        "### Assumptions\n\n- TBD",
+        "### Assumptions\n\n- The existing Issue Quality Gate remains the acceptance boundary for generated tracker issues.",
+    );
+    draft = draft.replace(
+        "## Non-Negotiable Guardrails\n\n- Keep Jade Symphony orchestration infrastructure separate from downstream product business logic.",
+        &format!(
+            "## Non-Negotiable Guardrails\n\n- Keep Jade Symphony orchestration infrastructure separate from downstream product business logic.\n{}",
+            skill
+                .guardrails
+                .iter()
+                .map(|guardrail| format!("- {guardrail}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+    );
+    draft = draft.replace(
+        &format!("### In Scope\n\n- {}", input.title),
+        &format!(
+            "### In Scope\n\n- Implement the smallest executable slice for: {}.\n- Update tests and docs that directly describe this capability.",
+            input.title
+        ),
+    );
+    draft = draft.replace(
+        "### Target Repository / Package\n\n- TBD",
+        "### Target Repository / Package\n\n- Alive24/jade-symphony",
+    );
+    draft = draft.replace(
+        "### Relevant Knowledge Sources\n\n- TBD",
+        &format!(
+            "### Relevant Knowledge Sources\n\n{}",
+            skill
+                .knowledge_sources
+                .iter()
+                .map(|source| format!("- {source}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+    );
+    draft = draft.replace(
+        "### Relevant Code Paths\n\n- TBD",
+        &format!(
+            "### Relevant Code Paths\n\n{}",
+            skill
+                .code_paths
+                .iter()
+                .map(|path| format!("- {path}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+    );
+    draft = draft.replace(
+        "## Current State\n\nTBD",
+        "## Current State\n\nOperator intent has been captured by Issue Forge and shaped into a quality-gated issue contract.",
+    );
+    draft = draft.replace(
+        "## Deliverable Shape\n\nTBD",
+        "## Deliverable Shape\n\nA focused code, test, fixture, or documentation change matching the selected Issue Forge skill.",
+    );
+    draft = draft.replace(
+        "## Risks or Constraints\n\n- TBD",
+        "## Risks or Constraints\n\n- Do not expand this issue into unrelated roadmap or product work.\n- Keep live external mutations behind explicit `--write` flags.",
+    );
+    draft = draft.replace(
+        "## Expected Outcome\n\nTBD",
+        "## Expected Outcome\n\nA locally verifiable slice that can be handed from main implementation to Agent Review.",
+    );
+    draft = draft.replace(
+        "### Completion Criteria\n\n- TBD",
+        "### Completion Criteria\n\n- The issue contract passes `jade-symphony forge-validate`.\n- Implementation and documentation are limited to the issue scope.",
+    );
+    draft = draft.replace(
+        "### Functional Verification\n\n- TBD",
+        "### Functional Verification\n\n- Run `cargo test`.\n- Run `cargo fmt --check`.\n- Run `cargo clippy --all-targets --all-features -- -D warnings`.",
+    );
+    draft = draft.replace(
+        "### Context Verification\n\n- Confirm the issue still matches canonical sources.",
+        "### Context Verification\n\n- Confirm the issue still matches canonical sources and Project #9 state before dispatch.",
+    );
+    draft
+}
+
+fn format_interactive_context(input: &InteractiveForgeInput, skill: &IssueForgeSkill) -> String {
+    let mut lines = vec![
+        "## Issue Context".to_string(),
+        String::new(),
+        format!(
+            "- Selected Issue Forge skill: `{}` ({})",
+            skill.key, skill.label
+        ),
+        format!("- Operator intent: {}", input.intent.trim()),
+    ];
+    if let Some(context) = input
+        .context
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        lines.push("- Supplied context:".into());
+        lines.push(String::new());
+        lines.push("```md".into());
+        lines.push(context.trim().into());
+        lines.push("```".into());
+    }
+    lines.join("\n")
+}
+
+fn focused_interactive_question(
+    input: &InteractiveForgeInput,
+    skill: &IssueForgeSkill,
+    validation: &ForgeValidationReport,
+) -> Option<ClarificationQuestion> {
+    if let Some(question) = next_clarification_question(&validation.decision) {
+        return Some(question);
+    }
+
+    if input.intent.split_whitespace().count() < 5 {
+        return Some(ClarificationQuestion {
+            question: format!(
+                "What concrete behavior should the `{}` issue change first?",
+                skill.key
+            ),
+            why_it_matters:
+                "The generated issue is structurally valid, but the operator intent is still thin."
+                    .into(),
+        });
+    }
+
+    None
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+fn reflective_signal(line: &str) -> bool {
+    let normalized = line.to_lowercase();
+    contains_any(
+        &normalized,
+        &[
+            "not implemented",
+            "follow-up",
+            "todo",
+            "missing",
+            "must exist",
+            "next issue",
+            "recommended next",
+        ],
+    )
+}
+
+fn reflective_title(line: &str, index: usize) -> String {
+    if let Some(title) = reflective_table_title(line) {
+        return title;
+    }
+
+    let cleaned = line
+        .trim_start_matches(|ch: char| {
+            ch == '-' || ch == '*' || ch == '#' || ch.is_ascii_digit() || ch == '.'
+        })
+        .trim();
+    let words = cleaned
+        .split_whitespace()
+        .take(9)
+        .collect::<Vec<_>>()
+        .join(" ");
+    if words.is_empty() {
+        format!("Reflective follow-up {index}")
+    } else {
+        format!("Follow-up: {words}")
+    }
+}
+
+fn reflective_table_title(line: &str) -> Option<String> {
+    if !line.contains('|') {
+        return None;
+    }
+
+    let cells = line
+        .split('|')
+        .map(str::trim)
+        .filter(|cell| !cell.is_empty())
+        .collect::<Vec<_>>();
+    let capability = cells.first()?;
+    let status = cells.get(1).copied().unwrap_or_default().to_lowercase();
+    if status.contains("not implemented") || status.contains("remaining work") {
+        Some(format!("Follow-up: close {} readiness gap", capability))
+    } else {
+        Some(format!("Follow-up: {}", capability))
+    }
+}
+
+fn reflective_intent(line: &str) -> String {
+    format!(
+        "Turn this reflective readiness signal into an executable Jade Symphony issue: {}",
+        line.trim()
+    )
 }
 
 fn forge_issue(title: &str, markdown: &str) -> TrackerIssue {
@@ -376,5 +831,60 @@ mod tests {
             CandidateClassification::ReadyWithAssumptions
         ));
         assert!(!candidates[0].title.to_lowercase().contains("gsd"));
+    }
+
+    #[test]
+    fn selects_skill_from_explicit_key_or_intent() {
+        assert_eq!(select_issue_skill("anything", Some("review")).key, "review");
+        assert_eq!(
+            select_issue_skill("fix GitHub Project status writes", None).key,
+            "tracker"
+        );
+        assert_eq!(
+            select_issue_skill("update dogfood readiness docs", None).key,
+            "docs"
+        );
+    }
+
+    #[test]
+    fn interactive_forge_builds_quality_gated_contract() {
+        let report = interactive_forge(InteractiveForgeInput {
+            title: "Add resume preflight".into(),
+            intent: "run-loop should inspect runtime state before claiming new work".into(),
+            skill: Some("runtime".into()),
+            context: None,
+        });
+
+        assert_eq!(report.selected_skill.key, "runtime");
+        assert!(report.validation.decision.is_dispatchable());
+        assert!(report.issue_markdown.contains("## Issue Goal"));
+        assert!(report.issue_markdown.contains("src/runtime_state.rs"));
+        assert!(report.question.is_none());
+    }
+
+    #[test]
+    fn interactive_forge_asks_focused_question_for_thin_intent() {
+        let report = interactive_forge(InteractiveForgeInput {
+            title: "Improve tracker".into(),
+            intent: "fix tracker".into(),
+            skill: Some("tracker".into()),
+            context: None,
+        });
+
+        assert!(report.validation.decision.is_dispatchable());
+        assert!(report.question.unwrap().question.contains("tracker"));
+    }
+
+    #[test]
+    fn reflective_candidates_are_conservative_and_quality_gated() {
+        let candidates = reflective_candidates_from_context(
+            "- Not implemented yet: live PR creation.\n- Already done: fixture planning.",
+            None,
+            3,
+        );
+
+        assert_eq!(candidates.len(), 1);
+        assert!(candidates[0].validation.decision.is_dispatchable());
+        assert!(candidates[0].title.contains("live PR creation"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@ use jade_symphony::config::RuntimeConfig;
 use jade_symphony::event_log::{EventLog, EventRecord};
 use jade_symphony::handoff::{plan_issue_handoff, HandoffError, IssueHandoffPlan};
 use jade_symphony::issue_forge::{
-    discover_candidates, draft_from_template, repair_markdown, validate_markdown,
+    discover_candidates, draft_from_template, find_issue_skill, interactive_forge,
+    reflective_candidates_from_context, repair_markdown, validate_markdown, InteractiveForgeInput,
 };
 use jade_symphony::model::{normalize_state, GateDecision, GateDecisionKind, TrackerIssue};
 use jade_symphony::orchestrator::Orchestrator;
@@ -135,6 +136,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             add_to_project,
             write,
         } => forge_create(workflow_path, title, markdown, add_to_project, write),
+        Command::ForgeInteractive { options } => forge_interactive(options),
+        Command::ForgeReflect {
+            context,
+            skill,
+            limit,
+        } => forge_reflect(context, skill, limit),
         Command::Help => {
             println!("{}", usage());
             Ok(())
@@ -293,6 +300,73 @@ fn forge_create(
     }
 
     println!("forge_create=ok issue_id={issue_id} added_to_project={add_to_project}");
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ForgeInteractiveOptions {
+    workflow_path: Option<PathBuf>,
+    title: String,
+    intent: String,
+    skill: Option<String>,
+    context: Option<String>,
+    add_to_project: bool,
+    write: bool,
+    confirm_create: bool,
+}
+
+fn forge_interactive(options: ForgeInteractiveOptions) -> Result<(), Box<dyn std::error::Error>> {
+    let report = interactive_forge(InteractiveForgeInput {
+        title: options.title.clone(),
+        intent: options.intent,
+        skill: options.skill,
+        context: options.context,
+    });
+    print_interactive_forge_report(&report);
+
+    if options.write {
+        if !options.confirm_create {
+            return Err("forge-interactive --write requires --confirm-create".into());
+        }
+        let workflow_path = options
+            .workflow_path
+            .ok_or("forge-interactive --write requires --workflow")?;
+        forge_create(
+            workflow_path,
+            options.title,
+            report.issue_markdown,
+            options.add_to_project,
+            true,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn forge_reflect(
+    context: String,
+    skill: Option<String>,
+    limit: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if limit == 0 {
+        return Err("forge-reflect --limit must be greater than 0".into());
+    }
+
+    let candidates = reflective_candidates_from_context(&context, skill.as_deref(), limit);
+    println!("candidates={}", candidates.len());
+    for (index, candidate) in candidates.iter().enumerate() {
+        println!("{}. {}", index + 1, candidate.title);
+        println!("skill={}", candidate.skill.key);
+        println!("gate={:?}", candidate.validation.decision.kind);
+        println!(
+            "dispatchable={}",
+            candidate.validation.decision.is_dispatchable()
+        );
+        println!("rationale={}", candidate.rationale);
+        println!("--- issue draft ---");
+        println!("{}", candidate.issue_markdown);
+    }
+
     Ok(())
 }
 
@@ -1098,6 +1172,14 @@ enum Command {
         add_to_project: bool,
         write: bool,
     },
+    ForgeInteractive {
+        options: ForgeInteractiveOptions,
+    },
+    ForgeReflect {
+        context: String,
+        skill: Option<String>,
+        limit: usize,
+    },
     Help,
 }
 
@@ -1187,6 +1269,10 @@ enum CliCommand {
     ForgeRepair(ForgeMarkdownArgs),
     #[command(name = "forge-create")]
     ForgeCreate(ForgeCreateArgs),
+    #[command(name = "forge-interactive")]
+    ForgeInteractive(ForgeInteractiveArgs),
+    #[command(name = "forge-reflect")]
+    ForgeReflect(ForgeReflectArgs),
 }
 
 #[derive(Debug, Args)]
@@ -1358,6 +1444,40 @@ struct ForgeCreateArgs {
     _dry_run: bool,
 }
 
+#[derive(Debug, Args)]
+struct ForgeInteractiveArgs {
+    #[arg(long)]
+    workflow: Option<PathBuf>,
+    #[arg(long)]
+    title: String,
+    #[arg(long)]
+    intent: Option<String>,
+    #[arg(long)]
+    file: Option<PathBuf>,
+    #[arg(long)]
+    skill: Option<String>,
+    #[arg(long = "context-file")]
+    context_file: Option<PathBuf>,
+    #[arg(long = "add-to-project")]
+    add_to_project: bool,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "confirm-create")]
+    confirm_create: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct ForgeReflectArgs {
+    #[arg(long = "context-file")]
+    context_file: PathBuf,
+    #[arg(long)]
+    skill: Option<String>,
+    #[arg(long, default_value_t = 3)]
+    limit: usize,
+}
+
 impl TryFrom<Cli> for Command {
     type Error = String;
 
@@ -1470,6 +1590,23 @@ impl TryFrom<Cli> for Command {
                         add_to_project: args.add_to_project,
                         write: args.write,
                     }),
+                    CliCommand::ForgeInteractive(args) => Ok(Self::ForgeInteractive {
+                        options: ForgeInteractiveOptions {
+                            workflow_path: args.workflow,
+                            title: args.title,
+                            intent: read_source_arg(args.intent, args.file)?,
+                            skill: validate_optional_forge_skill(args.skill)?,
+                            context: read_optional_file(args.context_file)?,
+                            add_to_project: args.add_to_project,
+                            write: args.write,
+                            confirm_create: args.confirm_create,
+                        },
+                    }),
+                    CliCommand::ForgeReflect(args) => Ok(Self::ForgeReflect {
+                        context: read_required_file(args.context_file)?,
+                        skill: validate_optional_forge_skill(args.skill)?,
+                        limit: args.limit,
+                    }),
                 }
             }
         }
@@ -1536,6 +1673,24 @@ fn read_source_arg(inline: Option<String>, file: Option<PathBuf>) -> Result<Stri
     }
 }
 
+fn read_optional_file(file: Option<PathBuf>) -> Result<Option<String>, String> {
+    file.map(read_required_file).transpose()
+}
+
+fn read_required_file(path: PathBuf) -> Result<String, String> {
+    std::fs::read_to_string(&path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))
+}
+
+fn validate_optional_forge_skill(skill: Option<String>) -> Result<Option<String>, String> {
+    if let Some(key) = skill.as_deref() {
+        if find_issue_skill(key).is_none() {
+            return Err(format!("unknown Issue Forge skill: {key}"));
+        }
+    }
+    Ok(skill)
+}
+
 fn print_forge_validation(report: &jade_symphony::issue_forge::ForgeValidationReport) {
     println!("title={}", report.title);
     println!("gate={:?}", report.decision.kind);
@@ -1550,6 +1705,19 @@ fn print_forge_validation(report: &jade_symphony::issue_forge::ForgeValidationRe
         println!("question={}", question.question);
         println!("why={}", question.why_it_matters);
     }
+}
+
+fn print_interactive_forge_report(report: &jade_symphony::issue_forge::InteractiveForgeReport) {
+    println!("skill={}", report.selected_skill.key);
+    print_forge_validation(&report.validation);
+    if let Some(question) = &report.question {
+        println!("clarification_question={}", question.question);
+        println!("clarification_why={}", question.why_it_matters);
+    } else {
+        println!("clarification_question=none");
+    }
+    println!("\n--- issue draft ---\n");
+    println!("{}", report.issue_markdown);
 }
 
 fn usage() -> String {
@@ -1925,6 +2093,56 @@ mod tests {
         assert!(markdown.contains("## Issue Goal"));
         assert!(add_to_project);
         assert!(write);
+    }
+
+    #[test]
+    fn parses_forge_interactive_flags() {
+        let command = Command::parse(vec![
+            "forge-interactive".into(),
+            "--workflow".into(),
+            "examples/github-project-workflow.md".into(),
+            "--title".into(),
+            "Add resume preflight".into(),
+            "--intent".into(),
+            "run-loop should inspect runtime state before claiming new work".into(),
+            "--skill".into(),
+            "runtime".into(),
+            "--add-to-project".into(),
+            "--write".into(),
+            "--confirm-create".into(),
+        ])
+        .unwrap();
+
+        let Command::ForgeInteractive { options } = command else {
+            panic!("expected forge-interactive command");
+        };
+
+        assert_eq!(
+            options.workflow_path,
+            Some(PathBuf::from("examples/github-project-workflow.md"))
+        );
+        assert_eq!(options.title, "Add resume preflight");
+        assert!(options.intent.contains("runtime state"));
+        assert_eq!(options.skill.as_deref(), Some("runtime"));
+        assert!(options.add_to_project);
+        assert!(options.write);
+        assert!(options.confirm_create);
+    }
+
+    #[test]
+    fn rejects_unknown_forge_skill() {
+        let error = Command::parse(vec![
+            "forge-interactive".into(),
+            "--title".into(),
+            "Add a thing".into(),
+            "--intent".into(),
+            "make the runtime loop safer".into(),
+            "--skill".into(),
+            "product-roadmap".into(),
+        ])
+        .unwrap_err();
+
+        assert!(error.contains("unknown Issue Forge skill"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a lightweight Issue Forge skill registry for runtime, tracker, backend, review, docs, and integration-test issue shapes
- add forge-interactive and forge-reflect CLI commands that produce quality-gated issue drafts without live writes by default
- document the dry-run-first interactive/reflection flow and explicit --write/--confirm-create creation boundary

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- forge-interactive --title 'Add resume preflight' --intent 'run-loop should inspect runtime state before claiming new work' --skill runtime
- cargo run -- forge-reflect --context-file docs/dogfood-readiness.md --limit 1

Closes #37