### PR TITLE
#46: Add runtime supervision preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ one-issue-one-PR automation are still future work.
 - JSONL event-log primitives exist.
 - runtime state helpers can write, read, and clear a tracker-neutral
   `runtime/runtime-state.json` file under the configured logs root.
+- write-mode `run-loop` performs a resume preflight before claiming new work:
+  active runtime state must reconcile with tracker state, retry backoff is
+  honored, and stale active work is reported as stalled instead of being
+  silently overwritten.
 - write-mode `run-loop` saves active issue runtime state, updates it with
   backend result evidence, records final transition intent, and clears it after
   successful handoff/block transition.
@@ -192,11 +196,11 @@ claim reconciliation, resume state, and PR automation exist.
 
 - long-running worker supervision beyond idle polling in `run-loop`.
 - richer issue claiming, state transition, and reconciliation safety beyond the
-  current claim helper and runtime-state wiring.
-- full runtime-state resume reconciliation after interruption.
+  current claim helper and resume preflight.
+- full multi-worker runtime-state resume reconciliation after interruption.
 - workspace-per-issue branch and PR automation beyond current handoff planning
   and workpad evidence.
-- retry timers, continuation retries, and stall restart.
+- continuation retries and automated stall restart.
 - terminal workspace cleanup tied to tracker state.
 - live token/rate-limit accounting beyond the current snapshot counters.
 - persistent Agent Review worker supervision and reconciliation.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -16,11 +16,11 @@ yet.
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
-| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
+| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, resume preflight, retry backoff records, stall detection, and planned handoff evidence exists. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, review-freshness evidence for Merging conflict repair, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
-| Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
+| Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution; resume, retry, and stall supervision events are also recorded. No web/API surface yet. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
 
 ## Before Executing GitHub Project Issues
@@ -95,8 +95,9 @@ Project v2 issues:
      supervision is still pending.
    - claimed/running/retry state ownership.
    - Runtime state writes exist for claim/resume, backend result evidence, and
-     final transition intent; full resume reconciliation after interruption
-     remains pending.
+     final transition intent. Resume preflight now blocks conflicting stale
+     active state, honors retry backoff, and reports stalls; full multi-worker
+     reconciliation remains pending.
    - workspace/branch/PR handoff planning is recorded by `run-loop`, but the
      runtime still needs live worktree creation, branch checkout, push, PR
      creation, and PR link recording.
@@ -184,6 +185,9 @@ Acceptance:
   gaps.
 - uses the runtime state file model to resume active issue, workspace, branch,
   backend session, attempt count, last event, and last transition.
