### PR TITLE
#45: Wire live worktree PR handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It does **not** yet fully autonomously execute GitHub Project v2 issues,
 run Codex/Claude through the final app-server flow, or supervise long-running
 workers. A `run-loop` skeleton now exists and can idle-poll in unbounded
 write mode, but full claim reconciliation, runtime resume, and
-one-issue-one-PR automation are still future work.
+worker supervision are still future work.
 
 ## What Works Now
 
@@ -63,6 +63,9 @@ one-issue-one-PR automation are still future work.
 - workspace/branch/PR handoff planning can derive a deterministic issue
   workspace key, branch name, and PR handoff body, and can detect an existing
   branch that appears to belong to a different issue.
+- live GitHub `run-loop --write` can create or reuse the planned issue
+  worktree/branch, run the configured backend inside that worktree, push the
+  branch, and create or reuse one GitHub PR after successful execution.
 - terminal status output reports polling state, planned running/skipped/retrying
   issues, token counters, event-log path, gate details, and integration gaps.
 - JSONL event-log primitives exist.
@@ -81,8 +84,9 @@ one-issue-one-PR automation are still future work.
   print dry-run claim/run/workpad/handoff actions, surface deterministic
   workspace/branch/PR handoff plans, use tracker claim helpers to
   claim/resume/skip externally changed issues, and in explicit `--write` mode
-  run one issue at a time, record planned handoff evidence, and stop main-agent
-  completion at `Agent Review`;
+  run one issue at a time, record handoff evidence, create a live PR handoff in
+  non-fixture GitHub Project v2 mode, and stop main-agent completion at
+  `Agent Review`;
   unbounded write mode sleeps on idle polls using the workflow polling interval.
 
 ## Dry-Run Only
@@ -178,7 +182,7 @@ claim reconciliation, resume state, and PR automation exist.
 ## Stubbed
 
 - linked PR attachment/linking as a first-class relationship.
-- live git worktree creation and `gh pr create` from the runtime loop.
+- robust cleanup for live git worktrees after terminal tracker reconciliation.
 - rich interactive Issue Forge TUI; the current flow is CLI-first and
   command-step based.
 - Linear live adapter credential-gated smoke coverage.
@@ -194,8 +198,8 @@ claim reconciliation, resume state, and PR automation exist.
 - richer issue claiming, state transition, and reconciliation safety beyond the
   current claim helper and runtime-state wiring.
 - full runtime-state resume reconciliation after interruption.
-- workspace-per-issue branch and PR automation beyond current handoff planning
-  and workpad evidence.
+- richer workspace-per-issue branch and PR reconciliation beyond current
+  create-or-reuse handoff.
 - retry timers, continuation retries, and stall restart.
 - terminal workspace cleanup tied to tracker state.
 - live token/rate-limit accounting beyond the current snapshot counters.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -16,8 +16,8 @@ yet.
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
-| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
+| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and live PR handoff in non-fixture GitHub mode exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, PR create-or-reuse, and run-loop handoff evidence exist. Runtime reconciliation cleanup is not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, review-freshness evidence for Merging conflict repair, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
@@ -97,9 +97,11 @@ Project v2 issues:
    - Runtime state writes exist for claim/resume, backend result evidence, and
      final transition intent; full resume reconciliation after interruption
      remains pending.
-   - workspace/branch/PR handoff planning is recorded by `run-loop`, but the
-     runtime still needs live worktree creation, branch checkout, push, PR
-     creation, and PR link recording.
+   - workspace/branch/PR handoff is recorded by `run-loop`; in live
+     non-fixture GitHub mode the runtime can create/reuse the issue worktree and
+     branch, push the branch, and create/reuse one PR after successful backend
+     execution. Remaining work: cleanup, richer reconciliation, and stronger
+     verification command modeling.
    - continuation retry after normal active-state exits.
    - exponential backoff for failures.
    - stall detection.
@@ -224,20 +226,18 @@ Acceptance:
 - terminal cleanup is tied to tracker reconciliation.
 - path escape tests cover symlink and non-directory cases.
 
-### 6. Wire Workspace Branch And PR Handoff Into Run-Loop
+### 6. Harden Workspace Branch And PR Handoff Reconciliation
 
