### PR TITLE
#42: Differentiate agent git identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ one-issue-one-PR automation are still future work.
 - workspace identifiers are sanitized; local workspace paths stay under the
   configured root; hooks support timeouts, stdout/stderr capture,
   `before_remove`, and safe cleanup helpers.
+- workflow identity config can distinguish the acting role/label from the human
+  operator and can apply configured git author metadata with repository-local
+  `git config --local` only.
 - workspace/branch/PR handoff planning can derive a deterministic issue
   workspace key, branch name, and PR handoff body, and can detect an existing
   branch that appears to belong to a different issue.
@@ -72,7 +75,8 @@ one-issue-one-PR automation are still future work.
   backend result evidence, records final transition intent, and clears it after
   successful handoff/block transition.
 - `run-once` can prepare one dry-run workspace, render a prompt file, run the
-  dry-run backend, and append JSONL events.
+  dry-run backend, apply local git identity when the prepared workspace is a git
+  repository, and append JSONL events with actor metadata.
 - `run-once` can execute the conservative Codex subprocess backend when a
   workflow explicitly sets `agent.backend: codex`.
 - `run-once` can execute the conservative Claude Code subprocess backend when a
@@ -117,6 +121,7 @@ cargo run -- plan examples/dry-run-workflow.md
 cargo run -- plan-dispatch examples/dry-run-workflow.md
 cargo run -- status examples/dry-run-workflow.md
 cargo run -- run-once examples/dry-run-workflow.md
+cargo run -- run-once examples/git-identity-workflow.md
 cargo run -- run-once examples/codex-subprocess-workflow.md
 cargo run -- run-once examples/claude-subprocess-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
@@ -137,6 +142,11 @@ cargo run -- forge-create --workflow path/to/WORKFLOW.md --title "Follow-up titl
 fixtures show controlled real-backend paths without invoking live hosted
 services. They write `JADE_SYMPHONY_PROMPT.md` into the prepared workspace and
 append JSONL events for the selected workflow.
+
+`examples/git-identity-workflow.md` is a fixture workflow that runs
+`after_create: git init`, applies the configured `identity.git` values with
+workspace-local git config, and prints actor/git identity evidence. Jade
+Symphony does not write global git identity config.
 
 Live GitHub write commands are explicit and require a non-fixture workflow plus
 usable GitHub auth through `GITHUB_TOKEN` / `GH_TOKEN` or `gh api graphql`:
@@ -179,6 +189,7 @@ claim reconciliation, resume state, and PR automation exist.
 
 - linked PR attachment/linking as a first-class relationship.
 - live git worktree creation and `gh pr create` from the runtime loop.
+- profile-specific account/token routing for git hosts or agent backends.
 - rich interactive Issue Forge TUI; the current flow is CLI-first and
   command-step based.
 - Linear live adapter credential-gated smoke coverage.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -10,17 +10,17 @@ yet.
 | Capability | Current Status |
 | --- | --- |
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
-| Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
+| Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings and operator/agent identity metadata. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, review-freshness evidence for Merging conflict repair, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
-| Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
+| Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events with actor metadata. Runtime state files are written during write-mode `run-loop` issue execution, including actor role/label and git author when configured, but full resume reconciliation is still pending. No web/API surface yet. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
 
 ## Before Executing GitHub Project Issues
@@ -89,6 +89,8 @@ Project v2 issues:
      events.
    - Ensure external command execution happens only inside the prepared
      workspace.
+   - Keep acting identity explicit in backend context and avoid sharing profile
+     credentials across concurrent workers.
 
 7. Long-running orchestration.
    - Continuous idle polling exists for unbounded write mode; full active worker
@@ -100,6 +102,9 @@ Project v2 issues:
    - workspace/branch/PR handoff planning is recorded by `run-loop`, but the
      runtime still needs live worktree creation, branch checkout, push, PR
      creation, and PR link recording.
+   - Local git identity application exists for prepared git repositories; the
+     future live worktree path must apply it before commits and preserve the
+     distinction between agent actors and human operators.
    - continuation retry after normal active-state exits.
    - exponential backoff for failures.
    - stall detection.