+- preserves the current resume preflight guarantees: stale active state must not
+  be overwritten, retry backoff must be visible, and stalled work must stop the
+  loop safely.
 
 ### 4. Implement Full Codex App-Server Backend
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use jade_symphony::agent::backend_from_config;
@@ -22,8 +22,9 @@ use jade_symphony::review::{
     ReviewFreshnessInput, ReviewJob, ReviewRequest, ReviewReworkClass, ReviewStaleReason,
 };
 use jade_symphony::runtime_state::{
-    clear_runtime_state, load_runtime_state, save_runtime_state, RuntimeIssueState, RuntimeState,
-    RuntimeTransition,
+    clear_runtime_state, detect_runtime_stall, load_runtime_state, mark_runtime_state_updated,
+    record_runtime_retry, save_runtime_state, RuntimeIssueState, RuntimeRetryState,
+    RuntimeStallState, RuntimeState, RuntimeTransition,
 };
 use jade_symphony::status_surface::render_snapshot;
 use jade_symphony::tracker::{
@@ -695,6 +696,73 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         let config = RuntimeConfig::from_workflow(&workflow, &options.workflow_path)?;
         config.validate()?;
         let adapter = adapter_from_config(&config);
+        if options.write {
+            let runtime_state = load_runtime_state(&config)?;
+            match run_loop_resume_preflight(
+                adapter.as_ref(),
+                &config,
+                runtime_state.as_ref(),
+                current_time_ms(),
+            )? {
+                ResumePreflightAction::Continue => {}
+                ResumePreflightAction::ClearCompleted { issue_identifier } => {
+                    clear_runtime_state(&config)?;
+                    println!(
+                        "run_loop_resume_preflight action=clear issue={} reason=tracker_state_terminal",
+                        issue_identifier
+                    );
+                }
+                ResumePreflightAction::RetryLater {
+                    issue_identifier,
+                    retry,
+                    due_in_ms,
+                } => {
+                    append_runtime_supervision_event(
+                        &config,
+                        runtime_state.as_ref(),
+                        "RetryDeferred",
+                        &format!(
+                            "issue={issue_identifier} attempt={} due_in_ms={} error={}",
+                            retry.attempt, due_in_ms, retry.error
+                        ),
+                    )?;
+                    println!(
+                        "run_loop=stopped reason=retry_backoff issue={} due_in_ms={} attempt={}",
+                        issue_identifier, due_in_ms, retry.attempt
+                    );
+                    break;
+                }
+                ResumePreflightAction::Stalled {
+                    issue_identifier,
+                    stall,
+                } => {
+                    append_runtime_supervision_event(
+                        &config,
+                        runtime_state.as_ref(),
+                        "RuntimeStalled",
+                        &format!(
+                            "issue={issue_identifier} stalled_for_ms={} reason={}",
+                            stall.stalled_for_ms, stall.reason
+                        ),
+                    )?;
+                    println!(
+                        "run_loop=stopped reason=runtime_stalled issue={} stalled_for_ms={}",
+                        issue_identifier, stall.stalled_for_ms
+                    );
+                    break;
+                }
+                ResumePreflightAction::Block { reason } => {
+                    append_runtime_supervision_event(
+                        &config,
+                        runtime_state.as_ref(),
+                        "ResumeBlocked",
+                        &reason,
+                    )?;
+                    println!("run_loop=stopped reason=resume_preflight_blocked detail={reason}");
+                    break;
+                }
+            }
+        }
         let issues = adapter.list_dispatchable_issues()?;
         let orchestrator = Orchestrator::new(config.clone());
         let mut plan = orchestrator.plan_dispatch(issues);
@@ -814,6 +882,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             &config.backend.kind,
             event,
         );
+        mark_runtime_state_updated(&mut runtime_state, current_time_ms());
         save_runtime_state(&config, &runtime_state)?;
         println!(
             "run_loop_runtime_state action=saved issue={} event={event}",
@@ -827,6 +896,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             &handoff.workspace_key,
         )?;
         runtime_state = run_loop_runtime_state_with_result(runtime_state, &result);
+        mark_runtime_state_updated(&mut runtime_state, current_time_ms());
         save_runtime_state(&config, &runtime_state)?;
         println!(
             "run_loop_runtime_state action=updated issue={} event={}",
@@ -847,6 +917,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
                 "agent_review",
                 "main agent completed",
             );
+            mark_runtime_state_updated(&mut runtime_state, current_time_ms());
             save_runtime_state(&config, &runtime_state)?;
             adapter.set_state(&latest.identifier, "agent_review")?;
             clear_runtime_state(&config)?;
@@ -855,19 +926,49 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
                 latest.identifier
             );
         } else {
-            runtime_state = run_loop_runtime_state_with_transition(
-                runtime_state,
-                Some(latest.state.clone()),
-                "need_human_input",
-                "backend run failed",
-            );
-            save_runtime_state(&config, &runtime_state)?;
-            adapter.set_state(&latest.identifier, "need_human_input")?;
-            clear_runtime_state(&config)?;
-            println!(
-                "run_loop_action=blocked issue={} target_state=need_human_input",
-                latest.identifier
-            );
+            let retry_delay_ms = Orchestrator::new(config.clone())
+                .retry_delay_ms(runtime_state.attempt_count, false);
+            if runtime_state.attempt_count < config.agent.max_turns {
+                record_runtime_retry(
+                    &mut runtime_state,
+                    current_time_ms(),
+                    retry_delay_ms,
+                    result.message.clone(),
+                );
+                save_runtime_state(&config, &runtime_state)?;
+                append_runtime_supervision_event(
+                    &config,
+                    Some(&runtime_state),
+                    "RetryScheduled",
+                    &format!(
+                        "issue={} attempt={} due_in_ms={} error={}",
+                        latest.identifier,
+                        runtime_state.attempt_count,
+                        retry_delay_ms,
+                        result.message
+                    ),
+                )?;
+                println!(
+                    "run_loop_action=retry_scheduled issue={} attempt={} due_in_ms={}",
+                    latest.identifier, runtime_state.attempt_count, retry_delay_ms
+                );
+                break;
+            } else {
+                runtime_state = run_loop_runtime_state_with_transition(
+                    runtime_state,
+                    Some(latest.state.clone()),
+                    "need_human_input",
+                    "backend run failed after retry limit",
+                );
+                mark_runtime_state_updated(&mut runtime_state, current_time_ms());
+                save_runtime_state(&config, &runtime_state)?;
+                adapter.set_state(&latest.identifier, "need_human_input")?;
+                clear_runtime_state(&config)?;
+                println!(
+                    "run_loop_action=blocked issue={} target_state=need_human_input",
+                    latest.identifier
+                );
+            }
         }
     }
 