-Goal: connect handoff planning evidence to controlled runtime mutation without
-mixing multiple issue scopes in one branch.
+Goal: strengthen the current live handoff path without mixing multiple issue
+scopes in one branch.
 
 Acceptance:
 
-- records the planned workspace key, workspace path, branch, and PR title in
-  `run-loop` dry-run output and workpad evidence.
-- refuses branches that appear to belong to a different issue.
-- creates or reuses one isolated git worktree per issue.
-- checks out the planned issue branch from the configured base branch.
-- pushes the issue branch after local completion.
-- creates one PR with a handoff body and records the PR link in the workpad.
+- reconciles existing worktrees with tracker state before reuse.
+- records PR URL and branch evidence in the tracker workpad.
+- detects missing remote commits or no-op branches before PR creation.
+- adds configured verification command execution before push/PR handoff.
+- cleans terminal worktrees after tracker reconciliation.
 - keeps main implementation completion at `Agent Review`.
 
 ### 7. Add Agent Review Gate
@@ -318,5 +318,5 @@ GitHub Project v2 execution is hardened.
 manual live Project v2 reads and explicit tracker writes through `gh`. It still
 uses the `dry-run` backend by default. `run-loop --write` is available only as a
 bounded runtime skeleton and should not be treated as full autonomous agent
-execution until claim reconciliation, full runtime resume reconciliation, and
-live PR automation wiring exist.
+execution until claim reconciliation, full runtime resume reconciliation,
+configured verification commands, and worker supervision are hardened.