--- a/examples/fixtures/git-identity-issues.json
+++ b/examples/fixtures/git-identity-issues.json
@@ -1,0 +1,23 @@
+[
+  {
+    "tracker_kind": "memory",
+    "id": "GHI_git_identity_42",
+    "item_id": "PVTI_git_identity_42",
+    "identifier": "#42",
+    "title": "Differentiate agent and human Git identities",
+    "description": "## Issue Setup\n\n- UAT Required: No\n\n## Issue Goal\n\nDifferentiate agent and human Git identities in prepared workspaces and runtime evidence.\n\n## Why Now\n\nDogfooding needs commits, logs, and workpads to make the acting identity clear without changing global operator settings.\n\n## Issue Context\n\nJade Symphony can prepare workspaces and run dry-run backends, but identity metadata is not yet captured consistently.\n\n## Decisions / Assumptions\n\n### Decisions\n\n- Apply configured git identity with local repository config only.\n- Record actor role and label in runtime evidence.\n\n### Assumptions\n\n- GitHub API identity remains controlled by authenticated gh credentials until profile-specific auth exists.\n\n## Non-Negotiable Guardrails\n\n- Do not write global git config.\n- Do not claim Human Review from main implementation work.\n- Do not read or log secrets.\n\n## Scope\n\n### In Scope\n\n- Workflow identity config.\n- Local workspace git identity application.\n- Runtime state, event log, and workpad identity metadata.\n- Fixture verification.\n\n### Out of Scope\n\n- Account manager.\n- Token routing.\n- Commit signing enforcement.\n\n## Canonical References\n\n### Target Repository / Package\n\n- Alive24/jade-symphony\n\n### Relevant Knowledge Sources\n\n- docs/bootstrap/JADE_WORKFLOW.md\n- docs/bootstrap/JADE_SYMPHONY_SPEC.md\n\n### Relevant Code Paths\n\n- src/config.rs\n- src/workspace.rs\n- src/runtime_state.rs\n- src/event_log.rs\n- src/main.rs\n\n## Current State\n\nWorkspace preparation exists, but git actor identity is implicit.\n\n## Deliverable Shape\n\nA focused identity configuration and local git application slice with tests and docs.\n\n## Risks or Constraints\n\n- Applying identity globally would contaminate the operator environment.\n\n## Expected Outcome\n\nA fixture run shows actor metadata and local git identity evidence.\n\n## Verification\n\n### Completion Criteria\n\n- cargo run -- run-once examples/git-identity-workflow.md prints actor and git identity evidence.\n\n### Functional Verification\n\n- cargo test\n- cargo fmt --check\n- cargo clippy --all-targets --all-features -- -D warnings\n\n### UAT\n\n- Not required.\n\n### Context Verification\n\n- Confirm local git config is set only inside the prepared workspace.",
+    "url": "https://github.com/Alive24/jade-symphony/issues/42",
+    "state": "Todo",
+    "labels": ["dogfood", "identity"],
+    "assignees": ["codex"],
+    "priority": 1,
+    "branch_name": null,
+    "linked_pull_requests": [],
+    "blocked_by": [],
+    "project_fields": {
+      "Status": "Todo"
+    },
+    "created_at": "2026-05-13T01:00:00Z",
+    "updated_at": "2026-05-13T01:05:00Z"
+  }
+]