@@ -887,6 +988,26 @@ enum RunLoopClaimAction {
     StopAndReplan { current_state: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ResumePreflightAction {
+    Continue,
+    ClearCompleted {
+        issue_identifier: String,
+    },
+    RetryLater {
+        issue_identifier: String,
+        retry: RuntimeRetryState,
+        due_in_ms: u64,
+    },
+    Stalled {
+        issue_identifier: String,
+        stall: RuntimeStallState,
+    },
+    Block {
+        reason: String,
+    },
+}
+
 fn run_loop_claim_action(issue: &TrackerIssue, config: &RuntimeConfig) -> RunLoopClaimAction {
     match claim_decision(issue, config) {
         ClaimDecision::Claimable => RunLoopClaimAction::Claim,
@@ -895,6 +1016,70 @@ fn run_loop_claim_action(issue: &TrackerIssue, config: &RuntimeConfig) -> RunLoo
             RunLoopClaimAction::StopAndReplan { current_state }
         }
     }
+}
+
+fn run_loop_resume_preflight(
+    adapter: &dyn jade_symphony::tracker::TrackerAdapter,
+    config: &RuntimeConfig,
+    state: Option<&RuntimeState>,
+    now_ms: u64,
+) -> Result<ResumePreflightAction, Box<dyn std::error::Error>> {
+    let Some(state) = state else {
+        return Ok(ResumePreflightAction::Continue);
+    };
+    let Some(active_issue) = state.active_issue.as_ref() else {
+        return Ok(ResumePreflightAction::Continue);
+    };
+
+    let Some(issue) = adapter.get_issue(&active_issue.identifier)? else {
+        return Ok(ResumePreflightAction::Block {
+            reason: format!(
+                "runtime state references missing issue {}",
+                active_issue.identifier
+            ),
+        });
+    };
+    let normalized_state = normalize_state(&issue.state);
+
+    if config
+        .terminal_state_set()
+        .iter()
+        .any(|state| state == &normalized_state)
+        || matches!(normalized_state.as_str(), "agent review" | "human review")
+    {
+        return Ok(ResumePreflightAction::ClearCompleted {
+            issue_identifier: active_issue.identifier.clone(),
+        });
+    }
+
+    if normalized_state != "in progress" {
+        return Ok(ResumePreflightAction::Block {
+            reason: format!(
+                "runtime state references {} but tracker state is {}",
+                active_issue.identifier, issue.state
+            ),
+        });
+    }
+
+    if let Some(retry) = state.retry.clone() {
+        let due_in_ms = retry.due_in_ms(now_ms);
+        if due_in_ms > 0 {
+            return Ok(ResumePreflightAction::RetryLater {
+                issue_identifier: active_issue.identifier.clone(),
+                retry,
+                due_in_ms,
+            });
+        }
+    }
+
+    if let Some(stall) = detect_runtime_stall(state, now_ms, config.codex.stall_timeout_ms) {
+        return Ok(ResumePreflightAction::Stalled {
+            issue_identifier: active_issue.identifier.clone(),
+            stall,
+        });
+    }
+
+    Ok(ResumePreflightAction::Continue)
 }
 
 fn no_dispatch_action(
@@ -911,6 +1096,31 @@ fn no_dispatch_action(
     NoDispatchAction::SleepAndContinue {
         delay_ms: poll_interval_ms,
     }
+}
+
+fn current_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn append_runtime_supervision_event(
+    config: &RuntimeConfig,
+    state: Option<&RuntimeState>,
+    event: &str,
+    message: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let log = EventLog::new(config.observability.logs_root.join("jade-symphony.jsonl"));
+    let active_issue = state.and_then(|state| state.active_issue.as_ref());
+    log.append(&EventRecord {
+        event: event.into(),
+        issue_id: active_issue.map(|issue| issue.id.clone()),
+        issue_identifier: active_issue.map(|issue| issue.identifier.clone()),
+        session_id: state.and_then(|state| state.backend_session_id.clone()),
+        message: message.into(),
+    })?;
+    Ok(())
 }
 
 fn run_loop_runtime_state_for_issue(
@@ -1839,6 +2049,7 @@ fn usage() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use jade_symphony::tracker::MemoryTracker;
 
     fn forge_contract() -> String {
         [
@@ -1895,6 +2106,18 @@ mod tests {
             created_at: None,
             updated_at: None,
         }
+    }
+
+    fn active_runtime_state(identifier: &str) -> RuntimeState {
+        let mut state = RuntimeState::active(
+            RuntimeIssueState {
+                id: "ISSUE_29".into(),
+                identifier: identifier.into(),
+            },
+            "dry-run",
+        );
+        state.updated_at_ms = Some(1_000);
+        state
     }
 
     #[test]
@@ -2090,6 +2313,80 @@ mod tests {
             run_loop_claim_action(&tracker_issue("Agent Review"), &config),
             RunLoopClaimAction::StopAndReplan {
                 current_state: "Agent Review".into()
+            }
+        );
+    }
+
+    #[test]
+    fn resume_preflight_continues_active_in_progress_state() {
+        let config = test_config();
+        let tracker = MemoryTracker::new(vec![tracker_issue("In Progress")]);
+        let state = active_runtime_state("#29");
+
+        let action = run_loop_resume_preflight(&tracker, &config, Some(&state), 2_000).unwrap();
+
+        assert_eq!(action, ResumePreflightAction::Continue);
+    }
+
+    #[test]
+    fn resume_preflight_blocks_conflicting_tracker_state() {
+        let config = test_config();
+        let tracker = MemoryTracker::new(vec![tracker_issue("Todo")]);
+        let state = active_runtime_state("#29");
+
+        let action = run_loop_resume_preflight(&tracker, &config, Some(&state), 2_000).unwrap();
+
+        assert!(matches!(action, ResumePreflightAction::Block { .. }));
+    }
+
+    #[test]
+    fn resume_preflight_defers_until_retry_is_due() {
+        let config = test_config();
+        let tracker = MemoryTracker::new(vec![tracker_issue("In Progress")]);
+        let mut state = active_runtime_state("#29");
+        record_runtime_retry(&mut state, 1_000, 5_000, "rate limited");
+
+        let action = run_loop_resume_preflight(&tracker, &config, Some(&state), 2_000).unwrap();
+
+        assert!(matches!(
+            action,
+            ResumePreflightAction::RetryLater {
+                due_in_ms: 4_000,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resume_preflight_detects_stalled_active_state() {
+        let config = test_config();
+        let tracker = MemoryTracker::new(vec![tracker_issue("In Progress")]);
+        let mut state = active_runtime_state("#29");
+        state.updated_at_ms = Some(1_000);
+
+        let action = run_loop_resume_preflight(
+            &tracker,
+            &config,
+            Some(&state),
+            config.codex.stall_timeout_ms + 2_000,
+        )
+        .unwrap();
+
+        assert!(matches!(action, ResumePreflightAction::Stalled { .. }));
+    }
+
+    #[test]
+    fn resume_preflight_clears_completed_tracker_state() {
+        let config = test_config();
+        let tracker = MemoryTracker::new(vec![tracker_issue("Agent Review")]);
+        let state = active_runtime_state("#29");
+
+        let action = run_loop_resume_preflight(&tracker, &config, Some(&state), 2_000).unwrap();
+
+        assert_eq!(
+            action,
+            ResumePreflightAction::ClearCompleted {
+                issue_identifier: "#29".into()
             }
         );
     }

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -16,6 +16,12 @@ pub struct RuntimeState {
     pub backend: String,
     pub backend_session_id: Option<String>,
     pub attempt_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry: Option<RuntimeRetryState>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stall: Option<RuntimeStallState>,
     pub last_event: Option<String>,
     pub last_transition: Option<RuntimeTransition>,
 }
@@ -29,6 +35,9 @@ impl RuntimeState {
             backend: backend.into(),
             backend_session_id: None,
             attempt_count: 1,
+            updated_at_ms: None,
+            retry: None,
+            stall: None,
             last_event: None,
             last_transition: None,
         }
@@ -46,6 +55,60 @@ pub struct RuntimeTransition {
     pub from: Option<String>,
     pub to: String,
     pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeRetryState {
+    pub attempt: u32,
+    pub scheduled_at_ms: u64,
+    pub next_retry_at_ms: u64,
+    pub error: String,
+}
+
+impl RuntimeRetryState {
+    pub fn due_in_ms(&self, now_ms: u64) -> u64 {
+        self.next_retry_at_ms.saturating_sub(now_ms)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeStallState {
+    pub detected_at_ms: u64,
+    pub stalled_for_ms: u64,
+    pub reason: String,
+}
+
+pub fn mark_runtime_state_updated(state: &mut RuntimeState, now_ms: u64) {
+    state.updated_at_ms = Some(now_ms);
+}
+
+pub fn record_runtime_retry(
+    state: &mut RuntimeState,
+    now_ms: u64,
+    delay_ms: u64,
+    error: impl Into<String>,
+) {
+    state.retry = Some(RuntimeRetryState {
+        attempt: state.attempt_count,
+        scheduled_at_ms: now_ms,
+        next_retry_at_ms: now_ms.saturating_add(delay_ms),
+        error: error.into(),
+    });
+    mark_runtime_state_updated(state, now_ms);
+}
+
+pub fn detect_runtime_stall(
+    state: &RuntimeState,
+    now_ms: u64,
+    stall_timeout_ms: u64,
+) -> Option<RuntimeStallState> {
+    let updated_at_ms = state.updated_at_ms?;
+    let stalled_for_ms = now_ms.saturating_sub(updated_at_ms);
+    (stall_timeout_ms > 0 && stalled_for_ms >= stall_timeout_ms).then(|| RuntimeStallState {
+        detected_at_ms: now_ms,
+        stalled_for_ms,
+        reason: format!("no runtime update for {stalled_for_ms}ms"),
+    })
 }
 
 #[derive(Debug, Error)]
@@ -142,6 +205,9 @@ mod tests {
             backend: "dry-run".into(),
             backend_session_id: Some("session".into()),
             attempt_count: 2,
+            updated_at_ms: Some(1_000),
+            retry: None,
+            stall: None,
             last_event: Some("Completed".into()),
             last_transition: Some(RuntimeTransition {
                 from: Some("In Progress".into()),
@@ -192,5 +258,29 @@ mod tests {
         clear_runtime_state_at_path(&path).unwrap();
 
         assert_eq!(load_runtime_state_from_path(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn retry_state_reports_due_in_ms() {
+        let retry = RuntimeRetryState {
+            attempt: 2,
+            scheduled_at_ms: 1_000,
+            next_retry_at_ms: 6_000,
+            error: "rate limited".into(),
+        };
+
+        assert_eq!(retry.due_in_ms(2_000), 4_000);
+        assert_eq!(retry.due_in_ms(7_000), 0);
+    }
+
+    #[test]
+    fn detects_stale_runtime_state_as_stall() {
+        let mut state = state();
+        state.updated_at_ms = Some(1_000);
+
+        let stall = detect_runtime_stall(&state, 7_000, 5_000).unwrap();
+
+        assert_eq!(stall.stalled_for_ms, 6_000);
+        assert!(stall.reason.contains("no runtime update"));
     }
 }


### PR DESCRIPTION
## Summary

- adds persisted retry and stall metadata to runtime state
- adds write-mode `run-loop` resume preflight before new dispatch
- blocks unsafe stale active state, honors retry backoff, and reports stalled active work
- records retry/resume supervision events in the JSONL event log
- updates docs to describe the current durable-runtime baseline honestly

## Validation

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Notes

This is a first supervision slice. It does not implement distributed workers, automated stall restart, or full multi-worker reconciliation.
