### PR TITLE
#39: Add cockpit execution profile discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,18 @@ one-issue-one-PR automation are still future work.
   `before_remove`, and safe cleanup helpers.
 - workspace/branch/PR handoff planning can derive a deterministic issue
   workspace key, branch name, and PR handoff body, and can detect an existing
-  branch that appears to belong to a different issue.
+  branch that appears to belong to a different issue; profile-scoped workspace
+  keys can avoid collisions between parallel worker identities.
+- execution profiles can be listed from workflow config. The first slice can
+  read cockpit-tools Codex instance stores (`codex_instances.json`) and treats
+  each instance name as a Jade worker profile without reading or logging account
+  bindings.
 - terminal status output reports polling state, planned running/skipped/retrying
   issues, token counters, event-log path, gate details, and integration gaps.
-- JSONL event-log primitives exist.
+- JSONL event-log primitives exist and can record selected profile identity.
 - runtime state helpers can write, read, and clear a tracker-neutral
-  `runtime/runtime-state.json` file under the configured logs root.
+  `runtime/runtime-state.json` file under the configured logs root, including
+  optional profile and instance identity.
 - write-mode `run-loop` saves active issue runtime state, updates it with
   backend result evidence, records final transition intent, and clears it after
   successful handoff/block transition.
@@ -110,6 +116,7 @@ cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-once examples/codex-subprocess-workflow.md
 cargo run -- run-once examples/claude-subprocess-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
+cargo run -- profiles examples/cockpit-profiles-workflow.md
 cargo run -- plan examples/linear-fixture-workflow.md
 cargo run -- gate examples/dry-run-workflow.md '#3'
 cargo run -- forge-discover --intent "Add Issue Forge validate and repair commands"
@@ -125,6 +132,15 @@ cargo run -- forge-create --workflow path/to/WORKFLOW.md --title "Follow-up titl
 fixtures show controlled real-backend paths without invoking live hosted
 services. They write `JADE_SYMPHONY_PROMPT.md` into the prepared workspace and
 append JSONL events for the selected workflow.
+
+`profiles` lists execution profiles discovered from workflow config. For
+cockpit-tools, Jade currently reads the Codex instance store shape inspected in
+`https://github.com/jlcodes99/cockpit-tools`: a local `codex_instances.json` with camelCase
+`instances[]` records such as `name`, `userDataDir`, `workingDir`, and
+`extraArgs`. Jade ignores account binding fields, uses the instance name as the
+worker identity, and falls back to explicit `profiles.entries` when the
+cockpit-tools file is not present. This is a small adapter boundary, not a full
+account manager.
 
 Live GitHub write commands are explicit and require a non-fixture workflow plus
 usable GitHub auth through `GITHUB_TOKEN` / `GH_TOKEN` or `gh api graphql`:
@@ -156,6 +172,8 @@ claim reconciliation, resume state, and PR automation exist.
 
 - linked PR attachment/linking as a first-class relationship.
 - live git worktree creation and `gh pr create` from the runtime loop.
+- full multi-account manager UI or account switching; cockpit-tools integration
+  is currently read-only fixture/path parsing for Codex instance names.
 - Linear live adapter credential-gated smoke coverage.
 - Codex app-server transport.
 - Claude Code full protocol transport beyond the subprocess fixture path.
@@ -173,6 +191,8 @@ claim reconciliation, resume state, and PR automation exist.
   and workpad evidence.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.
+- profile-aware tracker claim ownership beyond namespaced runtime/log/workspace
+  metadata.
 - live token/rate-limit accounting beyond the current snapshot counters.
 - persistent Agent Review worker supervision and reconciliation.
 - Issue Forge Project field setup after issue creation.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -10,17 +10,18 @@ yet.
 | Capability | Current Status |
 | --- | --- |
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
-| Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
+| Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings and first-slice execution profiles. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
-| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, run-loop handoff evidence, and profile-scoped workspace keys exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
+| Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
+| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Prepared runs include selected profile/instance metadata and profile environment context. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
-| Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
+| Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events with profile identity when configured. Runtime state files are written during write-mode `run-loop` issue execution and include optional profile/instance identity, but full resume reconciliation is still pending. No web/API surface yet. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
 
 ## Before Executing GitHub Project Issues
@@ -80,6 +81,8 @@ Project v2 issues:
 6. Live agent execution.
    - Harden the Codex and Claude Code subprocess backends, then implement full
      protocol transports.
+   - Preserve selected profile identity in prepared runs, logs, runtime state,
+     and backend environment context without logging secrets.
    - Keep Claude Code as a peer backend path.
    - Normalize session IDs, completion, failures, token usage, and rate-limit
      events.
@@ -96,6 +99,8 @@ Project v2 issues:
    - workspace/branch/PR handoff planning is recorded by `run-loop`, but the
      runtime still needs live worktree creation, branch checkout, push, PR
      creation, and PR link recording.
+   - profile-scoped workspace keys exist, but tracker claim ownership still
+     needs profile-aware reconciliation before parallel worker dogfooding.
    - continuation retry after normal active-state exits.
    - exponential backoff for failures.
    - stall detection.
@@ -115,6 +120,13 @@ Project v2 issues:
    - Fixture tests for pagination, status option cache, malformed payloads, and
      permission failures.
    - Dry-run fixtures remain available for local development without credentials.
+   - cockpit-tools integration remains a small adapter over the local Codex
+     instance store. The inspected source in
+     `https://github.com/jlcodes99/cockpit-tools` uses a camelCase `InstanceStore`
+     (`instances`, `defaultSettings`) and `InstanceProfile` records with
+     `id`, `name`, `userDataDir`, `workingDir`, `extraArgs`, launch metadata,
+     and account binding fields. Jade reads only non-secret instance identity
+     and path/argument context.
 
 10. Issue Forge tracker completion.
    - `forge-create` can create a tracker issue and optionally add it to the

--- a/examples/cockpit-profiles-workflow.md
+++ b/examples/cockpit-profiles-workflow.md
@@ -1,0 +1,24 @@
+---
+tracker:
+  kind: memory
+  fixture_path: fixtures/dry-run-issues.json
+workspace:
+  root: /tmp/jade-symphony-profile-workspaces
+agent:
+  backend: dry-run
+profiles:
+  default: codex-alpha
+  cockpit_tools:
+    codex_instances_path: fixtures/cockpit-tools-codex-instances.json
+  entries:
+    - id: fallback-local
+      instance_name: Fallback Local
+      backend: dry-run
+      workspace_namespace: fallback-local
+      env:
+        JADE_SYMPHONY_FIXTURE_PROFILE: fallback-local
+observability:
+  logs_root: /tmp/jade-symphony-profile-logs
+---
+
+Use the issue contract and keep this fixture workflow dry-run only.