--- a/examples/git-identity-workflow.md
+++ b/examples/git-identity-workflow.md
@@ -1,0 +1,43 @@
+---
+tracker:
+  kind: memory
+  fixture_path: fixtures/git-identity-issues.json
+  state_map:
+    todo: Todo
+    in_progress: In Progress
+    agent_review: Agent Review
+    need_human_input: Need Human Input
+  active_states:
+    - Todo
+    - Rework
+  assignee_filter:
+    source: issue_assignees
+    allow_unassigned: true
+workspace:
+  root: /tmp/jade-symphony-git-identity-workspaces
+hooks:
+  after_create: git init
+agent:
+  backend: dry-run
+  max_concurrent_agents: 1
+  max_turns: 3
+  max_retry_backoff_ms: 300000
+identity:
+  actor_role: implementation_agent
+  actor_label: Jade Symphony Dry Run Agent
+  git:
+    name: Jade Symphony Agent
+    email: jade-symphony-agent@example.invalid
+    extra:
+      jade.actorRole: implementation_agent
+observability:
+  logs_root: /tmp/jade-symphony-git-identity-logs
+---
+
+You are working on Jade Symphony issue {{ issue.identifier }}.
+
+Title: {{ issue.title }}
+State: {{ issue.state }}
+
+Use the configured actor identity only for local workspace git metadata and
+runtime evidence. Do not write global git config or log secrets.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -19,6 +19,9 @@ pub struct PreparedRun {
     pub timeout_ms: u64,
     pub approval_policy: Option<String>,
     pub sandbox: Option<String>,
+    pub actor_role: Option<String>,
+    pub actor_label: Option<String>,
+    pub git_author: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -62,7 +65,7 @@ impl AgentBackend for DryRunBackend {
         &self,
         workspace: PathBuf,
         rendered_prompt: String,
-        _config: &RuntimeConfig,
+        config: &RuntimeConfig,
     ) -> Result<PreparedRun, AgentError> {
         Ok(PreparedRun {
             backend: self.name().into(),
@@ -72,6 +75,9 @@ impl AgentBackend for DryRunBackend {
             timeout_ms: 0,
             approval_policy: None,
             sandbox: None,
+            actor_role: Some(config.identity.actor_role.clone()),
+            actor_label: Some(config.identity.actor_label.clone()),
+            git_author: config.identity.git.author(),
         })
     }
 
@@ -128,6 +134,9 @@ impl AgentBackend for CodexBackend {
             timeout_ms: config.codex.turn_timeout_ms,
             approval_policy: Some(config.codex.approval_policy.to_string()),
             sandbox: Some(config.codex.thread_sandbox.clone()),
+            actor_role: Some(config.identity.actor_role.clone()),
+            actor_label: Some(config.identity.actor_label.clone()),
+            git_author: config.identity.git.author(),
         })
     }
 
@@ -166,6 +175,9 @@ impl AgentBackend for ClaudeCodeBackend {
             timeout_ms: config.claude.turn_timeout_ms,
             approval_policy: None,
             sandbox: None,
+            actor_role: Some(config.identity.actor_role.clone()),
+            actor_label: Some(config.identity.actor_label.clone()),
+            git_author: config.identity.git.author(),
         })
     }
 
