### PR TITLE
#41: Add bounded independent review loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ one-issue-one-PR automation are still future work.
 - review freshness helpers can classify Merging-to-Rework repairs as
   mechanical, semantic, or unknown and render workpad evidence for whether prior
   Human Review remains valid.
+- `review-loop` can discover `Agent Review` issues, avoid duplicate review
+  worker markers, run a configured independent review backend in bounded mode,
+  and reconcile pass/rework/inconclusive transitions through the Review Agent
+  authority boundary.
 - Issue Forge can discover local candidates from intent, ask one focused
   clarification question, draft from the quality template, validate Markdown,
   repair rough Markdown into an executable issue contract shape, and create a
@@ -149,6 +153,7 @@ cargo run -- add-to-project path/to/WORKFLOW.md <github-issue-node-id> --write
 cargo run -- gate-apply path/to/WORKFLOW.md '#123' --write
 cargo run -- review-once path/to/WORKFLOW.md '#123' --write
 cargo run -- review-fake path/to/WORKFLOW.md '#123' --outcome pass --write
+cargo run -- review-loop examples/review-fixture-workflow.md --max-iterations 1 --dry-run
 cargo run -- review-freshness --issue '#123' --prior-head old --current-head new --prior-base old-base --current-base new-base --changed-file docs/dogfood-readiness.md --stale-reason merge-conflict --rework-class mechanical-conflict-resolution --patch-summary "Resolved merge conflict without semantic changes."
 ```
 
@@ -165,6 +170,10 @@ Capability, is still a follow-up.
 `review-once` / `review-fake` are independent Review Agent commands: a passing
 review can move `Agent Review` to `Human Review`, confirmed findings move to
 `Rework`, and failed or inconclusive reviews do not advance to `Human Review`.
+`review-loop` is the first runtime-style Review Agent command: it selects
+eligible `Agent Review` issues, prints intended review work in dry-run mode, and
+in write mode records review evidence plus the allowed review transition. It is
+bounded by `--max-iterations` or `--once` and is not a persistent daemon yet.
 `review-freshness` is an evidence command for Merging conflict repair: it does
 not mutate tracker state, does not approve a PR, and does not authorize the main
 implementation agent to set `Human Review`. Mechanical conflict repair can
@@ -199,7 +208,8 @@ claim reconciliation, resume state, and PR automation exist.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.
 - live token/rate-limit accounting beyond the current snapshot counters.
-- persistent Agent Review worker supervision and reconciliation.
+- persistent background Agent Review worker supervision beyond bounded
+  `review-loop` ticks.
 - Issue Forge Project field setup after issue creation.
 - autonomous Issue Forge issue creation from reflective mode without explicit
   operator confirmation.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -19,7 +19,7 @@ yet.
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
-| Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, review-freshness evidence for Merging conflict repair, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
+| Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, review-freshness evidence for Merging conflict repair, bounded `review-loop` selection/reconciliation, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
 
@@ -65,6 +65,9 @@ Project v2 issues:
      `Agent Review` but cannot set `Human Review`.
    - Independent Review Agent commands can set `Human Review` only after a
      passed review with evidence.
+   - Bounded `review-loop` can discover eligible `Agent Review` issues, skip
+     existing review-worker markers, and apply the same independent Review Agent
+     transition rules as `review-once`.
    - Confirmed findings route to `Rework`.
    - Failed, timed out, inconclusive, or unavailable reviews remain out of
      `Human Review` and route to `Need Human Input` or stay in `Agent Review`.
@@ -240,21 +243,20 @@ Acceptance:
 - creates one PR with a handoff body and records the PR link in the workpad.
 - keeps main implementation completion at `Agent Review`.
 
-### 7. Add Agent Review Gate
+### 7. Add Persistent Agent Review Worker Supervision
 
-Goal: make `Agent Review` a real state before `Human Review`.
+Goal: evolve the bounded `review-loop` into persistent worker supervision.
 
 Acceptance:
 
 - reviewer backend is selected through config.
-- findings are classified as `Confirmed`, `Plausible`, `Rejected`, or
-  `Needs Context`.
-- confirmed findings block human handoff.
-- rejected/deferred findings are recorded in the workpad.
-- main implementation agent completion target is `Agent Review`.
-- independent Review Agent may move passed reviews to `Human Review` only after
-  evidence is recorded.
-- failed, timed out, inconclusive, or unavailable reviews must not set
+- one review worker per issue/PR is started and reconciled without blocking the
+  main run-loop.
+- review job identity, backend, artifact path, and result evidence are persisted
+  in workpad/runtime state.
+- duplicate review workers are prevented across repeated loop ticks.
+- passed reviews move to `Human Review`; confirmed findings move to `Rework`;
+  failed, timed out, inconclusive, or unavailable reviews must not set
   `Human Review`.
 
 ### 7b. Preserve Review Freshness During Merging Rework

--- a/examples/fixtures/review-issues.json
+++ b/examples/fixtures/review-issues.json
@@ -1,0 +1,52 @@
+[
+  {
+    "tracker_kind": "github_project_v2",
+    "id": "GHI_review_1",
+    "item_id": "PVTI_review_1",
+    "identifier": "#41",
+    "title": "Review fixture issue",
+    "description": "## Issue Goal\n\nExercise the review runtime fixture path.\n\n## Why Now\n\nAgent Review should be runnable without live credentials in tests.\n\n## Issue Context\n\nThis issue is already in Agent Review.\n\n## Non-Negotiable Guardrails\n\n- Main implementation agent must not set Human Review.\n\n## Scope\n\n### In Scope\n\n- Review fixture only.\n\n## Canonical References\n\n### Target Repository / Package\n\n- Alive24/jade-symphony\n\n## Verification\n\n### Completion Criteria\n\n- Review loop can select this issue.",
+    "url": "https://github.com/Alive24/jade-symphony/issues/41",
+    "state": "Agent Review",
+    "labels": ["review"],
+    "assignees": [],
+    "priority": 1,
+    "branch_name": "feature/review-fixture",
+    "linked_pull_requests": [
+      {
+        "id": "PR_review_1",
+        "number": 41,
+        "url": "https://github.com/Alive24/jade-symphony/pull/41",
+        "state": "OPEN"
+      }
+    ],
+    "blocked_by": [],
+    "project_fields": {
+      "Status": "Agent Review"
+    },
+    "created_at": "2026-05-13T00:00:00Z",
+    "updated_at": "2026-05-13T00:10:00Z"
+  },
+  {
+    "tracker_kind": "github_project_v2",
+    "id": "GHI_review_queued",
+    "item_id": "PVTI_review_queued",
+    "identifier": "#42",
+    "title": "Queued review fixture issue",
+    "description": "## Issue Goal\n\nExercise duplicate review worker detection.",
+    "url": "https://github.com/Alive24/jade-symphony/issues/42",
+    "state": "Agent Review",
+    "labels": ["review"],
+    "assignees": [],
+    "priority": 2,
+    "branch_name": null,
+    "linked_pull_requests": [],
+    "blocked_by": [],
+    "project_fields": {
+      "Status": "Agent Review",
+      "Review Worker": "queued review:#42:fake-reviewer"
+    },
+    "created_at": "2026-05-13T00:00:00Z",
+    "updated_at": "2026-05-13T00:10:00Z"
+  }
+]

--- a/examples/review-fixture-workflow.md
+++ b/examples/review-fixture-workflow.md
@@ -1,0 +1,45 @@
+---
+tracker:
+  kind: memory
+  owner: Alive24
+  repo: jade-symphony
+  project_owner: Alive24
+  project_number: 1
+  status_field: Status
+  fixture_path: fixtures/review-issues.json
+  state_map:
+    backlog: Backlog
+    todo: Todo
+    need_to_clarify: Need to Clarify
+    in_progress: In Progress
+    need_human_input: Need Human Input
+    agent_review: Agent Review
+    human_review: Human Review
+    rework: Rework
+    merging: Merging
+    done: Done
+  assignee_filter:
+    source: issue_assignees
+    allow_unassigned: true
+    assignees: []
+  workpad:
+    source: issue_comment
+    marker: "<!-- jade-symphony-workpad -->"
+polling:
+  interval_ms: 5000
+workspace:
+  root: /tmp/jade-symphony-review-workspaces
+agent:
+  backend: dry-run
+  max_concurrent_agents: 1
+  max_turns: 1
+  max_retry_backoff_ms: 300000
+review:
+  backend: fake
+  gemini_command: gemini
+  timeout_ms: 600000
+observability:
+  logs_root: /tmp/jade-symphony-review-log
+---
+
+Review fixture workflow for Jade Symphony.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,10 @@ use jade_symphony::prompt::render_prompt;
 use jade_symphony::quality_gate::evaluate_issue;
 use jade_symphony::review::{
     classify_review_freshness, render_review_freshness_workpad, render_review_workpad,
-    review_gate_decision, transition_allowed_for_main_agent, transition_allowed_for_review_agent,
-    FakeReviewBackend, FakeReviewOutcome, GeminiCliReviewBackend, ReviewBackend,
-    ReviewFreshnessInput, ReviewJob, ReviewRequest, ReviewReworkClass, ReviewStaleReason,
+    review_gate_decision, review_run_eligibility, transition_allowed_for_main_agent,
+    transition_allowed_for_review_agent, FakeReviewBackend, FakeReviewOutcome,
+    GeminiCliReviewBackend, ReviewBackend, ReviewFreshnessInput, ReviewJob, ReviewRequest,
+    ReviewReworkClass, ReviewRunEligibility, ReviewStaleReason,
 };
 use jade_symphony::runtime_state::{
     clear_runtime_state, load_runtime_state, save_runtime_state, RuntimeIssueState, RuntimeState,
@@ -86,6 +87,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             write,
         } => review_once(workflow_path, issue_ref, write),
         Command::ReviewFreshness { input } => review_freshness(input),
+        Command::ReviewLoop { options } => review_loop(options),
         Command::Gate {
             workflow_path,
             issue_ref,
@@ -510,6 +512,163 @@ fn review_freshness(input: ReviewFreshnessInput) -> Result<(), Box<dyn std::erro
     println!("\n--- workpad evidence ---\n");
     println!("{}", render_review_freshness_workpad(&report));
     Ok(())
+}
+
+fn review_loop(options: ReviewLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
+    let limit = options.iteration_limit();
+    let mut iterations = 0usize;
+
+    loop {
+        if let Some(max) = limit {
+            if iterations >= max {
+                println!("review_loop=stopped reason=max_iterations iterations={iterations}");
+                break;
+            }
+        }
+
+        iterations += 1;
+        let config = load_config(&options.workflow_path)?;
+        let adapter = adapter_from_config(&config);
+        let issues = adapter
+            .fetch_issues_by_states(std::slice::from_ref(&config.tracker.state_map.agent_review))?;
+
+        let Some(issue) = issues.first().cloned() else {
+            println!("review_loop=stopped reason=no_agent_review_issue iterations={iterations}");
+            break;
+        };
+
+        let backend_kind = review_backend_kind(&config, options.fake_outcome.as_ref());
+        match review_run_eligibility(
+            &issue,
+            &config.tracker.state_map.agent_review,
+            &backend_kind,
+        ) {
+            ReviewRunEligibility::Eligible { worker_key } => {
+                println!(
+                    "review_loop_iteration={iterations} issue={} worker_key={worker_key} mode={}",
+                    issue.identifier,
+                    if options.write { "write" } else { "dry-run" }
+                );
+                if !options.write {
+                    println!(
+                        "review_loop_dry_run action=start issue={} backend={backend_kind}",
+                        issue.identifier
+                    );
+                    println!(
+                        "review_loop_dry_run action=workpad issue={} evidence=review_job",
+                        issue.identifier
+                    );
+                    println!(
+                        "review_loop_dry_run action=reconcile issue={} actor=independent_review_agent",
+                        issue.identifier
+                    );
+                    if limit.is_none() {
+                        println!(
+                            "review_loop=stopped reason=dry_run_would_repeat_without_mutation iterations={iterations}"
+                        );
+                        break;
+                    }
+                    continue;
+                }
+
+                let latest = adapter.get_issue(&issue.identifier)?.ok_or_else(|| {
+                    format!("issue disappeared before review: {}", issue.identifier)
+                })?;
+                match review_run_eligibility(
+                    &latest,
+                    &config.tracker.state_map.agent_review,
+                    &backend_kind,
+                ) {
+                    ReviewRunEligibility::Eligible { .. } => {
+                        let job = run_review_job(&config, &latest, options.fake_outcome.clone())?;
+                        apply_review_result(adapter.as_ref(), &latest.identifier, &latest, &job)?;
+                        let decision = review_gate_decision(&job);
+                        println!(
+                            "review_loop_action=reconciled issue={} backend={} outcome={:?} target_state={:?}",
+                            latest.identifier, job.backend, decision.outcome, decision.target_state
+                        );
+                    }
+                    ReviewRunEligibility::AlreadyQueued { worker_key } => {
+                        println!(
+                            "review_loop_action=skip issue={} reason=review_worker_exists worker_key={worker_key}",
+                            latest.identifier
+                        );
+                    }
+                    ReviewRunEligibility::NotInAgentReview { current_state } => {
+                        println!(
+                            "review_loop_action=skip issue={} reason=state_changed current_state={current_state:?}",
+                            latest.identifier
+                        );
+                    }
+                }
+            }
+            ReviewRunEligibility::AlreadyQueued { worker_key } => {
+                println!(
+                    "review_loop_action=skip issue={} reason=review_worker_exists worker_key={worker_key}",
+                    issue.identifier
+                );
+            }
+            ReviewRunEligibility::NotInAgentReview { current_state } => {
+                println!(
+                    "review_loop_action=skip issue={} reason=state_changed current_state={current_state:?}",
+                    issue.identifier
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn review_backend_kind(config: &RuntimeConfig, fake_outcome: Option<&FakeReviewOutcome>) -> String {
+    if fake_outcome.is_some() {
+        "fake-reviewer".into()
+    } else if config.review.backend == "gemini-cli" {
+        "gemini-cli".into()
+    } else {
+        "fake-reviewer".into()
+    }
+}
+
+fn run_review_job(
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+    fake_outcome: Option<FakeReviewOutcome>,
+) -> Result<ReviewJob, Box<dyn std::error::Error>> {
+    let request = ReviewRequest {
+        issue: issue.clone(),
+        prompt: format!(
+            "Review {} {}\n\n{}",
+            issue.identifier,
+            issue.title,
+            issue.description.as_deref().unwrap_or_default()
+        ),
+        workspace: config.workspace.root.clone(),
+        artifact_root: config.observability.logs_root.join("reviews"),
+    };
+
+    if let Some(outcome) = fake_outcome {
+        let backend = FakeReviewBackend::new(outcome);
+        return Ok(backend.poll(backend.start(request)?)?);
+    }
+
+    match config.review.backend.as_str() {
+        "gemini-cli" => {
+            let backend = GeminiCliReviewBackend::new(config.review.gemini_command.clone());
+            match backend.start(request) {
+                Ok(job) => Ok(backend.poll(job)?),
+                Err(error) => Ok(ReviewJob::failed_unavailable(
+                    issue.identifier.clone(),
+                    "gemini-cli",
+                    error.to_string(),
+                )),
+            }
+        }
+        _ => {
+            let backend = FakeReviewBackend::new(FakeReviewOutcome::Pass);
+            Ok(backend.poll(backend.start(request)?)?)
+        }
+    }
 }
 
 fn apply_review_result(
@@ -1174,6 +1333,9 @@ enum Command {
     ReviewFreshness {
         input: ReviewFreshnessInput,
     },
+    ReviewLoop {
+        options: ReviewLoopOptions,
+    },
     Gate {
         workflow_path: PathBuf,
         issue_ref: String,
@@ -1223,6 +1385,25 @@ struct RunLoopOptions {
     max_iterations: Option<usize>,
     once: bool,
     write: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReviewLoopOptions {
+    workflow_path: PathBuf,
+    max_iterations: Option<usize>,
+    once: bool,
+    write: bool,
+    fake_outcome: Option<FakeReviewOutcome>,
+}
+
+impl ReviewLoopOptions {
+    fn iteration_limit(&self) -> Option<usize> {
+        if self.once {
+            Some(1)
+        } else {
+            self.max_iterations
+        }
+    }
 }
 
 impl RunLoopOptions {
@@ -1290,6 +1471,8 @@ enum CliCommand {
     ReviewOnce(ReviewOnceArgs),
     #[command(name = "review-freshness")]
     ReviewFreshness(ReviewFreshnessArgs),
+    #[command(name = "review-loop")]
+    ReviewLoop(ReviewLoopArgs),
     Gate(GateArgs),
     #[command(name = "gate-apply")]
     GateApply(GateArgs),
@@ -1439,6 +1622,22 @@ struct ReviewFreshnessArgs {
     rework_class: CliReviewReworkClass,
     #[arg(long = "patch-summary")]
     patch_summary: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct ReviewLoopArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
+    workflow_path: PathBuf,
+    #[arg(long)]
+    max_iterations: Option<usize>,
+    #[arg(long)]
+    once: bool,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+    #[arg(long = "fake-outcome", value_enum)]
+    fake_outcome: Option<CliFakeReviewOutcome>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -1663,6 +1862,20 @@ impl TryFrom<Cli> for Command {
                             patch_summary: args.patch_summary,
                         },
                     }),
+                    CliCommand::ReviewLoop(args) => {
+                        if args.max_iterations == Some(0) {
+                            return Err(usage());
+                        }
+                        Ok(Self::ReviewLoop {
+                            options: ReviewLoopOptions {
+                                workflow_path: args.workflow_path,
+                                max_iterations: args.max_iterations,
+                                once: args.once,
+                                write: args.write,
+                                fake_outcome: args.fake_outcome.map(Into::into),
+                            },
+                        })
+                    }
                     CliCommand::Gate(args) => Ok(Self::Gate {
                         workflow_path: args.workflow_path,
                         issue_ref: args.issue_ref,
@@ -2014,6 +2227,53 @@ mod tests {
     }
 
     #[test]
+    fn parses_review_loop_flags() {
+        let command = Command::parse(vec![
+            "review-loop".into(),
+            "examples/review-fixture-workflow.md".into(),
+            "--max-iterations".into(),
+            "2".into(),
+            "--fake-outcome".into(),
+            "confirmed".into(),
+            "--write".into(),
+        ])
+        .unwrap();
+
+        let Command::ReviewLoop { options } = command else {
+            panic!("expected review-loop command");
+        };
+
+        assert_eq!(
+            options.workflow_path,
+            PathBuf::from("examples/review-fixture-workflow.md")
+        );
+        assert_eq!(options.max_iterations, Some(2));
+        assert_eq!(
+            options.fake_outcome,
+            Some(FakeReviewOutcome::ConfirmedFinding)
+        );
+        assert!(options.write);
+    }
+
+    #[test]
+    fn review_loop_once_overrides_max_iterations() {
+        let command = Command::parse(vec![
+            "review-loop".into(),
+            "WORKFLOW.md".into(),
+            "--max-iterations".into(),
+            "4".into(),
+            "--once".into(),
+        ])
+        .unwrap();
+
+        let Command::ReviewLoop { options } = command else {
+            panic!("expected review-loop command");
+        };
+
+        assert_eq!(options.iteration_limit(), Some(1));
+    }
+
+    #[test]
     fn parses_run_loop_flags() {
         let command = Command::parse(vec![
             "run-loop".into(),
@@ -2061,6 +2321,19 @@ mod tests {
     fn rejects_zero_run_loop_iterations() {
         let error = Command::parse(vec![
             "run-loop".into(),
+            "WORKFLOW.md".into(),
+            "--max-iterations".into(),
+            "0".into(),
+        ])
+        .unwrap_err();
+
+        assert!(error.contains("Usage:"));
+    }
+
+    #[test]
+    fn rejects_zero_review_loop_iterations() {
+        let error = Command::parse(vec![
+            "review-loop".into(),
             "WORKFLOW.md".into(),
             "--max-iterations".into(),
             "0".into(),

--- a/src/review.rs
+++ b/src/review.rs
@@ -9,7 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::model::TrackerIssue;
+use crate::model::{normalize_state, TrackerIssue};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReviewFindingClass {
@@ -142,6 +142,13 @@ pub struct ReviewFreshnessDecision {
 pub struct ReviewFreshnessReport {
     pub input: ReviewFreshnessInput,
     pub decision: ReviewFreshnessDecision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReviewRunEligibility {
+    Eligible { worker_key: String },
+    AlreadyQueued { worker_key: String },
+    NotInAgentReview { current_state: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -440,12 +447,64 @@ pub fn review_gate_decision_for_actor(job: &ReviewJob, actor: ReviewActor) -> Re
     }
 }
 
+pub fn review_worker_key(issue: &TrackerIssue, backend: &str) -> String {
+    format!(
+        "review:{}:{}",
+        issue.identifier.trim(),
+        backend.trim().to_lowercase()
+    )
+}
+
+pub fn review_run_eligibility(
+    issue: &TrackerIssue,
+    agent_review_state: &str,
+    backend: &str,
+) -> ReviewRunEligibility {
+    if issue.normalized_state() != normalize_state(agent_review_state) {
+        return ReviewRunEligibility::NotInAgentReview {
+            current_state: issue.state.clone(),
+        };
+    }
+
+    let worker_key = review_worker_key(issue, backend);
+    if has_active_review_worker(issue, &worker_key) {
+        ReviewRunEligibility::AlreadyQueued { worker_key }
+    } else {
+        ReviewRunEligibility::Eligible { worker_key }
+    }
+}
+
+fn has_active_review_worker(issue: &TrackerIssue, worker_key: &str) -> bool {
+    issue.project_fields.iter().any(|(key, value)| {
+        let key = key.to_lowercase();
+        if !key.contains("review") {
+            return false;
+        }
+
+        let value = value
+            .as_str()
+            .map(str::to_string)
+            .unwrap_or_else(|| value.to_string());
+        active_review_marker_matches(&value, worker_key)
+    }) || issue
+        .description
+        .as_deref()
+        .is_some_and(|description| active_review_marker_matches(description, worker_key))
+}
+
+fn active_review_marker_matches(value: &str, worker_key: &str) -> bool {
+    let value = value.to_lowercase();
+    value.contains(&worker_key.to_lowercase())
+        && (value.contains("queued") || value.contains("running"))
+}
+
 pub fn render_review_workpad(issue: &TrackerIssue, job: &ReviewJob) -> String {
     let decision = review_gate_decision_for_actor(job, ReviewActor::IndependentReviewAgent);
     let mut lines = vec![
         "## Agent Review".to_string(),
         String::new(),
         format!("- Issue: {} {}", issue.identifier, issue.title),
+        format!("- Worker key: {}", review_worker_key(issue, &job.backend)),
         format!("- Reviewer backend: {}", job.backend),
         format!("- Job state: {:?}", job.state),
         format!("- Decision: {}", decision.message),
@@ -902,5 +961,58 @@ mod tests {
         assert!(workpad.contains("Prior Human Review still valid: `true`"));
         assert!(workpad.contains("Main implementation agent still stops at `Agent Review`"));
         assert!(workpad.contains("Human Review"));
+    }
+
+    #[test]
+    fn review_run_eligibility_accepts_agent_review_issue() {
+        assert_eq!(
+            review_run_eligibility(&issue(), "Agent Review", "fake"),
+            ReviewRunEligibility::Eligible {
+                worker_key: "review:#1:fake".into()
+            }
+        );
+    }
+
+    #[test]
+    fn review_run_eligibility_rejects_non_agent_review_issue() {
+        let mut issue = issue();
+        issue.state = "Todo".into();
+
+        assert_eq!(
+            review_run_eligibility(&issue, "Agent Review", "fake"),
+            ReviewRunEligibility::NotInAgentReview {
+                current_state: "Todo".into()
+            }
+        );
+    }
+
+    #[test]
+    fn review_run_eligibility_detects_existing_worker_marker() {
+        let mut issue = issue();
+        issue.project_fields.insert(
+            "Review Worker".into(),
+            serde_json::Value::String("queued review:#1:fake".into()),
+        );
+
+        assert_eq!(
+            review_run_eligibility(&issue, "Agent Review", "fake"),
+            ReviewRunEligibility::AlreadyQueued {
+                worker_key: "review:#1:fake".into()
+            }
+        );
+    }
+
+    #[test]
+    fn review_run_eligibility_detects_workpad_worker_marker() {
+        let mut issue = issue();
+        issue.description =
+            Some("## Workpad\n\nReview worker running with key `review:#1:fake`.".into());
+
+        assert_eq!(
+            review_run_eligibility(&issue, "Agent Review", "fake"),
+            ReviewRunEligibility::AlreadyQueued {
+                worker_key: "review:#1:fake".into()
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Implements #41 with a bounded `review-loop` command for independent Review Agent ticks.
- Adds review eligibility/duplicate-worker checks, including workpad/body markers and project-field markers.
- Adds fixture review workflow/data, fake review-loop smoke coverage, and docs for the current bounded behavior.

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- review-loop examples/review-fixture-workflow.md --max-iterations 1 --dry-run
- cargo run -- review-loop examples/review-fixture-workflow.md --max-iterations 1 --fake-outcome pass --write

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #41
