### PR TITLE
feat: preserve review freshness evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ one-issue-one-PR automation are still future work.
 - dry-run dispatch planning sorts by priority and respects global/state
   concurrency limits.
 - Issue Quality Gate classifies executable versus underspecified issue bodies.
+- review freshness helpers can classify Merging-to-Rework repairs as
+  mechanical, semantic, or unknown and render workpad evidence for whether prior
+  Human Review remains valid.
 - Issue Forge can discover local candidates from intent, ask one focused
   clarification question, draft from the quality template, validate Markdown,
   repair rough Markdown into an executable issue contract shape, and create a
@@ -137,6 +140,7 @@ cargo run -- add-to-project path/to/WORKFLOW.md <github-issue-node-id> --write
 cargo run -- gate-apply path/to/WORKFLOW.md '#123' --write
 cargo run -- review-once path/to/WORKFLOW.md '#123' --write
 cargo run -- review-fake path/to/WORKFLOW.md '#123' --outcome pass --write
+cargo run -- review-freshness --issue '#123' --prior-head old --current-head new --prior-base old-base --current-base new-base --changed-file docs/dogfood-readiness.md --stale-reason merge-conflict --rework-class mechanical-conflict-resolution --patch-summary "Resolved merge conflict without semantic changes."
 ```
 
 `add-to-project` initializes the configured ProjectV2 `Status` field to the
@@ -148,6 +152,12 @@ Capability, is still a follow-up.
 `review-once` / `review-fake` are independent Review Agent commands: a passing
 review can move `Agent Review` to `Human Review`, confirmed findings move to
 `Rework`, and failed or inconclusive reviews do not advance to `Human Review`.
+`review-freshness` is an evidence command for Merging conflict repair: it does
+not mutate tracker state, does not approve a PR, and does not authorize the main
+implementation agent to set `Human Review`. Mechanical conflict repair can
+preserve prior Human Review evidence for an authorized merge/handoff flow;
+semantic or unknown rework requires the normal Agent Review and Human Review
+path.
 These commands are adapter operations plus the first runtime-loop
 skeleton, not full autonomous orchestration. Use write mode carefully until
 claim reconciliation, resume state, and PR automation exist.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -19,7 +19,7 @@ yet.
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
-| Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
+| Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, review-freshness evidence for Merging conflict repair, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
 
@@ -68,6 +68,10 @@ Project v2 issues:
    - Confirmed findings route to `Rework`.
    - Failed, timed out, inconclusive, or unavailable reviews remain out of
      `Human Review` and route to `Need Human Input` or stay in `Agent Review`.
+   - Merging-to-Rework repairs must record review freshness evidence before
+     preserving prior Human Review. Mechanical conflict repair can preserve
+     prior Human Review for an authorized merge/handoff flow; semantic or
+     unknown rework requires the normal Agent Review and Human Review path.
 
 5. Linear integration hardening.
    - Add credential-gated live smoke tests for reads, state updates, and workpad
@@ -246,6 +250,22 @@ Acceptance:
   evidence is recorded.
 - failed, timed out, inconclusive, or unavailable reviews must not set
   `Human Review`.
+
+### 7b. Preserve Review Freshness During Merging Rework
+
+Goal: reduce repeated human review for mechanical Merging conflict repair
+without weakening the review boundary.
+
+Acceptance:
+
+- records stale reason, rework class, prior/current head SHA, prior/current base
+  SHA, changed files, and patch summary in workpad evidence.
+- classifies mechanical conflict repair and base refresh as prior-review
+  preserving only when evidence is explicit.
+- classifies semantic or unknown rework as requiring the normal Agent Review and
+  Human Review path.
+- keeps `Human Review` out of the main implementation agent authority boundary.
+- does not auto-approve or merge PRs.
 
 ### 8. Add Linear Credential-Gated Smoke Tests
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,10 @@ use jade_symphony::orchestrator::Orchestrator;
 use jade_symphony::prompt::render_prompt;
 use jade_symphony::quality_gate::evaluate_issue;
 use jade_symphony::review::{
-    render_review_workpad, review_gate_decision, transition_allowed_for_main_agent,
-    transition_allowed_for_review_agent, FakeReviewBackend, FakeReviewOutcome,
-    GeminiCliReviewBackend, ReviewBackend, ReviewJob, ReviewRequest,
+    classify_review_freshness, render_review_freshness_workpad, render_review_workpad,
+    review_gate_decision, transition_allowed_for_main_agent, transition_allowed_for_review_agent,
+    FakeReviewBackend, FakeReviewOutcome, GeminiCliReviewBackend, ReviewBackend,
+    ReviewFreshnessInput, ReviewJob, ReviewRequest, ReviewReworkClass, ReviewStaleReason,
 };
 use jade_symphony::runtime_state::{
     clear_runtime_state, load_runtime_state, save_runtime_state, RuntimeIssueState, RuntimeState,
@@ -83,6 +84,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             issue_ref,
             write,
         } => review_once(workflow_path, issue_ref, write),
+        Command::ReviewFreshness { input } => review_freshness(input),
         Command::Gate {
             workflow_path,
             issue_ref,
@@ -404,6 +406,35 @@ fn review_once(
         job.backend, decision.outcome, decision.target_state
     );
     println!("{}", decision.message);
+    Ok(())
+}
+
+fn review_freshness(input: ReviewFreshnessInput) -> Result<(), Box<dyn std::error::Error>> {
+    let report = classify_review_freshness(input);
+    println!("review_freshness={:?}", report.decision.kind);
+    println!(
+        "prior_human_review_valid={}",
+        report.decision.prior_human_review_valid
+    );
+    println!(
+        "human_rereview_required={}",
+        report.decision.human_rereview_required
+    );
+    println!(
+        "main_agent_target_state={}",
+        report.decision.main_agent_target_state
+    );
+    println!(
+        "authorized_next_state={}",
+        report
+            .decision
+            .authorized_next_state
+            .as_deref()
+            .unwrap_or("none")
+    );
+    println!("rationale={}", report.decision.rationale);
+    println!("\n--- workpad evidence ---\n");
+    println!("{}", render_review_freshness_workpad(&report));
     Ok(())
 }
 
@@ -1066,6 +1097,9 @@ enum Command {
         issue_ref: String,
         write: bool,
     },
+    ReviewFreshness {
+        input: ReviewFreshnessInput,
+    },
     Gate {
         workflow_path: PathBuf,
         issue_ref: String,
@@ -1172,6 +1206,8 @@ enum CliCommand {
     ReviewFake(ReviewFakeArgs),
     #[command(name = "review-once")]
     ReviewOnce(ReviewOnceArgs),
+    #[command(name = "review-freshness")]
+    ReviewFreshness(ReviewFreshnessArgs),
     Gate(GateArgs),
     #[command(name = "gate-apply")]
     GateApply(GateArgs),
@@ -1295,6 +1331,68 @@ struct ReviewOnceArgs {
     write: bool,
     #[arg(long = "dry-run")]
     _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct ReviewFreshnessArgs {
+    #[arg(long = "issue")]
+    issue_ref: String,
+    #[arg(long = "prior-head")]
+    prior_head_sha: String,
+    #[arg(long = "current-head")]
+    current_head_sha: String,
+    #[arg(long = "prior-base")]
+    prior_base_sha: String,
+    #[arg(long = "current-base")]
+    current_base_sha: String,
+    #[arg(long = "changed-file")]
+    changed_files: Vec<String>,
+    #[arg(long = "stale-reason", value_enum)]
+    stale_reason: CliReviewStaleReason,
+    #[arg(long = "rework-class", value_enum)]
+    rework_class: CliReviewReworkClass,
+    #[arg(long = "patch-summary")]
+    patch_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliReviewStaleReason {
+    MergeConflict,
+    BaseBranchUpdated,
+    ReviewOutdated,
+    Unknown,
+}
+
+impl From<CliReviewStaleReason> for ReviewStaleReason {
+    fn from(value: CliReviewStaleReason) -> Self {
+        match value {
+            CliReviewStaleReason::MergeConflict => ReviewStaleReason::MergeConflict,
+            CliReviewStaleReason::BaseBranchUpdated => ReviewStaleReason::BaseBranchUpdated,
+            CliReviewStaleReason::ReviewOutdated => ReviewStaleReason::ReviewOutdated,
+            CliReviewStaleReason::Unknown => ReviewStaleReason::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliReviewReworkClass {
+    MechanicalConflictResolution,
+    BaseRefresh,
+    SemanticChange,
+    Unknown,
+}
+
+impl From<CliReviewReworkClass> for ReviewReworkClass {
+    fn from(value: CliReviewReworkClass) -> Self {
+        match value {
+            CliReviewReworkClass::MechanicalConflictResolution => {
+                ReviewReworkClass::MechanicalConflictResolution
+            }
+            CliReviewReworkClass::BaseRefresh => ReviewReworkClass::BaseRefresh,
+            CliReviewReworkClass::SemanticChange => ReviewReworkClass::SemanticChange,
+            CliReviewReworkClass::Unknown => ReviewReworkClass::Unknown,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -1431,6 +1529,19 @@ impl TryFrom<Cli> for Command {
                         workflow_path: args.workflow_path,
                         issue_ref: args.issue_ref,
                         write: args.write,
+                    }),
+                    CliCommand::ReviewFreshness(args) => Ok(Self::ReviewFreshness {
+                        input: ReviewFreshnessInput {
+                            issue_ref: args.issue_ref,
+                            prior_head_sha: args.prior_head_sha,
+                            current_head_sha: args.current_head_sha,
+                            prior_base_sha: args.prior_base_sha,
+                            current_base_sha: args.current_base_sha,
+                            changed_files: args.changed_files,
+                            stale_reason: args.stale_reason.into(),
+                            rework_class: args.rework_class.into(),
+                            patch_summary: args.patch_summary,
+                        },
                     }),
                     CliCommand::Gate(args) => Ok(Self::Gate {
                         workflow_path: args.workflow_path,
@@ -1693,6 +1804,45 @@ mod tests {
                 write: true
             }
         );
+    }
+
+    #[test]
+    fn parses_review_freshness_command() {
+        let command = Command::parse(vec![
+            "review-freshness".into(),
+            "--issue".into(),
+            "#33".into(),
+            "--prior-head".into(),
+            "old-head".into(),
+            "--current-head".into(),
+            "new-head".into(),
+            "--prior-base".into(),
+            "old-base".into(),
+            "--current-base".into(),
+            "new-base".into(),
+            "--changed-file".into(),
+            "docs/dogfood-readiness.md".into(),
+            "--stale-reason".into(),
+            "merge-conflict".into(),
+            "--rework-class".into(),
+            "mechanical-conflict-resolution".into(),
+            "--patch-summary".into(),
+            "Resolved conflict without semantic changes.".into(),
+        ])
+        .unwrap();
+
+        let Command::ReviewFreshness { input } = command else {
+            panic!("expected review-freshness command");
+        };
+
+        assert_eq!(input.issue_ref, "#33");
+        assert_eq!(input.changed_files, vec!["docs/dogfood-readiness.md"]);
+        assert_eq!(input.stale_reason, ReviewStaleReason::MergeConflict);
+        assert_eq!(
+            input.rework_class,
+            ReviewReworkClass::MechanicalConflictResolution
+        );
+        assert!(input.patch_summary.unwrap().contains("Resolved conflict"));
     }
 
     #[test]

--- a/src/review.rs
+++ b/src/review.rs
@@ -91,6 +91,59 @@ pub struct ReviewGateDecision {
     pub message: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReviewStaleReason {
+    MergeConflict,
+    BaseBranchUpdated,
+    ReviewOutdated,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReviewReworkClass {
+    MechanicalConflictResolution,
+    BaseRefresh,
+    SemanticChange,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReviewFreshnessDecisionKind {
+    PriorReviewStillValid,
+    PriorReviewInvalidated,
+    NeedsHumanInput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewFreshnessInput {
+    pub issue_ref: String,
+    pub prior_head_sha: String,
+    pub current_head_sha: String,
+    pub prior_base_sha: String,
+    pub current_base_sha: String,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    pub stale_reason: ReviewStaleReason,
+    pub rework_class: ReviewReworkClass,
+    pub patch_summary: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewFreshnessDecision {
+    pub kind: ReviewFreshnessDecisionKind,
+    pub prior_human_review_valid: bool,
+    pub human_rereview_required: bool,
+    pub main_agent_target_state: String,
+    pub authorized_next_state: Option<String>,
+    pub rationale: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReviewFreshnessReport {
+    pub input: ReviewFreshnessInput,
+    pub decision: ReviewFreshnessDecision,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReviewActor {
     MainImplementationAgent,
@@ -430,6 +483,100 @@ pub fn render_review_workpad(issue: &TrackerIssue, job: &ReviewJob) -> String {
     lines.join("\n")
 }
 
+pub fn classify_review_freshness(input: ReviewFreshnessInput) -> ReviewFreshnessReport {
+    let decision = match input.rework_class {
+        ReviewReworkClass::MechanicalConflictResolution | ReviewReworkClass::BaseRefresh => {
+            ReviewFreshnessDecision {
+                kind: ReviewFreshnessDecisionKind::PriorReviewStillValid,
+                prior_human_review_valid: true,
+                human_rereview_required: false,
+                main_agent_target_state: "agent_review".into(),
+                authorized_next_state: Some("merging".into()),
+                rationale: "Rework is classified as mechanical; prior Human Review can be preserved when evidence is recorded.".into(),
+            }
+        }
+        ReviewReworkClass::SemanticChange => ReviewFreshnessDecision {
+            kind: ReviewFreshnessDecisionKind::PriorReviewInvalidated,
+            prior_human_review_valid: false,
+            human_rereview_required: true,
+            main_agent_target_state: "agent_review".into(),
+            authorized_next_state: Some("agent_review".into()),
+            rationale: "Semantic implementation changes invalidate prior Human Review and require the normal Agent Review then Human Review path.".into(),
+        },
+        ReviewReworkClass::Unknown => ReviewFreshnessDecision {
+            kind: ReviewFreshnessDecisionKind::NeedsHumanInput,
+            prior_human_review_valid: false,
+            human_rereview_required: true,
+            main_agent_target_state: "agent_review".into(),
+            authorized_next_state: Some("need_human_input".into()),
+            rationale: "Rework class is unknown, so prior review freshness cannot be safely preserved.".into(),
+        },
+    };
+
+    ReviewFreshnessReport { input, decision }
+}
+
+pub fn render_review_freshness_workpad(report: &ReviewFreshnessReport) -> String {
+    let input = &report.input;
+    let decision = &report.decision;
+    let mut lines = vec![
+        "## Review Freshness".to_string(),
+        String::new(),
+        format!("- Issue: {}", input.issue_ref),
+        format!("- Stale reason: {:?}", input.stale_reason),
+        format!("- Rework class: {:?}", input.rework_class),
+        format!("- Prior head SHA: `{}`", input.prior_head_sha),
+        format!("- Current head SHA: `{}`", input.current_head_sha),
+        format!("- Prior base SHA: `{}`", input.prior_base_sha),
+        format!("- Current base SHA: `{}`", input.current_base_sha),
+        format!(
+            "- Prior Human Review still valid: `{}`",
+            decision.prior_human_review_valid
+        ),
+        format!(
+            "- Human re-review required: `{}`",
+            decision.human_rereview_required
+        ),
+        format!(
+            "- Main-agent target state: `{}`",
+            decision.main_agent_target_state
+        ),
+        format!(
+            "- Authorized next state after review-freshness evidence: `{}`",
+            decision.authorized_next_state.as_deref().unwrap_or("none")
+        ),
+        format!("- Decision: {:?}", decision.kind),
+        format!("- Rationale: {}", decision.rationale),
+    ];
+
+    lines.push(String::new());
+    lines.push("### Changed Files".into());
+    if input.changed_files.is_empty() {
+        lines.push("- None recorded.".into());
+    } else {
+        lines.extend(input.changed_files.iter().map(|file| format!("- `{file}`")));
+    }
+
+    lines.push(String::new());
+    lines.push("### Patch Summary".into());
+    lines.push(
+        input
+            .patch_summary
+            .as_deref()
+            .filter(|summary| !summary.trim().is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| "Not recorded.".into()),
+    );
+
+    lines.push(String::new());
+    lines.push("### Authority Boundary".into());
+    lines.push("- This freshness report is evidence, not an automatic approval.".into());
+    lines.push("- Main implementation agent still stops at `Agent Review`.".into());
+    lines.push("- `Human Review` remains reserved for an independent Review Agent or human-authorized workflow.".into());
+
+    lines.join("\n")
+}
+
 pub fn transition_allowed_for_main_agent(normalized_state: &str) -> bool {
     !matches!(normalized_state, "human_review" | "human review")
 }
@@ -681,5 +828,79 @@ mod tests {
             ReviewOutcome::NeedsHumanInput
         );
         assert_ne!(inconclusive_decision.target_state, Some("human_review"));
+    }
+
+    #[test]
+    fn mechanical_review_freshness_preserves_prior_human_review_evidence() {
+        let report = classify_review_freshness(ReviewFreshnessInput {
+            issue_ref: "#33".into(),
+            prior_head_sha: "old-head".into(),
+            current_head_sha: "new-head".into(),
+            prior_base_sha: "old-base".into(),
+            current_base_sha: "new-base".into(),
+            changed_files: vec!["docs/dogfood-readiness.md".into()],
+            stale_reason: ReviewStaleReason::MergeConflict,
+            rework_class: ReviewReworkClass::MechanicalConflictResolution,
+            patch_summary: Some("Resolved merge conflict without semantic changes.".into()),
+        });
+
+        assert_eq!(
+            report.decision.kind,
+            ReviewFreshnessDecisionKind::PriorReviewStillValid
+        );
+        assert!(report.decision.prior_human_review_valid);
+        assert!(!report.decision.human_rereview_required);
+        assert_eq!(report.decision.main_agent_target_state, "agent_review");
+        assert_eq!(
+            report.decision.authorized_next_state.as_deref(),
+            Some("merging")
+        );
+    }
+
+    #[test]
+    fn semantic_review_freshness_requires_normal_review_path() {
+        let report = classify_review_freshness(ReviewFreshnessInput {
+            issue_ref: "#38".into(),
+            prior_head_sha: "old-head".into(),
+            current_head_sha: "new-head".into(),
+            prior_base_sha: "same-base".into(),
+            current_base_sha: "same-base".into(),
+            changed_files: vec!["src/review.rs".into()],
+            stale_reason: ReviewStaleReason::ReviewOutdated,
+            rework_class: ReviewReworkClass::SemanticChange,
+            patch_summary: Some("Changed review decision behavior.".into()),
+        });
+
+        assert_eq!(
+            report.decision.kind,
+            ReviewFreshnessDecisionKind::PriorReviewInvalidated
+        );
+        assert!(!report.decision.prior_human_review_valid);
+        assert!(report.decision.human_rereview_required);
+        assert_eq!(report.decision.main_agent_target_state, "agent_review");
+        assert_eq!(
+            report.decision.authorized_next_state.as_deref(),
+            Some("agent_review")
+        );
+    }
+
+    #[test]
+    fn review_freshness_workpad_records_authority_boundary() {
+        let report = classify_review_freshness(ReviewFreshnessInput {
+            issue_ref: "#33".into(),
+            prior_head_sha: "old-head".into(),
+            current_head_sha: "new-head".into(),
+            prior_base_sha: "old-base".into(),
+            current_base_sha: "new-base".into(),
+            changed_files: Vec::new(),
+            stale_reason: ReviewStaleReason::BaseBranchUpdated,
+            rework_class: ReviewReworkClass::BaseRefresh,
+            patch_summary: None,
+        });
+        let workpad = render_review_freshness_workpad(&report);
+
+        assert!(workpad.contains("Prior Human Review still valid: `true`"));
+        assert!(workpad.contains("Main implementation agent still stops at `Agent Review`"));
+        assert!(workpad.contains("Human Review"));
     }
 }


### PR DESCRIPTION
## Summary
- add a review freshness model for Merging-to-Rework repair evidence
- add review-freshness CLI output with workpad evidence for mechanical, semantic, and unknown rework classes
- document the review freshness policy while preserving the main-agent/Human Review authority boundary

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- review-freshness --issue '#33' --prior-head old-head --current-head new-head --prior-base old-base --current-base new-base --changed-file docs/dogfood-readiness.md --stale-reason merge-conflict --rework-class mechanical-conflict-resolution --patch-summary 'Resolved merge conflict without semantic changes.'

Closes #38