@@ -224,6 +236,18 @@ fn run_subprocess_backend(
         .env(
             "JADE_SYMPHONY_SANDBOX",
             prepared.sandbox.as_deref().unwrap_or_default(),
+        )
+        .env(
+            "JADE_SYMPHONY_ACTOR_ROLE",
+            prepared.actor_role.as_deref().unwrap_or_default(),
+        )
+        .env(
+            "JADE_SYMPHONY_ACTOR_LABEL",
+            prepared.actor_label.as_deref().unwrap_or_default(),
+        )
+        .env(
+            "JADE_SYMPHONY_GIT_AUTHOR",
+            prepared.git_author.as_deref().unwrap_or_default(),
         )
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct RuntimeConfig {
     pub codex: CodexConfig,
     pub claude: ClaudeConfig,
     pub review: ReviewConfig,
+    pub identity: IdentityConfig,
     pub observability: ObservabilityConfig,
     pub server: ServerConfig,
     #[serde(default)]
@@ -129,6 +130,39 @@ pub struct ReviewConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdentityConfig {
+    pub actor_role: String,
+    pub actor_label: String,
+    pub git: GitIdentityConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct GitIdentityConfig {
+    pub name: Option<String>,
+    pub email: Option<String>,
+    pub signing_key: Option<String>,
+    pub extra: BTreeMap<String, String>,
+}
+
+impl GitIdentityConfig {
+    pub fn author(&self) -> Option<String> {
+        match (self.name.as_deref(), self.email.as_deref()) {
+            (Some(name), Some(email)) => Some(format!("{name} <{email}>")),
+            (Some(name), None) => Some(name.to_string()),
+            (None, Some(email)) => Some(format!("<{email}>")),
+            (None, None) => None,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none()
+            && self.email.is_none()
+            && self.signing_key.is_none()
+            && self.extra.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ObservabilityConfig {
     pub dashboard_enabled: bool,
     pub refresh_ms: u64,
@@ -220,6 +254,7 @@ impl RuntimeConfig {
                 .unwrap_or_else(|| "gemini".to_string()),
             timeout_ms: get_u64(root.get("review"), "timeout_ms").unwrap_or(600_000),
         };
+        let identity = parse_identity(root.get("identity"));
         let observability = ObservabilityConfig {
             dashboard_enabled: get_bool(root.get("observability"), "dashboard_enabled")
                 .unwrap_or(true),
@@ -247,6 +282,7 @@ impl RuntimeConfig {
             codex,
             claude,
             review,
+            identity,
             observability,
             server,
             raw: workflow.config.clone(),
@@ -408,6 +444,37 @@ fn parse_state_limits(value: Option<&Value>) -> BTreeMap<String, usize> {
     limits
 }
 
+fn parse_identity(value: Option<&Value>) -> IdentityConfig {
+    IdentityConfig {
+        actor_role: get_string(value, "actor_role")
+            .unwrap_or_else(|| "implementation_agent".to_string()),
+        actor_label: get_string(value, "actor_label")
+            .unwrap_or_else(|| "Jade Symphony Agent".to_string()),
+        git: parse_git_identity(get_value(value, "git")),
+    }
+}
+
+fn parse_git_identity(value: Option<&Value>) -> GitIdentityConfig {
+    GitIdentityConfig {
+        name: get_string(value, "name"),
+        email: get_string(value, "email"),
+        signing_key: get_string(value, "signing_key"),
+        extra: parse_string_map(get_value(value, "extra")),
+    }
+}
+
+fn parse_string_map(value: Option<&Value>) -> BTreeMap<String, String> {
+    let mut output = BTreeMap::new();
+    if let Some(Value::Object(map)) = value {
+        for (key, value) in map {
+            if let Some(value) = value.as_str() {
+                output.insert(key.clone(), value.to_string());
+            }
+        }
+    }
+    output
+}
+
 fn get_value<'a>(root: Option<&'a Value>, key: &str) -> Option<&'a Value> {
     root.and_then(Value::as_object).and_then(|map| map.get(key))
 }
@@ -566,6 +633,33 @@ mod tests {
             .agent
             .max_concurrent_agents_by_state
             .contains_key("bad"));
+    }
+
+    #[test]
+    fn parses_actor_and_git_identity_config() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\nidentity:\n  actor_role: review_agent\n  actor_label: Gemini Review Runner\n  git:\n    name: Jade Review Bot\n    email: jade-review@example.invalid\n    signing_key: ABC123\n    extra:\n      jade.actorRole: review_agent\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert_eq!(config.identity.actor_role, "review_agent");
+        assert_eq!(config.identity.actor_label, "Gemini Review Runner");
+        assert_eq!(
+            config.identity.git.author().as_deref(),
+            Some("Jade Review Bot <jade-review@example.invalid>")
+        );
+        assert_eq!(
+            config
+                .identity
+                .git
+                .extra
+                .get("jade.actorRole")
+                .map(String::as_str),
+            Some("review_agent")
+        );
     }
 
     #[test]

--- a/src/event_log.rs
+++ b/src/event_log.rs
@@ -11,6 +11,12 @@ pub struct EventRecord {
     pub issue_id: Option<String>,
     pub issue_identifier: Option<String>,
     pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_author: Option<String>,
     pub message: String,
 }
 
@@ -62,11 +68,15 @@ mod tests {
             issue_id: Some("id".into()),
             issue_identifier: Some("#1".into()),
             session_id: None,
+            actor_role: Some("implementation_agent".into()),
+            actor_label: Some("Jade Symphony Agent".into()),
+            git_author: Some("Jade Symphony Agent <jade@example.invalid>".into()),
             message: "queued".into(),
         })
         .unwrap();
 
         let content = std::fs::read_to_string(temp.path().join("events.jsonl")).unwrap();
         assert!(content.contains("\"event\":\"dispatch\""));
+        assert!(content.contains("\"actor_role\":\"implementation_agent\""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,10 @@ use jade_symphony::tracker::{
     adapter_from_config, claim_decision, ClaimDecision, FollowUpIssueInput,
 };
 use jade_symphony::workflow::WorkflowDefinition;
-use jade_symphony::workspace::{prepare_workspace, run_after_run, run_before_run};
+use jade_symphony::workspace::{
+    apply_local_git_identity, prepare_workspace, run_after_run, run_before_run,
+    GitIdentityApplyResult,
+};
 
 const DEFAULT_RUN_LOOP_BASE_BRANCH: &str = "main";
 
@@ -611,6 +614,13 @@ fn run_once(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     println!("issue={} {}", issue.identifier, issue.title);
     println!("workspace={}", result.workspace_path.display());
     println!("backend={}", result.backend);
+    println!("actor_role={}", result.actor_role);
+    println!("actor_label={}", result.actor_label);
+    println!(
+        "git_author={}",
+        result.git_author.as_deref().unwrap_or("n/a")
+    );
+    println!("git_identity={}", result.git_identity.summary());
     println!("success={}", result.success);
     println!(
         "event_log={}",
@@ -630,6 +640,10 @@ struct IssueExecutionResult {
     success: bool,
     session_id: Option<String>,
     message: String,
+    actor_role: String,
+    actor_label: String,
+    git_author: Option<String>,
+    git_identity: GitIdentityApplyResult,
 }
 
 fn execute_issue_once(
@@ -647,6 +661,7 @@ fn execute_issue_once_with_workspace_key(
     workspace_key: &str,
 ) -> Result<IssueExecutionResult, Box<dyn std::error::Error>> {
     let workspace = prepare_workspace(&config.workspace.root, workspace_key, &config.hooks)?;
+    let git_identity = apply_local_git_identity(&workspace.path, &config.identity.git)?;
     run_before_run(&workspace.path, &config.hooks)?;
 
     let prompt = render_prompt(&workflow.prompt_template, issue, None)?;
@@ -665,6 +680,9 @@ fn execute_issue_once_with_workspace_key(
             issue_id: Some(issue.id.clone()),
             issue_identifier: Some(issue.identifier.clone()),
             session_id: summary.session_id.clone(),
+            actor_role: Some(config.identity.actor_role.clone()),
+            actor_label: Some(config.identity.actor_label.clone()),
+            git_author: config.identity.git.author(),
             message: summary.message.clone(),
         })?;
     }
@@ -675,6 +693,10 @@ fn execute_issue_once_with_workspace_key(
         success: summary.success,
         session_id: summary.session_id,
         message: summary.message,
+        actor_role: config.identity.actor_role.clone(),
+        actor_label: config.identity.actor_label.clone(),
+        git_author: config.identity.git.author(),
+        git_identity,
     })
 }
 
@@ -749,7 +771,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         };
 
         if !options.write {
-            print_run_loop_dry_run_actions(&issue, &handoff);
+            print_run_loop_dry_run_actions(&issue, &handoff, &config);
             if limit.is_none() {
                 println!(
                     "run_loop=stopped reason=dry_run_would_repeat_without_mutation iterations={iterations}"
@@ -811,7 +833,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         let mut runtime_state = run_loop_runtime_state_for_issue(
             existing_runtime_state.as_ref(),
             &latest,
-            &config.backend.kind,
+            &config,
             event,
         );
         save_runtime_state(&config, &runtime_state)?;
@@ -916,7 +938,7 @@ fn no_dispatch_action(
 fn run_loop_runtime_state_for_issue(
     existing: Option<&RuntimeState>,
     issue: &TrackerIssue,
-    backend: &str,
+    config: &RuntimeConfig,
     event: &str,
 ) -> RuntimeState {
     let mut state = RuntimeState::active(
@@ -924,10 +946,13 @@ fn run_loop_runtime_state_for_issue(
             id: issue.id.clone(),
             identifier: issue.identifier.clone(),
         },
-        backend,
+        &config.backend.kind,
     );
     state.attempt_count = next_runtime_attempt_count(existing, &issue.identifier);
     state.branch_name = issue.branch_name.clone();
+    state.actor_role = Some(config.identity.actor_role.clone());
+    state.actor_label = Some(config.identity.actor_label.clone());
+    state.git_author = config.identity.git.author();
     state.last_event = Some(event.into());
     state
 }
@@ -951,6 +976,9 @@ fn run_loop_runtime_state_with_result(
     state.workspace_path = Some(result.workspace_path.clone());
     state.backend = result.backend.clone();
     state.backend_session_id = result.session_id.clone();
+    state.actor_role = Some(result.actor_role.clone());
+    state.actor_label = Some(result.actor_label.clone());
+    state.git_author = result.git_author.clone();
     state.last_event = Some(if result.success {
         "Completed".into()
     } else {
@@ -1034,7 +1062,11 @@ fn handle_run_loop_handoff_failure(
     Ok(())
 }
 
-fn print_run_loop_dry_run_actions(issue: &TrackerIssue, handoff: &IssueHandoffPlan) {
+fn print_run_loop_dry_run_actions(
+    issue: &TrackerIssue,
+    handoff: &IssueHandoffPlan,
+    config: &RuntimeConfig,
+) {
     if normalize_state(&issue.state) != "in progress" {
         println!(
             "run_loop_dry_run action=claim issue={} target_state=in_progress",
@@ -1050,6 +1082,13 @@ fn print_run_loop_dry_run_actions(issue: &TrackerIssue, handoff: &IssueHandoffPl
         handoff.workspace_path.display(),
         handoff.branch_name,
         handoff.pull_request.title
+    );
+    println!(
+        "run_loop_dry_run action=identity issue={} actor_role={} actor_label={:?} git_author={:?}",
+        issue.identifier,
+        config.identity.actor_role,
+        config.identity.actor_label,
+        config.identity.git.author()
     );
     println!(
         "run_loop_dry_run action=run issue={} backend=configured",
@@ -1080,6 +1119,13 @@ fn run_loop_handoff_workpad(
         "### Run Evidence".to_string(),
         format!("- Workspace: `{}`", result.workspace_path.display()),
         format!("- Backend: `{}`", result.backend),
+        format!("- Actor role: `{}`", result.actor_role),
+        format!("- Actor label: `{}`", result.actor_label),
+        format!(
+            "- Git author: `{}`",
+            result.git_author.as_deref().unwrap_or("n/a")
+        ),
+        format!("- Git identity: `{}`", result.git_identity.summary()),
         format!("- Success: `{}`", result.success),
         format!(
             "- Session: `{}`",
@@ -2096,10 +2142,11 @@ mod tests {
 
     #[test]
     fn run_loop_runtime_state_increments_same_issue_attempts() {
+        let config = test_config();
         let issue = tracker_issue("In Progress");
-        let existing = run_loop_runtime_state_for_issue(None, &issue, "dry-run", "Claimed");
+        let existing = run_loop_runtime_state_for_issue(None, &issue, &config, "Claimed");
 
-        let state = run_loop_runtime_state_for_issue(Some(&existing), &issue, "dry-run", "Resumed");
+        let state = run_loop_runtime_state_for_issue(Some(&existing), &issue, &config, "Resumed");
 
         assert_eq!(state.attempt_count, 2);
         assert_eq!(
@@ -2110,24 +2157,40 @@ mod tests {
             Some("#29")
         );
         assert_eq!(state.branch_name, issue.branch_name);
+        assert_eq!(state.actor_role.as_deref(), Some("implementation_agent"));
+        assert_eq!(state.actor_label.as_deref(), Some("Jade Symphony Agent"));
         assert_eq!(state.last_event.as_deref(), Some("Resumed"));
     }
 
     #[test]
     fn run_loop_runtime_state_records_result_and_transition() {
+        let config = test_config();
         let issue = tracker_issue("In Progress");
-        let state = run_loop_runtime_state_for_issue(None, &issue, "dry-run", "Claimed");
+        let state = run_loop_runtime_state_for_issue(None, &issue, &config, "Claimed");
         let result = IssueExecutionResult {
             workspace_path: PathBuf::from("/tmp/jade/issue-29"),
             backend: "dry-run".into(),
             success: true,
             session_id: Some("session-29".into()),
             message: "ok".into(),
+            actor_role: "implementation_agent".into(),
+            actor_label: "Jade Symphony Agent".into(),
+            git_author: Some("Jade Symphony Agent <jade@example.invalid>".into()),
+            git_identity: GitIdentityApplyResult {
+                status: jade_symphony::workspace::GitIdentityApplyStatus::Applied,
+                author: Some("Jade Symphony Agent <jade@example.invalid>".into()),
+                applied_keys: vec!["user.name".into(), "user.email".into()],
+            },
         };
 
         let state = run_loop_runtime_state_with_result(state, &result);
         assert_eq!(state.workspace_path, Some(result.workspace_path));
         assert_eq!(state.backend_session_id.as_deref(), Some("session-29"));
+        assert_eq!(state.actor_role.as_deref(), Some("implementation_agent"));
+        assert_eq!(
+            state.git_author.as_deref(),
+            Some("Jade Symphony Agent <jade@example.invalid>")
+        );
         assert_eq!(state.last_event.as_deref(), Some("Completed"));
 
         let state = run_loop_runtime_state_with_transition(
@@ -2200,11 +2263,23 @@ mod tests {
             success: true,
             session_id: Some("session-33".into()),
             message: "ok".into(),
+            actor_role: "implementation_agent".into(),
+            actor_label: "Jade Symphony Agent".into(),
+            git_author: Some("Jade Symphony Agent <jade@example.invalid>".into()),
+            git_identity: GitIdentityApplyResult {
+                status: jade_symphony::workspace::GitIdentityApplyStatus::Applied,
+                author: Some("Jade Symphony Agent <jade@example.invalid>".into()),
+                applied_keys: vec!["user.name".into(), "user.email".into()],
+            },
         };
 
         let workpad = run_loop_handoff_workpad(&issue, &result, &handoff);
 
         assert!(workpad.contains("### Planned Handoff"));
+        assert!(workpad.contains("Actor role: `implementation_agent`"));
+        assert!(
+            workpad.contains("Git identity: `applied:Jade Symphony Agent <jade@example.invalid>`")
+        );
         assert!(workpad
             .contains("Workspace key: `issue-29-wire-runtime-state-persistence-into-run-loop`"));
         assert!(workpad

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -15,6 +15,12 @@ pub struct RuntimeState {
     pub branch_name: Option<String>,
     pub backend: String,
     pub backend_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_role: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_author: Option<String>,
     pub attempt_count: u32,
     pub last_event: Option<String>,
     pub last_transition: Option<RuntimeTransition>,
@@ -28,6 +34,9 @@ impl RuntimeState {
             branch_name: None,
             backend: backend.into(),
             backend_session_id: None,
+            actor_role: None,
+            actor_label: None,
+            git_author: None,
             attempt_count: 1,
             last_event: None,
             last_transition: None,
@@ -141,6 +150,9 @@ mod tests {
             branch_name: Some("feature-issue-1".into()),
             backend: "dry-run".into(),
             backend_session_id: Some("session".into()),
+            actor_role: Some("implementation_agent".into()),
+            actor_label: Some("Jade Symphony Agent".into()),
+            git_author: Some("Jade Symphony Agent <jade@example.invalid>".into()),
             attempt_count: 2,
             last_event: Some("Completed".into()),
             last_transition: Some(RuntimeTransition {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use thiserror::Error;
 
-use crate::config::HooksConfig;
+use crate::config::{GitIdentityConfig, HooksConfig};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Workspace {
@@ -42,6 +42,33 @@ pub struct HookResult {
     pub status: i32,
     pub stdout: String,
     pub stderr: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitIdentityApplyResult {
+    pub status: GitIdentityApplyStatus,
+    pub author: Option<String>,
+    pub applied_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitIdentityApplyStatus {
+    Applied,
+    NotConfigured,
+    NotGitRepository,
+}
+
+impl GitIdentityApplyResult {
+    pub fn summary(&self) -> String {
+        match self.status {
+            GitIdentityApplyStatus::Applied => {
+                let author = self.author.as_deref().unwrap_or("configured");
+                format!("applied:{author}")
+            }
+            GitIdentityApplyStatus::NotConfigured => "skipped:not_configured".to_string(),
+            GitIdentityApplyStatus::NotGitRepository => "skipped:not_git_repository".to_string(),
+        }
+    }
 }
 
 impl HookResult {
@@ -106,6 +133,51 @@ pub fn run_before_run(path: &Path, hooks: &HooksConfig) -> Result<(), WorkspaceE
         run_hook("before_run", command, path, hooks.timeout_ms)?;
     }
     Ok(())
+}
+
+pub fn apply_local_git_identity(
+    path: &Path,
+    identity: &GitIdentityConfig,
+) -> Result<GitIdentityApplyResult, WorkspaceError> {
+    if identity.is_empty() {
+        return Ok(GitIdentityApplyResult {
+            status: GitIdentityApplyStatus::NotConfigured,
+            author: None,
+            applied_keys: Vec::new(),
+        });
+    }
+
+    if !path.join(".git").exists() {
+        return Ok(GitIdentityApplyResult {
+            status: GitIdentityApplyStatus::NotGitRepository,
+            author: identity.author(),
+            applied_keys: Vec::new(),
+        });
+    }
+
+    let mut applied_keys = Vec::new();
+    if let Some(name) = identity.name.as_deref() {
+        set_local_git_config(path, "user.name", name)?;
+        applied_keys.push("user.name".to_string());
+    }
+    if let Some(email) = identity.email.as_deref() {
+        set_local_git_config(path, "user.email", email)?;
+        applied_keys.push("user.email".to_string());
+    }
+    if let Some(signing_key) = identity.signing_key.as_deref() {
+        set_local_git_config(path, "user.signingkey", signing_key)?;
+        applied_keys.push("user.signingkey".to_string());
+    }
+    for (key, value) in &identity.extra {
+        set_local_git_config(path, key, value)?;
+        applied_keys.push(key.clone());
+    }
+
+    Ok(GitIdentityApplyResult {
+        status: GitIdentityApplyStatus::Applied,
+        author: identity.author(),
+        applied_keys,
+    })
 }
 
 pub fn run_after_run(path: &Path, hooks: &HooksConfig) {
@@ -220,6 +292,30 @@ fn run_hook(
         }
 
         thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn set_local_git_config(path: &Path, key: &str, value: &str) -> Result<(), WorkspaceError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .arg("config")
+        .arg("--local")
+        .arg(key)
+        .arg(value)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(WorkspaceError::HookFailed {
+            hook: format!("git config --local {key}"),
+            status: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
     }
 }
 
@@ -357,5 +453,81 @@ mod tests {
 
         assert!(matches!(result, Err(WorkspaceError::OutsideRoot { .. })));
         assert!(outside.path().exists());
+    }
+
+    #[test]
+    fn skips_git_identity_when_not_configured() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = apply_local_git_identity(temp.path(), &GitIdentityConfig::default()).unwrap();
+
+        assert_eq!(result.status, GitIdentityApplyStatus::NotConfigured);
+        assert_eq!(result.summary(), "skipped:not_configured");
+    }
+
+    #[test]
+    fn skips_git_identity_outside_git_repository() {
+        let temp = tempfile::tempdir().unwrap();
+        let identity = GitIdentityConfig {
+            name: Some("Jade Symphony Agent".into()),
+            email: Some("jade@example.invalid".into()),
+            signing_key: None,
+            extra: Default::default(),
+        };
+
+        let result = apply_local_git_identity(temp.path(), &identity).unwrap();
+
+        assert_eq!(result.status, GitIdentityApplyStatus::NotGitRepository);
+        assert_eq!(
+            result.author.as_deref(),
+            Some("Jade Symphony Agent <jade@example.invalid>")
+        );
+    }
+
+    #[test]
+    fn applies_git_identity_as_local_config_only() {
+        let temp = tempfile::tempdir().unwrap();
+        Command::new("git")
+            .arg("init")
+            .arg(temp.path())
+            .output()
+            .unwrap();
+        let mut extra = std::collections::BTreeMap::new();
+        extra.insert("jade.actorRole".into(), "implementation_agent".into());
+        let identity = GitIdentityConfig {
+            name: Some("Jade Symphony Agent".into()),
+            email: Some("jade@example.invalid".into()),
+            signing_key: None,
+            extra,
+        };
+
+        let result = apply_local_git_identity(temp.path(), &identity).unwrap();
+
+        assert_eq!(result.status, GitIdentityApplyStatus::Applied);
+        assert!(result.applied_keys.contains(&"user.name".to_string()));
+        assert_eq!(
+            git_local_config(temp.path(), "user.name"),
+            "Jade Symphony Agent"
+        );
+        assert_eq!(
+            git_local_config(temp.path(), "user.email"),
+            "jade@example.invalid"
+        );
+        assert_eq!(
+            git_local_config(temp.path(), "jade.actorRole"),
+            "implementation_agent"
+        );
+    }
+
+    fn git_local_config(path: &Path, key: &str) -> String {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(path)
+            .arg("config")
+            .arg("--local")
+            .arg(key)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
     }
 }


### PR DESCRIPTION
## Summary

- adds workflow actor/git identity config for Jade Symphony execution evidence
- applies configured git identity only with repository-local `git config --local`
- records actor role/label and git author in backend context, runtime state, event logs, run output, and workpad evidence
- adds a fixture workflow that initializes a local git workspace and demonstrates identity application

## Validation

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- run-once examples/git-identity-workflow.md`

## Notes

This is intentionally not an account manager or token-routing implementation. It keeps the slice focused on local workspace git identity and traceable runtime evidence.