--- a/examples/fixtures/cockpit-tools-codex-instances.json
+++ b/examples/fixtures/cockpit-tools-codex-instances.json
@@ -1,0 +1,36 @@
+{
+  "instances": [
+    {
+      "id": "fixture-codex-alpha",
+      "name": "codex-alpha",
+      "userDataDir": "/tmp/cockpit/codex-alpha",
+      "workingDir": "/tmp/jade/alpha",
+      "extraArgs": "--profile alpha",
+      "bindAccountId": "redacted-fixture-account",
+      "launchMode": "cli",
+      "createdAt": 1710000000000,
+      "lastLaunchedAt": null,
+      "lastPid": null
+    },
+    {
+      "id": "fixture-codex-beta",
+      "name": "codex-beta",
+      "userDataDir": "/tmp/cockpit/codex-beta",
+      "workingDir": "/tmp/jade/beta",
+      "extraArgs": "",
+      "bindAccountId": null,
+      "launchMode": "cli",
+      "createdAt": 1710000001000,
+      "lastLaunchedAt": null,
+      "lastPid": null
+    }
+  ],
+  "defaultSettings": {
+    "bindAccountId": null,
+    "extraArgs": "",
+    "workingDir": null,
+    "launchMode": "app",
+    "followLocalAccount": true,
+    "lastPid": null
+  }
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::thread;
@@ -9,6 +10,7 @@ use thiserror::Error;
 
 use crate::config::RuntimeConfig;
 use crate::model::AgentEvent;
+use crate::profiles::{selected_execution_profile, ExecutionProfile};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedRun {
@@ -19,6 +21,10 @@ pub struct PreparedRun {
     pub timeout_ms: u64,
     pub approval_policy: Option<String>,
     pub sandbox: Option<String>,
+    pub profile_id: Option<String>,
+    pub instance_name: Option<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -62,8 +68,10 @@ impl AgentBackend for DryRunBackend {
         &self,
         workspace: PathBuf,
         rendered_prompt: String,
-        _config: &RuntimeConfig,
+        config: &RuntimeConfig,
     ) -> Result<PreparedRun, AgentError> {
+        let profile = selected_execution_profile(&config.profiles)
+            .map_err(|error| AgentError::Unavailable(error.to_string()))?;
         Ok(PreparedRun {
             backend: self.name().into(),
             workspace,
@@ -72,18 +80,24 @@ impl AgentBackend for DryRunBackend {
             timeout_ms: 0,
             approval_policy: None,
             sandbox: None,
+            profile_id: profile.as_ref().map(|profile| profile.profile_id.clone()),
+            instance_name: profile
+                .as_ref()
+                .map(|profile| profile.instance_name.clone()),
+            env: profile_environment(profile.as_ref(), self.name()),
         })
     }
 
     fn run(&self, prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
+        let session_id = session_id_with_profile("dry-run-session", &prepared);
         Ok(vec![
             AgentEvent::SessionStarted {
                 backend: prepared.backend.clone(),
-                session_id: "dry-run-session".into(),
+                session_id: session_id.clone(),
             },
             AgentEvent::Completed {
                 backend: prepared.backend,
-                session_id: Some("dry-run-session".into()),
+                session_id: Some(session_id),
                 summary: "Dry-run backend did not execute external agent commands.".into(),
             },
         ])
@@ -100,7 +114,10 @@ impl AgentBackend for DryRunBackend {
         AgentSummary {
             backend: self.name().into(),
             success,
-            session_id: Some("dry-run-session".into()),
+            session_id: events.iter().find_map(|event| match event {
+                AgentEvent::SessionStarted { session_id, .. } => Some(session_id.clone()),
+                _ => None,
+            }),
             message: "dry-run complete".into(),
         }
     }
@@ -120,6 +137,8 @@ impl AgentBackend for CodexBackend {
         rendered_prompt: String,
         config: &RuntimeConfig,
     ) -> Result<PreparedRun, AgentError> {
+        let profile = selected_execution_profile(&config.profiles)
+            .map_err(|error| AgentError::Unavailable(error.to_string()))?;
         Ok(PreparedRun {
             backend: self.name().into(),
             workspace,
@@ -128,6 +147,11 @@ impl AgentBackend for CodexBackend {
             timeout_ms: config.codex.turn_timeout_ms,
             approval_policy: Some(config.codex.approval_policy.to_string()),
             sandbox: Some(config.codex.thread_sandbox.clone()),
+            profile_id: profile.as_ref().map(|profile| profile.profile_id.clone()),
+            instance_name: profile
+                .as_ref()
+                .map(|profile| profile.instance_name.clone()),
+            env: profile_environment(profile.as_ref(), self.name()),
         })
     }
 
@@ -158,6 +182,8 @@ impl AgentBackend for ClaudeCodeBackend {
         rendered_prompt: String,
         config: &RuntimeConfig,
     ) -> Result<PreparedRun, AgentError> {
+        let profile = selected_execution_profile(&config.profiles)
+            .map_err(|error| AgentError::Unavailable(error.to_string()))?;
         Ok(PreparedRun {
             backend: self.name().into(),
             workspace,
@@ -166,6 +192,11 @@ impl AgentBackend for ClaudeCodeBackend {
             timeout_ms: config.claude.turn_timeout_ms,
             approval_policy: None,
             sandbox: None,
+            profile_id: profile.as_ref().map(|profile| profile.profile_id.clone()),
+            instance_name: profile
+                .as_ref()
+                .map(|profile| profile.instance_name.clone()),
+            env: profile_environment(profile.as_ref(), self.name()),
         })
     }
 
@@ -187,9 +218,10 @@ fn run_subprocess_backend(
     session_id: &str,
     completion_subject: &str,
 ) -> Result<Vec<AgentEvent>, AgentError> {
+    let session_id = session_id_with_profile(session_id, &prepared);
     let mut events = vec![AgentEvent::SessionStarted {
         backend: prepared.backend.clone(),
-        session_id: session_id.into(),
+        session_id: session_id.clone(),
     }];
 
     if !prepared.workspace.is_dir() {
@@ -225,6 +257,7 @@ fn run_subprocess_backend(
             "JADE_SYMPHONY_SANDBOX",
             prepared.sandbox.as_deref().unwrap_or_default(),
         )
+        .envs(prepared.env.iter())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -244,21 +277,21 @@ fn run_subprocess_backend(
             if !stdout.trim().is_empty() {
                 events.push(AgentEvent::Message {
                     backend: prepared.backend.clone(),
-                    session_id: Some(session_id.into()),
+                    session_id: Some(session_id.clone()),
                     text: stdout,
                 });
             }
             if !stderr.trim().is_empty() {
                 events.push(AgentEvent::Message {
                     backend: prepared.backend.clone(),
-                    session_id: Some(session_id.into()),
+                    session_id: Some(session_id.clone()),
                     text: stderr,
                 });
             }
             if output.status.success() {
                 events.push(AgentEvent::Completed {
                     backend: prepared.backend,
-                    session_id: Some(session_id.into()),
+                    session_id: Some(session_id),
                     summary: format!("{completion_subject} completed successfully."),
                 });
             } else {
@@ -288,6 +321,23 @@ fn run_subprocess_backend(
 
         thread::sleep(Duration::from_millis(10));
     }
+}
+
+fn profile_environment(
+    profile: Option<&ExecutionProfile>,
+    backend: &str,
+) -> BTreeMap<String, String> {
+    profile
+        .map(|profile| profile.environment_for_backend(backend))
+        .unwrap_or_default()
+}
+
+fn session_id_with_profile(base: &str, prepared: &PreparedRun) -> String {
+    prepared
+        .profile_id
+        .as_deref()
+        .map(|profile| format!("{base}:{profile}"))
+        .unwrap_or_else(|| base.into())
 }
 
 fn summarize_events(backend: &str, events: &[AgentEvent]) -> AgentSummary {
@@ -364,6 +414,20 @@ mod tests {
         RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md")).unwrap()
     }
 
+    fn codex_config_with_profile(command: &str) -> RuntimeConfig {
+        let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("examples/fixtures/cockpit-tools-codex-instances.json");
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            &format!(
+                "---\nagent:\n  backend: codex\ncodex:\n  command: {command:?}\nprofiles:\n  default: codex-alpha\n  cockpit_tools:\n    codex_instances_path: {:?}\n---\nPrompt",
+                fixture_path.display().to_string()
+            ),
+        )
+        .unwrap();
+        RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md")).unwrap()
+    }
+
     #[test]
     fn codex_backend_runs_subprocess_in_workspace() {
         let temp = tempfile::tempdir().unwrap();
@@ -379,6 +443,27 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(temp.path().join("response.txt")).unwrap(),
             "hello prompt"
+        );
+    }
+
+    #[test]
+    fn codex_backend_prepared_run_includes_profile_context() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = codex_config_with_profile("printf profile");
+        let backend = CodexBackend;
+        let prepared = backend
+            .prepare(temp.path().to_path_buf(), "prompt".into(), &config)
+            .unwrap();
+
+        assert_eq!(prepared.profile_id.as_deref(), Some("codex-alpha"));
+        assert_eq!(prepared.instance_name.as_deref(), Some("codex-alpha"));
+        assert_eq!(
+            prepared.env.get("CODEX_HOME"),
+            Some(&"/tmp/cockpit/codex-alpha".into())
+        );
+        assert_eq!(
+            session_id_with_profile("codex-subprocess", &prepared),
+            "codex-subprocess:codex-alpha"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct RuntimeConfig {
     pub codex: CodexConfig,
     pub claude: ClaudeConfig,
     pub review: ReviewConfig,
+    pub profiles: ProfilesConfig,
     pub observability: ObservabilityConfig,
     pub server: ServerConfig,
     #[serde(default)]
@@ -128,6 +129,32 @@ pub struct ReviewConfig {
     pub timeout_ms: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ProfilesConfig {
+    pub default: Option<String>,
+    pub cockpit_tools: CockpitToolsProfilesConfig,
+    #[serde(default)]
+    pub entries: Vec<ExecutionProfileConfig>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct CockpitToolsProfilesConfig {
+    pub codex_instances_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ExecutionProfileConfig {
+    pub id: String,
+    pub instance_name: Option<String>,
+    pub backend: Option<String>,
+    pub workspace_namespace: Option<String>,
+    pub user_data_dir: Option<PathBuf>,
+    pub working_dir: Option<PathBuf>,
+    pub extra_args: Option<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObservabilityConfig {
     pub dashboard_enabled: bool,
@@ -220,6 +247,7 @@ impl RuntimeConfig {
                 .unwrap_or_else(|| "gemini".to_string()),
             timeout_ms: get_u64(root.get("review"), "timeout_ms").unwrap_or(600_000),
         };
+        let profiles = parse_profiles(root.get("profiles"), workflow_dir);
         let observability = ObservabilityConfig {
             dashboard_enabled: get_bool(root.get("observability"), "dashboard_enabled")
                 .unwrap_or(true),
@@ -247,6 +275,7 @@ impl RuntimeConfig {
             codex,
             claude,
             review,
+            profiles,
             observability,
             server,
             raw: workflow.config.clone(),
@@ -392,6 +421,61 @@ fn parse_workpad(value: Option<&Value>) -> WorkpadConfig {
         source: value_string(value, "source", "issue_comment"),
         marker: value_string(value, "marker", "<!-- jade-symphony-workpad -->"),
     }
+}
+
+fn parse_profiles(value: Option<&Value>, workflow_dir: &Path) -> ProfilesConfig {
+    ProfilesConfig {
+        default: get_string(value, "default"),
+        cockpit_tools: CockpitToolsProfilesConfig {
+            codex_instances_path: get_string(
+                get_value(value, "cockpit_tools"),
+                "codex_instances_path",
+            )
+            .map(|path| resolve_path(Some(&path), workflow_dir, Path::new(""))),
+        },
+        entries: parse_execution_profiles(get_value(value, "entries"), workflow_dir),
+    }
+}
+
+fn parse_execution_profiles(
+    value: Option<&Value>,
+    workflow_dir: &Path,
+) -> Vec<ExecutionProfileConfig> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    let id = get_string(Some(item), "id")?;
+                    Some(ExecutionProfileConfig {
+                        id,
+                        instance_name: get_string(Some(item), "instance_name"),
+                        backend: get_string(Some(item), "backend"),
+                        workspace_namespace: get_string(Some(item), "workspace_namespace"),
+                        user_data_dir: get_string(Some(item), "user_data_dir")
+                            .map(|path| resolve_path(Some(&path), workflow_dir, Path::new(""))),
+                        working_dir: get_string(Some(item), "working_dir")
+                            .map(|path| resolve_path(Some(&path), workflow_dir, Path::new(""))),
+                        extra_args: get_string(Some(item), "extra_args"),
+                        env: parse_string_map(get_value(Some(item), "env")),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_string_map(value: Option<&Value>) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    if let Some(Value::Object(values)) = value {
+        for (key, value) in values {
+            if let Some(value) = value.as_str() {
+                map.insert(key.clone(), value.to_string());
+            }
+        }
+    }
+    map
 }
 
 fn parse_state_limits(value: Option<&Value>) -> BTreeMap<String, usize> {
@@ -584,5 +668,37 @@ mod tests {
             Some("https://api.linear.app/graphql")
         );
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn parses_execution_profiles_from_workflow_config() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/config/WORKFLOW.md",
+            "---\nprofiles:\n  default: codex-alpha\n  cockpit_tools:\n    codex_instances_path: fixtures/cockpit-tools-codex-instances.json\n  entries:\n    - id: fallback\n      instance_name: Fallback Worker\n      backend: dry-run\n      workspace_namespace: fallback-worker\n      user_data_dir: ./profiles/fallback\n      env:\n        JADE_TEST_PROFILE: fallback\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/config/WORKFLOW.md")).unwrap();
+
+        assert_eq!(config.profiles.default.as_deref(), Some("codex-alpha"));
+        assert_eq!(
+            config
+                .profiles
+                .cockpit_tools
+                .codex_instances_path
+                .as_deref(),
+            Some(Path::new(
+                "/tmp/config/fixtures/cockpit-tools-codex-instances.json"
+            ))
+        );
+        assert_eq!(config.profiles.entries.len(), 1);
+        assert_eq!(
+            config.profiles.entries[0].env.get("JADE_TEST_PROFILE"),
+            Some(&"fallback".into())
+        );
+        assert_eq!(
+            config.profiles.entries[0].user_data_dir.as_deref(),
+            Some(Path::new("/tmp/config/profiles/fallback"))
+        );
     }
 }

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -11,6 +11,10 @@ pub struct EventRecord {
     pub issue_id: Option<String>,
     pub issue_identifier: Option<String>,
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub profile_id: Option<String>,
+    #[serde(default)]
+    pub instance_name: Option<String>,
     pub message: String,
 }
 
@@ -62,11 +66,14 @@ mod tests {
             issue_id: Some("id".into()),
             issue_identifier: Some("#1".into()),
             session_id: None,
+            profile_id: Some("codex-alpha".into()),
+            instance_name: Some("Codex Alpha".into()),
             message: "queued".into(),
         })
         .unwrap();
 
         let content = std::fs::read_to_string(temp.path().join("events.jsonl")).unwrap();
         assert!(content.contains("\"event\":\"dispatch\""));
+        assert!(content.contains("\"profile_id\":\"codex-alpha\""));
     }
 }

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -50,12 +50,22 @@ pub fn plan_issue_handoff(
     issue: &TrackerIssue,
     base_branch: &str,
 ) -> Result<IssueHandoffPlan, HandoffError> {
+    plan_issue_handoff_for_profile(workspace_root, issue, base_branch, None)
+}
+
+pub fn plan_issue_handoff_for_profile(
+    workspace_root: &Path,
+    issue: &TrackerIssue,
+    base_branch: &str,
+    profile_id: Option<&str>,
+) -> Result<IssueHandoffPlan, HandoffError> {
     if let Some(existing_branch) = issue.branch_name.as_deref() {
         guard_branch_for_issue(existing_branch, &issue.identifier)?;
     }
 
     let branch_name = branch_name_for_issue(&issue.identifier, &issue.title);
-    let workspace_key = workspace_key_for_issue(&issue.identifier, &issue.title);
+    let workspace_key =
+        profile_workspace_key_for_issue(profile_id, &issue.identifier, &issue.title);
     let workspace_path = workspace_root.join(&workspace_key);
     let pull_request =
         PullRequestHandoffPlan::new(&issue.identifier, &issue.title, &branch_name, base_branch);
@@ -76,6 +86,21 @@ pub fn workspace_key_for_issue(issue_identifier: &str, title: &str) -> String {
         issue_slug(issue_identifier),
         title_slug(title)
     ))
+}
+
+pub fn profile_workspace_key_for_issue(
+    profile_id: Option<&str>,
+    issue_identifier: &str,
+    title: &str,
+) -> String {
+    match profile_id.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(profile_id) => safe_identifier(&format!(
+            "{}--{}",
+            safe_identifier(profile_id),
+            workspace_key_for_issue(issue_identifier, title)
+        )),
+        None => workspace_key_for_issue(issue_identifier, title),
+    }
 }
 
 pub fn branch_name_for_issue(issue_identifier: &str, title: &str) -> String {
@@ -262,6 +287,23 @@ mod tests {
         );
         assert_eq!(plan.pull_request.head_branch, plan.branch_name);
         assert_eq!(plan.pull_request.base_branch, "main");
+    }
+
+    #[test]
+    fn profile_workspace_keys_avoid_worker_collisions() {
+        assert_eq!(
+            profile_workspace_key_for_issue(Some("codex-alpha"), "#39", "Add execution profiles"),
+            "codex-alpha--issue-39-add-execution-profiles"
+        );
+
+        let plan = plan_issue_handoff_for_profile(
+            Path::new("/tmp/jade-workspaces"),
+            &issue(),
+            "main",
+            Some("codex-alpha"),
+        )
+        .unwrap();
+        assert!(plan.workspace_key.starts_with("codex-alpha--issue-21"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod handoff;
 pub mod issue_forge;
 pub mod model;
 pub mod orchestrator;
+pub mod profiles;
 pub mod prompt;
 pub mod quality_gate;
 pub mod review;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,15 @@ use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum
 use jade_symphony::agent::backend_from_config;
 use jade_symphony::config::RuntimeConfig;
 use jade_symphony::event_log::{EventLog, EventRecord};
-use jade_symphony::handoff::{plan_issue_handoff, HandoffError, IssueHandoffPlan};
+use jade_symphony::handoff::{plan_issue_handoff_for_profile, HandoffError, IssueHandoffPlan};
 use jade_symphony::issue_forge::{
     discover_candidates, draft_from_template, repair_markdown, validate_markdown,
 };
 use jade_symphony::model::{normalize_state, GateDecision, GateDecisionKind, TrackerIssue};
 use jade_symphony::orchestrator::Orchestrator;
+use jade_symphony::profiles::{
+    discover_execution_profiles, selected_execution_profile, ExecutionProfile,
+};
 use jade_symphony::prompt::render_prompt;
 use jade_symphony::quality_gate::evaluate_issue;
 use jade_symphony::review::{
@@ -28,7 +31,9 @@ use jade_symphony::tracker::{
     adapter_from_config, claim_decision, ClaimDecision, FollowUpIssueInput,
 };
 use jade_symphony::workflow::WorkflowDefinition;
-use jade_symphony::workspace::{prepare_workspace, run_after_run, run_before_run};
+use jade_symphony::workspace::{
+    prepare_workspace, profile_scoped_identifier, run_after_run, run_before_run,
+};
 
 const DEFAULT_RUN_LOOP_BASE_BRANCH: &str = "main";
 
@@ -47,6 +52,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Command::Plan { workflow_path } => plan(workflow_path),
         Command::Validate { workflow_path } => validate(workflow_path),
         Command::Inspect { workflow_path } => inspect(workflow_path),
+        Command::Profiles { workflow_path } => list_profiles(workflow_path),
         Command::RunOnce { workflow_path } => run_once(workflow_path),
         Command::RunLoop { options } => run_loop(options),
         Command::SetState {
@@ -485,6 +491,29 @@ fn inspect(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn list_profiles(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let profiles = discover_execution_profiles(&config.profiles)?;
+    let selected = selected_execution_profile(&config.profiles)?;
+
+    println!("profiles={}", profiles.len());
+    if let Some(profile) = selected {
+        println!("selected_profile={}", profile.profile_id);
+        println!("selected_instance={}", profile.instance_name);
+    }
+    for profile in profiles {
+        println!(
+            "- profile_id={} instance_name={} source={} workspace_namespace={} backend={}",
+            profile.profile_id,
+            profile.instance_name,
+            profile.source,
+            profile.workspace_namespace,
+            profile.backend.as_deref().unwrap_or("configured")
+        );
+    }
+    Ok(())
+}
+
 fn run_once(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     let workflow = WorkflowDefinition::load(&workflow_path)?;
     let config = RuntimeConfig::from_workflow(&workflow, &workflow_path)?;
@@ -522,6 +551,8 @@ fn run_once(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
 struct IssueExecutionResult {
     workspace_path: PathBuf,
     backend: String,
+    profile_id: Option<String>,
+    instance_name: Option<String>,
     success: bool,
     session_id: Option<String>,
     message: String,
@@ -532,7 +563,14 @@ fn execute_issue_once(
     config: &RuntimeConfig,
     issue: &TrackerIssue,
 ) -> Result<IssueExecutionResult, Box<dyn std::error::Error>> {
-    execute_issue_once_with_workspace_key(workflow, config, issue, &issue.identifier)
+    let profile = selected_execution_profile(&config.profiles)?;
+    let workspace_identifier = profile_scoped_identifier(
+        profile
+            .as_ref()
+            .map(|profile| profile.workspace_namespace.as_str()),
+        &issue.identifier,
+    );
+    execute_issue_once_with_workspace_key(workflow, config, issue, &workspace_identifier)
 }
 
 fn execute_issue_once_with_workspace_key(
@@ -541,6 +579,7 @@ fn execute_issue_once_with_workspace_key(
     issue: &TrackerIssue,
     workspace_key: &str,
 ) -> Result<IssueExecutionResult, Box<dyn std::error::Error>> {
+    let profile = selected_execution_profile(&config.profiles)?;
     let workspace = prepare_workspace(&config.workspace.root, workspace_key, &config.hooks)?;
     run_before_run(&workspace.path, &config.hooks)?;
 
@@ -560,6 +599,10 @@ fn execute_issue_once_with_workspace_key(
             issue_id: Some(issue.id.clone()),
             issue_identifier: Some(issue.identifier.clone()),
             session_id: summary.session_id.clone(),
+            profile_id: profile.as_ref().map(|profile| profile.profile_id.clone()),
+            instance_name: profile
+                .as_ref()
+                .map(|profile| profile.instance_name.clone()),
             message: summary.message.clone(),
         })?;
     }
@@ -567,6 +610,10 @@ fn execute_issue_once_with_workspace_key(
     Ok(IssueExecutionResult {
         workspace_path: workspace.path,
         backend: summary.backend,
+        profile_id: profile.as_ref().map(|profile| profile.profile_id.clone()),
+        instance_name: profile
+            .as_ref()
+            .map(|profile| profile.instance_name.clone()),
         success: summary.success,
         session_id: summary.session_id,
         message: summary.message,
@@ -644,7 +691,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         };
 
         if !options.write {
-            print_run_loop_dry_run_actions(&issue, &handoff);
+            print_run_loop_dry_run_actions(&issue, &handoff, &config)?;
             if limit.is_none() {
                 println!(
                     "run_loop=stopped reason=dry_run_would_repeat_without_mutation iterations={iterations}"
@@ -707,6 +754,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             existing_runtime_state.as_ref(),
             &latest,
             &config.backend.kind,
+            selected_execution_profile(&config.profiles)?.as_ref(),
             event,
         );
         save_runtime_state(&config, &runtime_state)?;
@@ -812,6 +860,7 @@ fn run_loop_runtime_state_for_issue(
     existing: Option<&RuntimeState>,
     issue: &TrackerIssue,
     backend: &str,
+    profile: Option<&ExecutionProfile>,
     event: &str,
 ) -> RuntimeState {
     let mut state = RuntimeState::active(
@@ -823,6 +872,8 @@ fn run_loop_runtime_state_for_issue(
     );
     state.attempt_count = next_runtime_attempt_count(existing, &issue.identifier);
     state.branch_name = issue.branch_name.clone();
+    state.profile_id = profile.map(|profile| profile.profile_id.clone());
+    state.instance_name = profile.map(|profile| profile.instance_name.clone());
     state.last_event = Some(event.into());
     state
 }
@@ -846,6 +897,8 @@ fn run_loop_runtime_state_with_result(
     state.workspace_path = Some(result.workspace_path.clone());
     state.backend = result.backend.clone();
     state.backend_session_id = result.session_id.clone();
+    state.profile_id = result.profile_id.clone();
+    state.instance_name = result.instance_name.clone();
     state.last_event = Some(if result.success {
         "Completed".into()
     } else {
@@ -872,7 +925,16 @@ fn run_loop_handoff_plan(
     config: &RuntimeConfig,
     issue: &TrackerIssue,
 ) -> Result<IssueHandoffPlan, HandoffError> {
-    plan_issue_handoff(&config.workspace.root, issue, DEFAULT_RUN_LOOP_BASE_BRANCH)
+    let profile = selected_execution_profile(&config.profiles)
+        .ok()
+        .flatten()
+        .map(|profile| profile.workspace_namespace);
+    plan_issue_handoff_for_profile(
+        &config.workspace.root,
+        issue,
+        DEFAULT_RUN_LOOP_BASE_BRANCH,
+        profile.as_deref(),
+    )
 }
 
 fn handle_run_loop_gate_failure(
@@ -929,7 +991,12 @@ fn handle_run_loop_handoff_failure(
     Ok(())
 }
 
-fn print_run_loop_dry_run_actions(issue: &TrackerIssue, handoff: &IssueHandoffPlan) {
+fn print_run_loop_dry_run_actions(
+    issue: &TrackerIssue,
+    handoff: &IssueHandoffPlan,
+    config: &RuntimeConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let profile = selected_execution_profile(&config.profiles)?;
     if normalize_state(&issue.state) != "in progress" {
         println!(
             "run_loop_dry_run action=claim issue={} target_state=in_progress",
@@ -950,6 +1017,12 @@ fn print_run_loop_dry_run_actions(issue: &TrackerIssue, handoff: &IssueHandoffPl
         "run_loop_dry_run action=run issue={} backend=configured",
         issue.identifier
     );
+    if let Some(profile) = profile {
+        println!(
+            "run_loop_dry_run profile_id={} instance_name={}",
+            profile.profile_id, profile.instance_name
+        );
+    }
     println!(
         "run_loop_dry_run action=workpad issue={} evidence=run_summary",
         issue.identifier
@@ -958,6 +1031,7 @@ fn print_run_loop_dry_run_actions(issue: &TrackerIssue, handoff: &IssueHandoffPl
         "run_loop_dry_run action=handoff issue={} target_state=agent_review",
         issue.identifier
     );
+    Ok(())
 }
 
 fn run_loop_handoff_workpad(
@@ -975,6 +1049,14 @@ fn run_loop_handoff_workpad(
         "### Run Evidence".to_string(),
         format!("- Workspace: `{}`", result.workspace_path.display()),
         format!("- Backend: `{}`", result.backend),
+        format!(
+            "- Profile: `{}`",
+            result.profile_id.as_deref().unwrap_or("n/a")
+        ),
+        format!(
+            "- Instance: `{}`",
+            result.instance_name.as_deref().unwrap_or("n/a")
+        ),
         format!("- Success: `{}`", result.success),
         format!(
             "- Session: `{}`",
@@ -1024,6 +1106,9 @@ enum Command {
         workflow_path: PathBuf,
     },
     Inspect {
+        workflow_path: PathBuf,
+    },
+    Profiles {
         workflow_path: PathBuf,
     },
     RunOnce {
@@ -1157,6 +1242,7 @@ enum CliCommand {
     #[command(alias = "validate-workflow")]
     Validate(WorkflowPathArgs),
     Inspect(WorkflowPathArgs),
+    Profiles(WorkflowPathArgs),
     #[command(name = "run-once")]
     RunOnce(WorkflowPathArgs),
     #[command(name = "run-loop")]
@@ -1380,6 +1466,9 @@ impl TryFrom<Cli> for Command {
                         workflow_path: args.workflow_path,
                     }),
                     CliCommand::Inspect(args) => Ok(Self::Inspect {
+                        workflow_path: args.workflow_path,
+                    }),
+                    CliCommand::Profiles(args) => Ok(Self::Profiles {
                         workflow_path: args.workflow_path,
                     }),
                     CliCommand::RunOnce(args) => Ok(Self::RunOnce {
@@ -1648,6 +1737,12 @@ mod tests {
                 workflow_path: PathBuf::from("examples/dry-run-workflow.md")
             }
         );
+        assert_eq!(
+            parse(&["profiles", "examples/dry-run-workflow.md"]),
+            Command::Profiles {
+                workflow_path: PathBuf::from("examples/dry-run-workflow.md")
+            }
+        );
     }
 
     #[test]
@@ -1779,9 +1874,10 @@ mod tests {
     #[test]
     fn run_loop_runtime_state_increments_same_issue_attempts() {
         let issue = tracker_issue("In Progress");
-        let existing = run_loop_runtime_state_for_issue(None, &issue, "dry-run", "Claimed");
+        let existing = run_loop_runtime_state_for_issue(None, &issue, "dry-run", None, "Claimed");
 
-        let state = run_loop_runtime_state_for_issue(Some(&existing), &issue, "dry-run", "Resumed");
+        let state =
+            run_loop_runtime_state_for_issue(Some(&existing), &issue, "dry-run", None, "Resumed");
 
         assert_eq!(state.attempt_count, 2);
         assert_eq!(
@@ -1798,10 +1894,12 @@ mod tests {
     #[test]
     fn run_loop_runtime_state_records_result_and_transition() {
         let issue = tracker_issue("In Progress");
-        let state = run_loop_runtime_state_for_issue(None, &issue, "dry-run", "Claimed");
+        let state = run_loop_runtime_state_for_issue(None, &issue, "dry-run", None, "Claimed");
         let result = IssueExecutionResult {
             workspace_path: PathBuf::from("/tmp/jade/issue-29"),
             backend: "dry-run".into(),
+            profile_id: Some("codex-alpha".into()),
+            instance_name: Some("Codex Alpha".into()),
             success: true,
             session_id: Some("session-29".into()),
             message: "ok".into(),
@@ -1810,6 +1908,7 @@ mod tests {
         let state = run_loop_runtime_state_with_result(state, &result);
         assert_eq!(state.workspace_path, Some(result.workspace_path));
         assert_eq!(state.backend_session_id.as_deref(), Some("session-29"));
+        assert_eq!(state.profile_id.as_deref(), Some("codex-alpha"));
         assert_eq!(state.last_event.as_deref(), Some("Completed"));
 
         let state = run_loop_runtime_state_with_transition(
@@ -1879,6 +1978,8 @@ mod tests {
         let result = IssueExecutionResult {
             workspace_path: handoff.workspace_path.clone(),
             backend: "dry-run".into(),
+            profile_id: None,
+            instance_name: None,
             success: true,
             session_id: Some("session-33".into()),
             message: "ok".into(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -102,6 +102,10 @@ pub struct RunningSnapshot {
     pub backend: String,
     pub workspace_path: Option<String>,
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub profile_id: Option<String>,
+    #[serde(default)]
+    pub instance_name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -86,6 +86,8 @@ impl Orchestrator {
                     backend: self.config.backend.kind.clone(),
                     workspace_path: None,
                     session_id: None,
+                    profile_id: None,
+                    instance_name: None,
                 })
                 .collect(),
             retrying: Vec::new(),

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -1,0 +1,256 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::config::{ExecutionProfileConfig, ProfilesConfig};
+use crate::workspace::safe_identifier;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionProfile {
+    pub profile_id: String,
+    pub instance_name: String,
+    pub source: String,
+    pub backend: Option<String>,
+    pub workspace_namespace: String,
+    pub user_data_dir: Option<PathBuf>,
+    pub working_dir: Option<PathBuf>,
+    pub extra_args: Option<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+}
+
+impl ExecutionProfile {
+    pub fn environment_for_backend(&self, backend: &str) -> BTreeMap<String, String> {
+        let mut env = self.env.clone();
+        env.insert("JADE_SYMPHONY_PROFILE_ID".into(), self.profile_id.clone());
+        env.insert(
+            "JADE_SYMPHONY_INSTANCE_NAME".into(),
+            self.instance_name.clone(),
+        );
+        env.insert("JADE_SYMPHONY_PROFILE_SOURCE".into(), self.source.clone());
+        if let Some(path) = &self.user_data_dir {
+            env.insert(
+                "JADE_SYMPHONY_PROFILE_HOME".into(),
+                path.display().to_string(),
+            );
+            if backend == "codex" {
+                env.insert("CODEX_HOME".into(), path.display().to_string());
+            }
+        }
+        if let Some(args) = &self.extra_args {
+            if !args.trim().is_empty() {
+                env.insert("JADE_SYMPHONY_COCKPIT_EXTRA_ARGS".into(), args.clone());
+            }
+        }
+        env
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ProfileError {
+    #[error("profile config io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("profile config parse error at {path}: {source}")]
+    Parse {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+    #[error("configured default profile was not discovered: {0}")]
+    MissingDefault(String),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CockpitCodexInstanceStore {
+    #[serde(default)]
+    instances: Vec<CockpitCodexInstance>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CockpitCodexInstance {
+    id: String,
+    name: String,
+    user_data_dir: String,
+    #[serde(default)]
+    working_dir: Option<String>,
+    #[serde(default)]
+    extra_args: String,
+}
+
+pub fn discover_execution_profiles(
+    config: &ProfilesConfig,
+) -> Result<Vec<ExecutionProfile>, ProfileError> {
+    let mut profiles = Vec::new();
+    if let Some(path) = &config.cockpit_tools.codex_instances_path {
+        if path.exists() {
+            profiles.extend(load_cockpit_codex_profiles(path)?);
+        }
+    }
+
+    if profiles.is_empty() {
+        profiles.extend(explicit_profiles(&config.entries));
+    }
+
+    Ok(profiles)
+}
+
+pub fn selected_execution_profile(
+    config: &ProfilesConfig,
+) -> Result<Option<ExecutionProfile>, ProfileError> {
+    let profiles = discover_execution_profiles(config)?;
+    if profiles.is_empty() {
+        return Ok(None);
+    }
+
+    if let Some(default) = config.default.as_deref() {
+        return profiles
+            .into_iter()
+            .find(|profile| {
+                profile.profile_id == default
+                    || profile.instance_name == default
+                    || profile.workspace_namespace == safe_identifier(default)
+            })
+            .map(Some)
+            .ok_or_else(|| ProfileError::MissingDefault(default.into()));
+    }
+
+    Ok(profiles.into_iter().next())
+}
+
+pub fn load_cockpit_codex_profiles(path: &Path) -> Result<Vec<ExecutionProfile>, ProfileError> {
+    let content = fs::read_to_string(path).map_err(|source| ProfileError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let store: CockpitCodexInstanceStore =
+        serde_json::from_str(&content).map_err(|source| ProfileError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    Ok(cockpit_instances_to_profiles(store.instances))
+}
+
+fn cockpit_instances_to_profiles(instances: Vec<CockpitCodexInstance>) -> Vec<ExecutionProfile> {
+    let mut used = BTreeSet::new();
+    instances
+        .into_iter()
+        .filter_map(|instance| {
+            let name = instance.name.trim();
+            if name.is_empty() {
+                return None;
+            }
+            let mut namespace = safe_identifier(name);
+            if !used.insert(namespace.clone()) {
+                namespace = safe_identifier(&format!("{}-{}", name, instance.id));
+                used.insert(namespace.clone());
+            }
+
+            Some(ExecutionProfile {
+                profile_id: namespace.clone(),
+                instance_name: name.to_string(),
+                source: "cockpit-tools:codex_instances".into(),
+                backend: Some("codex".into()),
+                workspace_namespace: namespace,
+                user_data_dir: nonempty_path(instance.user_data_dir),
+                working_dir: instance.working_dir.and_then(nonempty_path),
+                extra_args: nonempty_string(instance.extra_args),
+                env: BTreeMap::new(),
+            })
+        })
+        .collect()
+}
+
+fn explicit_profiles(configs: &[ExecutionProfileConfig]) -> Vec<ExecutionProfile> {
+    configs
+        .iter()
+        .filter_map(|profile| {
+            let id = profile.id.trim();
+            if id.is_empty() {
+                return None;
+            }
+
+            Some(ExecutionProfile {
+                profile_id: safe_identifier(id),
+                instance_name: profile
+                    .instance_name
+                    .clone()
+                    .unwrap_or_else(|| id.to_string()),
+                source: "workflow:profiles.entries".into(),
+                backend: profile.backend.clone(),
+                workspace_namespace: profile
+                    .workspace_namespace
+                    .as_deref()
+                    .map(safe_identifier)
+                    .unwrap_or_else(|| safe_identifier(id)),
+                user_data_dir: profile.user_data_dir.clone(),
+                working_dir: profile.working_dir.clone(),
+                extra_args: profile.extra_args.clone().and_then(nonempty_string),
+                env: profile.env.clone(),
+            })
+        })
+        .collect()
+}
+
+fn nonempty_path(value: String) -> Option<PathBuf> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+}
+
+fn nonempty_string(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_cockpit_tools_codex_instance_store() {
+        let path = Path::new("examples/fixtures/cockpit-tools-codex-instances.json");
+        let profiles = load_cockpit_codex_profiles(path).unwrap();
+
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[0].profile_id, "codex-alpha");
+        assert_eq!(profiles[0].instance_name, "codex-alpha");
+        assert_eq!(
+            profiles[0].user_data_dir.as_deref(),
+            Some(Path::new("/tmp/cockpit/codex-alpha"))
+        );
+        assert_eq!(profiles[0].backend.as_deref(), Some("codex"));
+    }
+
+    #[test]
+    fn cockpit_profile_environment_sets_backend_context_without_account_ids() {
+        let profile = load_cockpit_codex_profiles(Path::new(
+            "examples/fixtures/cockpit-tools-codex-instances.json",
+        ))
+        .unwrap()
+        .remove(0);
+
+        let env = profile.environment_for_backend("codex");
+
+        assert_eq!(
+            env.get("JADE_SYMPHONY_PROFILE_ID"),
+            Some(&"codex-alpha".into())
+        );
+        assert_eq!(
+            env.get("JADE_SYMPHONY_INSTANCE_NAME"),
+            Some(&"codex-alpha".into())
+        );
+        assert_eq!(
+            env.get("CODEX_HOME"),
+            Some(&"/tmp/cockpit/codex-alpha".into())
+        );
+        assert!(!env.contains_key("bindAccountId"));
+        assert!(!env.contains_key("BIND_ACCOUNT_ID"));
+    }
+}

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -15,6 +15,10 @@ pub struct RuntimeState {
     pub branch_name: Option<String>,
     pub backend: String,
     pub backend_session_id: Option<String>,
+    #[serde(default)]
+    pub profile_id: Option<String>,
+    #[serde(default)]
+    pub instance_name: Option<String>,
     pub attempt_count: u32,
     pub last_event: Option<String>,
     pub last_transition: Option<RuntimeTransition>,
@@ -28,6 +32,8 @@ impl RuntimeState {
             branch_name: None,
             backend: backend.into(),
             backend_session_id: None,
+            profile_id: None,
+            instance_name: None,
             attempt_count: 1,
             last_event: None,
             last_transition: None,
@@ -141,6 +147,8 @@ mod tests {
             branch_name: Some("feature-issue-1".into()),
             backend: "dry-run".into(),
             backend_session_id: Some("session".into()),
+            profile_id: Some("codex-alpha".into()),
+            instance_name: Some("Codex Alpha".into()),
             attempt_count: 2,
             last_event: Some("Completed".into()),
             last_transition: Some(RuntimeTransition {
@@ -180,6 +188,31 @@ mod tests {
         let loaded = load_runtime_state_from_path(&path).unwrap();
 
         assert_eq!(loaded, Some(state));
+    }
+
+    #[test]
+    fn reads_runtime_state_without_profile_identity_for_backcompat() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("runtime-state.json");
+        fs::write(
+            &path,
+            r##"{
+  "active_issue": {"id": "GHI_1", "identifier": "#1"},
+  "workspace_path": null,
+  "branch_name": null,
+  "backend": "dry-run",
+  "backend_session_id": null,
+  "attempt_count": 1,
+  "last_event": "Claimed",
+  "last_transition": null
+}"##,
+        )
+        .unwrap();
+
+        let loaded = load_runtime_state_from_path(&path).unwrap().unwrap();
+
+        assert_eq!(loaded.profile_id, None);
+        assert_eq!(loaded.instance_name, None);
     }
 
     #[test]

--- a/src/status_surface.rs
+++ b/src/status_surface.rs
@@ -47,11 +47,12 @@ fn render_running(snapshot: &RuntimeSnapshot, lines: &mut Vec<String>) {
     lines.push("running issues:".into());
     for entry in &snapshot.running {
         lines.push(format!(
-            "- {} {} state={} backend={} workspace={} session={}",
+            "- {} {} state={} backend={} profile={} workspace={} session={}",
             entry.issue_id,
             entry.identifier,
             entry.state,
             entry.backend,
+            entry.profile_id.as_deref().unwrap_or("n/a"),
             entry.workspace_path.as_deref().unwrap_or("n/a"),
             entry.session_id.as_deref().unwrap_or("n/a"),
         ));
@@ -140,6 +141,8 @@ mod tests {
                 backend: "codex".into(),
                 workspace_path: Some("/tmp/ws".into()),
                 session_id: Some("session".into()),
+                profile_id: Some("codex-alpha".into()),
+                instance_name: Some("Codex Alpha".into()),
             }],
             retrying: vec![RetrySnapshot {
                 issue_id: "GHI_2".into(),
@@ -175,6 +178,7 @@ mod tests {
         });
 
         assert!(rendered.contains("running issues:"));
+        assert!(rendered.contains("profile=codex-alpha"));
         assert!(rendered.contains("retrying issues:"));
         assert!(rendered.contains("skipped issues:"));
         assert!(rendered.contains("gate=NeedToClarify"));

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -68,6 +68,17 @@ pub fn safe_identifier(identifier: &str) -> String {
         .collect()
 }
 
+pub fn profile_scoped_identifier(profile_id: Option<&str>, identifier: &str) -> String {
+    match profile_id.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(profile_id) => format!(
+            "{}--{}",
+            safe_identifier(profile_id),
+            safe_identifier(identifier)
+        ),
+        None => identifier.to_string(),
+    }
+}
+
 pub fn prepare_workspace(
     root: &Path,
     identifier: &str,
@@ -246,6 +257,15 @@ mod tests {
         .unwrap();
         assert!(workspace.path.is_dir());
         assert_eq!(workspace.workspace_key, "_1");
+    }
+
+    #[test]
+    fn scopes_workspace_identifier_by_profile() {
+        assert_eq!(
+            profile_scoped_identifier(Some("codex alpha"), "#39"),
+            "codex_alpha--_39"
+        );
+        assert_eq!(profile_scoped_identifier(None, "#39"), "#39");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Implements the first #39 slice around cockpit-tools Codex instance discovery.
- Adds workflow execution profiles, a cockpit `codex_instances.json` fixture parser, profile-aware backend prepared runs, runtime state, event logs, and workspace/handoff keys.
- Documents the inspected cockpit-tools config shape and keeps this as read-only adapter plumbing, not a full account manager.

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- profiles examples/cockpit-profiles-workflow.md
- cargo run -- run-loop examples/cockpit-profiles-workflow.md --max-iterations 1 --dry-run

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #39