--- a/src/git_handoff.rs
+++ b/src/git_handoff.rs
@@ -1,0 +1,424 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::handoff::IssueHandoffPlan;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiveWorktreeResult {
+    pub workspace_path: PathBuf,
+    pub branch_name: String,
+    pub created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestPublication {
+    pub branch_pushed: bool,
+    pub pr_url: String,
+    pub pr_created: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutput {
+    pub status: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub trait HandoffCommandRunner {
+    fn run(
+        &self,
+        program: &str,
+        args: &[String],
+        cwd: &Path,
+    ) -> Result<CommandOutput, GitHandoffError>;
+}
+
+#[derive(Debug, Default)]
+pub struct ProcessHandoffCommandRunner;
+
+impl HandoffCommandRunner for ProcessHandoffCommandRunner {
+    fn run(
+        &self,
+        program: &str,
+        args: &[String],
+        cwd: &Path,
+    ) -> Result<CommandOutput, GitHandoffError> {
+        let output = Command::new(program).args(args).current_dir(cwd).output()?;
+        Ok(CommandOutput {
+            status: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum GitHandoffError {
+    #[error("git handoff io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("{program} failed with status {status}: stdout={stdout} stderr={stderr}")]
+    CommandFailed {
+        program: String,
+        status: i32,
+        stdout: String,
+        stderr: String,
+    },
+    #[error("existing worktree {path} is on branch {current_branch}, expected {expected_branch}")]
+    WorktreeBranchMismatch {
+        path: PathBuf,
+        expected_branch: String,
+        current_branch: String,
+    },
+    #[error("pull request command did not return a URL")]
+    MissingPullRequestUrl,
+}
+
+pub fn prepare_issue_worktree(
+    repo_root: &Path,
+    plan: &IssueHandoffPlan,
+    runner: &dyn HandoffCommandRunner,
+) -> Result<LiveWorktreeResult, GitHandoffError> {
+    if plan.workspace_path.exists() {
+        let current_branch = current_branch(&plan.workspace_path, runner)?;
+        if current_branch != plan.branch_name {
+            return Err(GitHandoffError::WorktreeBranchMismatch {
+                path: plan.workspace_path.clone(),
+                expected_branch: plan.branch_name.clone(),
+                current_branch,
+            });
+        }
+
+        return Ok(LiveWorktreeResult {
+            workspace_path: plan.workspace_path.clone(),
+            branch_name: plan.branch_name.clone(),
+            created: false,
+        });
+    }
+
+    if let Some(parent) = plan.workspace_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let branch_ref = format!("refs/heads/{}", plan.branch_name);
+    let branch_exists = command_status(
+        "git",
+        &[
+            "-C".into(),
+            repo_root.display().to_string(),
+            "show-ref".into(),
+            "--verify".into(),
+            "--quiet".into(),
+            branch_ref,
+        ],
+        repo_root,
+        runner,
+    )? == 0;
+
+    let args = if branch_exists {
+        vec![
+            "-C".into(),
+            repo_root.display().to_string(),
+            "worktree".into(),
+            "add".into(),
+            plan.workspace_path.display().to_string(),
+            plan.branch_name.clone(),
+        ]
+    } else {
+        vec![
+            "-C".into(),
+            repo_root.display().to_string(),
+            "worktree".into(),
+            "add".into(),
+            "-b".into(),
+            plan.branch_name.clone(),
+            plan.workspace_path.display().to_string(),
+            plan.pull_request.base_branch.clone(),
+        ]
+    };
+    require_success("git", runner.run("git", &args, repo_root)?)?;
+
+    Ok(LiveWorktreeResult {
+        workspace_path: plan.workspace_path.clone(),
+        branch_name: plan.branch_name.clone(),
+        created: true,
+    })
+}
+
+pub fn publish_issue_pull_request(
+    plan: &IssueHandoffPlan,
+    runner: &dyn HandoffCommandRunner,
+) -> Result<PullRequestPublication, GitHandoffError> {
+    require_success(
+        "git",
+        runner.run(
+            "git",
+            &[
+                "push".into(),
+                "-u".into(),
+                "origin".into(),
+                plan.branch_name.clone(),
+            ],
+            &plan.workspace_path,
+        )?,
+    )?;
+
+    let existing = runner.run(
+        "gh",
+        &[
+            "pr".into(),
+            "view".into(),
+            plan.branch_name.clone(),
+            "--json".into(),
+            "url".into(),
+            "--jq".into(),
+            ".url".into(),
+        ],
+        &plan.workspace_path,
+    )?;
+    if existing.status == 0 {
+        let url = extract_url(&existing.stdout)?;
+        return Ok(PullRequestPublication {
+            branch_pushed: true,
+            pr_url: url,
+            pr_created: false,
+        });
+    }
+
+    let created = runner.run(
+        "gh",
+        &[
+            "pr".into(),
+            "create".into(),
+            "--title".into(),
+            plan.pull_request.title.clone(),
+            "--body".into(),
+            plan.pull_request.body.clone(),
+            "--base".into(),
+            plan.pull_request.base_branch.clone(),
+            "--head".into(),
+            plan.pull_request.head_branch.clone(),
+        ],
+        &plan.workspace_path,
+    )?;
+    require_success("gh", created.clone())?;
+
+    Ok(PullRequestPublication {
+        branch_pushed: true,
+        pr_url: extract_url(&created.stdout)?,
+        pr_created: true,
+    })
+}
+
+fn current_branch(
+    workspace_path: &Path,
+    runner: &dyn HandoffCommandRunner,
+) -> Result<String, GitHandoffError> {
+    let output = runner.run(
+        "git",
+        &["branch".into(), "--show-current".into()],
+        workspace_path,
+    )?;
+    require_success("git", output.clone())?;
+    Ok(output.stdout.trim().to_string())
+}
+
+fn command_status(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    runner: &dyn HandoffCommandRunner,
+) -> Result<i32, GitHandoffError> {
+    Ok(runner.run(program, args, cwd)?.status)
+}
+
+fn require_success(program: &str, output: CommandOutput) -> Result<(), GitHandoffError> {
+    if output.status == 0 {
+        Ok(())
+    } else {
+        Err(GitHandoffError::CommandFailed {
+            program: program.into(),
+            status: output.status,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        })
+    }
+}
+
+fn extract_url(stdout: &str) -> Result<String, GitHandoffError> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("http://") || line.starts_with("https://"))
+        .map(ToOwned::to_owned)
+        .ok_or(GitHandoffError::MissingPullRequestUrl)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handoff::plan_issue_handoff;
+    use crate::model::TrackerIssue;
+    use std::cell::RefCell;
+
+    #[derive(Debug, Default)]
+    struct FakeRunner {
+        commands: RefCell<Vec<String>>,
+        existing_branch: bool,
+        existing_pr_url: Option<String>,
+        worktree_branch: Option<String>,
+    }
+
+    impl HandoffCommandRunner for FakeRunner {
+        fn run(
+            &self,
+            program: &str,
+            args: &[String],
+            _cwd: &Path,
+        ) -> Result<CommandOutput, GitHandoffError> {
+            let command = format!("{program} {}", args.join(" "));
+            self.commands.borrow_mut().push(command.clone());
+
+            if command.contains("show-ref --verify --quiet") {
+                return Ok(CommandOutput {
+                    status: if self.existing_branch { 0 } else { 1 },
+                    stdout: String::new(),
+                    stderr: String::new(),
+                });
+            }
+            if command.contains("branch --show-current") {
+                return Ok(CommandOutput {
+                    status: 0,
+                    stdout: self.worktree_branch.clone().unwrap_or_default(),
+                    stderr: String::new(),
+                });
+            }
+            if command.starts_with("gh pr view") {
+                return Ok(match &self.existing_pr_url {
+                    Some(url) => CommandOutput {
+                        status: 0,
+                        stdout: format!("{url}\n"),
+                        stderr: String::new(),
+                    },
+                    None => CommandOutput {
+                        status: 1,
+                        stdout: String::new(),
+                        stderr: "no pull request".into(),
+                    },
+                });
+            }
+            if command.starts_with("gh pr create") {
+                return Ok(CommandOutput {
+                    status: 0,
+                    stdout: "https://github.com/Alive24/jade-symphony/pull/99\n".into(),
+                    stderr: String::new(),
+                });
+            }
+
+            Ok(CommandOutput {
+                status: 0,
+                stdout: String::new(),
+                stderr: String::new(),
+            })
+        }
+    }
+
+    fn issue() -> TrackerIssue {
+        TrackerIssue {
+            tracker_kind: "github_project_v2".into(),
+            id: "I_45".into(),
+            item_id: Some("PVTI_45".into()),
+            identifier: "#45".into(),
+            title: "Wire live worktree and PR creation into run-loop".into(),
+            description: None,
+            url: None,
+            state: "In Progress".into(),
+            labels: Vec::new(),
+            assignees: Vec::new(),
+            priority: None,
+            branch_name: None,
+            linked_pull_requests: Vec::new(),
+            blocked_by: Vec::new(),
+            project_fields: Default::default(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    #[test]
+    fn creates_new_issue_worktree_from_base_branch() {
+        let temp = tempfile::tempdir().unwrap();
+        let plan = plan_issue_handoff(temp.path(), &issue(), "main").unwrap();
+        let runner = FakeRunner::default();
+
+        let result = prepare_issue_worktree(temp.path(), &plan, &runner).unwrap();
+
+        assert!(result.created);
+        assert_eq!(result.branch_name, plan.branch_name);
+        let commands = runner.commands.borrow().join("\n");
+        assert!(commands.contains("show-ref --verify --quiet"));
+        assert!(commands.contains("worktree add -b feature/issue-45"));
+    }
+
+    #[test]
+    fn refuses_existing_worktree_on_different_branch() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("workspaces");
+        let plan = plan_issue_handoff(&workspace_root, &issue(), "main").unwrap();
+        fs::create_dir_all(&plan.workspace_path).unwrap();
+        let runner = FakeRunner {
+            worktree_branch: Some("feature/issue-99-other".into()),
+            ..Default::default()
+        };
+
+        let error = prepare_issue_worktree(temp.path(), &plan, &runner).unwrap_err();
+
+        assert!(matches!(
+            error,
+            GitHandoffError::WorktreeBranchMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn reuses_existing_pull_request_after_push() {
+        let temp = tempfile::tempdir().unwrap();
+        let plan = plan_issue_handoff(temp.path(), &issue(), "main").unwrap();
+        let runner = FakeRunner {
+            existing_pr_url: Some("https://github.com/Alive24/jade-symphony/pull/45".into()),
+            ..Default::default()
+        };
+
+        let result = publish_issue_pull_request(&plan, &runner).unwrap();
+
+        assert!(result.branch_pushed);
+        assert!(!result.pr_created);
+        assert_eq!(
+            result.pr_url,
+            "https://github.com/Alive24/jade-symphony/pull/45"
+        );
+        let commands = runner.commands.borrow().join("\n");
+        assert!(commands.contains("git push -u origin"));
+        assert!(!commands.contains("gh pr create"));
+    }
+
+    #[test]
+    fn creates_pull_request_when_none_exists() {
+        let temp = tempfile::tempdir().unwrap();
+        let plan = plan_issue_handoff(temp.path(), &issue(), "main").unwrap();
+        let runner = FakeRunner::default();
+
+        let result = publish_issue_pull_request(&plan, &runner).unwrap();
+
+        assert!(result.branch_pushed);
+        assert!(result.pr_created);
+        assert_eq!(
+            result.pr_url,
+            "https://github.com/Alive24/jade-symphony/pull/99"
+        );
+        let commands = runner.commands.borrow().join("\n");
+        assert!(commands.contains("gh pr create"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod config;
 pub mod event_log;
+pub mod git_handoff;
 pub mod handoff;
 pub mod issue_forge;
 pub mod model;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,10 @@ use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum
 use jade_symphony::agent::backend_from_config;
 use jade_symphony::config::RuntimeConfig;
 use jade_symphony::event_log::{EventLog, EventRecord};
+use jade_symphony::git_handoff::{
+    prepare_issue_worktree, publish_issue_pull_request, LiveWorktreeResult,
+    ProcessHandoffCommandRunner, PullRequestPublication,
+};
 use jade_symphony::handoff::{plan_issue_handoff, HandoffError, IssueHandoffPlan};
 use jade_symphony::issue_forge::{
     discover_candidates, draft_from_template, find_issue_skill, interactive_forge,
@@ -630,6 +634,14 @@ struct IssueExecutionResult {
     success: bool,
     session_id: Option<String>,
     message: String,
+    live_handoff: Option<RunLoopLiveHandoff>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RunLoopLiveHandoff {
+    worktree: LiveWorktreeResult,
+    publication: PullRequestPublication,
+    verification: String,
 }
 
 fn execute_issue_once(
@@ -675,6 +687,7 @@ fn execute_issue_once_with_workspace_key(
         success: summary.success,
         session_id: summary.session_id,
         message: summary.message,
+        live_handoff: None,
     })
 }
 
@@ -820,12 +833,50 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             latest.identifier
         );
 
-        let result = execute_issue_once_with_workspace_key(
+        let live_worktree = if run_loop_live_handoff_enabled(&config) {
+            let runner = ProcessHandoffCommandRunner;
+            let repo_root = std::env::current_dir()?;
+            let worktree = prepare_issue_worktree(&repo_root, &handoff, &runner)?;
+            println!(
+                "run_loop_action=worktree issue={} workspace={} branch={} created={}",
+                latest.identifier,
+                worktree.workspace_path.display(),
+                worktree.branch_name,
+                worktree.created
+            );
+            Some(worktree)
+        } else {
+            None
+        };
+
+        let mut result = execute_issue_once_with_workspace_key(
             &workflow,
             &config,
             &latest,
             &handoff.workspace_key,
         )?;
+        if result.success {
+            if let Some(worktree) = live_worktree {
+                let runner = ProcessHandoffCommandRunner;
+                match publish_issue_pull_request(&handoff, &runner) {
+                    Ok(publication) => {
+                        println!(
+                            "run_loop_action=pr issue={} url={} created={}",
+                            latest.identifier, publication.pr_url, publication.pr_created
+                        );
+                        result.live_handoff = Some(RunLoopLiveHandoff {
+                            worktree,
+                            publication,
+                            verification: "skipped:not_configured".into(),
+                        });
+                    }
+                    Err(error) => {
+                        result.success = false;
+                        result.message = format!("handoff publication failed: {error}");
+                    }
+                }
+            }
+        }
         runtime_state = run_loop_runtime_state_with_result(runtime_state, &result);
         save_runtime_state(&config, &runtime_state)?;
         println!(
@@ -980,6 +1031,10 @@ fn run_loop_handoff_plan(
     plan_issue_handoff(&config.workspace.root, issue, DEFAULT_RUN_LOOP_BASE_BRANCH)
 }
 
+fn run_loop_live_handoff_enabled(config: &RuntimeConfig) -> bool {
+    config.tracker.kind == "github_project_v2" && config.tracker.fixture_path.is_none()
+}
+
 fn handle_run_loop_gate_failure(
     adapter: &dyn jade_symphony::tracker::TrackerAdapter,
     issue: &TrackerIssue,
@@ -1056,6 +1111,16 @@ fn print_run_loop_dry_run_actions(issue: &TrackerIssue, handoff: &IssueHandoffPl
         issue.identifier
     );
     println!(
+        "run_loop_dry_run action=worktree issue={} workspace={} branch={}",
+        issue.identifier,
+        handoff.workspace_path.display(),
+        handoff.branch_name
+    );
+    println!(
+        "run_loop_dry_run action=pr issue={} head={} base={}",
+        issue.identifier, handoff.branch_name, handoff.pull_request.base_branch
+    );
+    println!(
         "run_loop_dry_run action=workpad issue={} evidence=run_summary",
         issue.identifier
     );
@@ -1093,13 +1158,26 @@ fn run_loop_handoff_workpad(
         format!("- Branch: `{}`", handoff.branch_name),
         format!("- PR title: `{}`", handoff.pull_request.title),
         format!("- PR base branch: `{}`", handoff.pull_request.base_branch),
-        "- PR creation is planned evidence only in this slice.".to_string(),
+        live_handoff_workpad_line(result),
         String::new(),
         "### Main-Agent Boundary".to_string(),
         "- Locally complete main-agent work stops at `Agent Review`.".to_string(),
         "- `Human Review` is reserved for independent Review Agent pass evidence.".to_string(),
     ]
     .join("\n")
+}
+
+fn live_handoff_workpad_line(result: &IssueExecutionResult) -> String {
+    match &result.live_handoff {
+        Some(handoff) => format!(
+            "- Live PR: `{}` (created: `{}`, branch pushed: `{}`, verification: `{}`)",
+            handoff.publication.pr_url,
+            handoff.publication.pr_created,
+            handoff.publication.branch_pushed,
+            handoff.verification
+        ),
+        None => "- Live PR: `not-created`".to_string(),
+    }
 }
 
 fn run_loop_handoff_failure_workpad(issue: &TrackerIssue, error: &HandoffError) -> String {
@@ -2123,6 +2201,7 @@ mod tests {
             success: true,
             session_id: Some("session-29".into()),
             message: "ok".into(),
+            live_handoff: None,
         };
 
         let state = run_loop_runtime_state_with_result(state, &result);
@@ -2200,6 +2279,19 @@ mod tests {
             success: true,
             session_id: Some("session-33".into()),
             message: "ok".into(),
+            live_handoff: Some(RunLoopLiveHandoff {
+                worktree: LiveWorktreeResult {
+                    workspace_path: handoff.workspace_path.clone(),
+                    branch_name: handoff.branch_name.clone(),
+                    created: true,
+                },
+                publication: PullRequestPublication {
+                    branch_pushed: true,
+                    pr_url: "https://github.com/Alive24/jade-symphony/pull/45".into(),
+                    pr_created: true,
+                },
+                verification: "skipped:not_configured".into(),
+            }),
         };
 
         let workpad = run_loop_handoff_workpad(&issue, &result, &handoff);
@@ -2210,6 +2302,7 @@ mod tests {
         assert!(workpad
             .contains("Branch: `feature/issue-29-wire-runtime-state-persistence-into-run-loop`"));
         assert!(workpad.contains("PR title: `#29: Wire runtime state persistence into run-loop`"));
+        assert!(workpad.contains("Live PR: `https://github.com/Alive24/jade-symphony/pull/45`"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- adds a small `git_handoff` adapter around local `git` and `gh` subprocesses
- wires live non-fixture GitHub `run-loop --write` to create/reuse the planned issue worktree and branch before backend execution
- pushes the issue branch and creates or reuses one PR after successful backend execution
- records PR URL/branch evidence in the run-loop workpad while fixture/dry-run modes remain non-mutating

## Validation

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run`

## Notes

This keeps main-agent completion at `Agent Review`. Verification command modeling, cleanup, and deeper reconciliation remain documented follow-ups.
