### PR TITLE
#47: Add source alignment quality gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ one-issue-one-PR automation are still future work.
   `In Progress`, and externally changed states.
 - dry-run dispatch planning sorts by priority and respects global/state
   concurrency limits.
-- Issue Quality Gate classifies executable versus underspecified issue bodies.
+- Issue Quality Gate classifies executable versus underspecified issue bodies
+  and, where workflow/repo context is available, runs deterministic
+  source-alignment checks for target repository, referenced local paths, and
+  verification command shapes.
 - review freshness helpers can classify Merging-to-Rework repairs as
   mechanical, semantic, or unknown and render workpad evidence for whether prior
   Human Review remains valid.
@@ -203,7 +206,7 @@ claim reconciliation, resume state, and PR automation exist.
 - Issue Forge Project field setup after issue creation.
 - autonomous Issue Forge issue creation from reflective mode without explicit
   operator confirmation.
-- automated Issue Quality Gate application inside the polling runtime.
+- richer semantic or LLM-assisted Issue Quality Gate analysis.
 - full Liquid-compatible prompt renderer.
 - credential-gated integration tests.
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -14,7 +14,7 @@ yet.
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
-| Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
+| Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies target repository, referenced local paths, and supported verification command shapes; richer semantic validation is still a follow-up. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
@@ -57,8 +57,8 @@ Project v2 issues:
    - Keep GitHub-specific fields out of `orchestrator`.
 - Current explicit `gate-apply` can record quality-gate assumptions or
   missing context in the workpad and move non-dispatchable issues to
-  `Need to Clarify` / `Need Human Input`; the future runtime must call that
-  flow automatically before dispatch.
+  `Need to Clarify` / `Need Human Input`; run-loop pre-dispatch uses the same
+  deterministic source-alignment decision before dispatch.
 
 4. Agent Review authority boundary.
    - Main implementation commands can move locally complete work to
@@ -184,6 +184,18 @@ Acceptance:
   gaps.
 - uses the runtime state file model to resume active issue, workspace, branch,
   backend session, attempt count, last event, and last transition.
+
+### 3b. Add LLM-Assisted Issue Quality Gate
+
+Goal: augment the deterministic source-alignment gate with optional local model
+review while preserving explainable, non-mutating defaults.
+
+Acceptance:
+
+- keeps deterministic checks as the first gate.
+- runs only when explicitly configured.
+- records model findings in the workpad.
+- routes missing or inconclusive model output to clarification, not dispatch.
 
 ### 4. Implement Full Codex App-Server Backend
 

--- a/examples/fixtures/source-alignment-issues.json
+++ b/examples/fixtures/source-alignment-issues.json
@@ -1,0 +1,44 @@
+[
+  {
+    "tracker_kind": "github_project_v2",
+    "id": "GHI_source_valid",
+    "item_id": "PVTI_source_valid",
+    "identifier": "#valid",
+    "title": "Valid source-aligned fixture",
+    "description": "## Issue Goal\n\nValidate a source-aligned issue.\n\n## Why Now\n\nThe gate needs deterministic fixture coverage.\n\n## Issue Context\n\nThis fixture references real repository paths and supported commands.\n\n## Decisions / Assumptions\n\n### Assumptions\n\n- Static checks are enough.\n\n## Non-Negotiable Guardrails\n\n- Keep this deterministic.\n\n## Scope\n\n### In Scope\n\n- Gate fixture.\n\n## Canonical References\n\n### Target Repository / Package\n\n- `Alive24/jade-symphony`\n\n### Relevant Knowledge Sources\n\n- `docs/dogfood-readiness.md`\n\n### Relevant Code Paths\n\n- `src/quality_gate.rs`\n\n## Verification\n\n### Completion Criteria\n\n- Gate passes.\n\n### Functional Verification\n\n- `cargo test`",
+    "url": "https://github.com/Alive24/jade-symphony/issues/1001",
+    "state": "Todo",
+    "labels": ["fixture"],
+    "assignees": ["codex"],
+    "priority": 1,
+    "branch_name": null,
+    "linked_pull_requests": [],
+    "blocked_by": [],
+    "project_fields": {
+      "Status": "Todo"
+    },
+    "created_at": "2026-05-13T01:00:00Z",
+    "updated_at": "2026-05-13T01:00:00Z"
+  },
+  {
+    "tracker_kind": "github_project_v2",
+    "id": "GHI_source_broken",
+    "item_id": "PVTI_source_broken",
+    "identifier": "#broken",
+    "title": "Broken source-aligned fixture",
+    "description": "## Issue Goal\n\nValidate a broken source-alignment issue.\n\n## Why Now\n\nThe gate needs deterministic failure coverage.\n\n## Issue Context\n\nThis fixture references missing repository paths and weak verification.\n\n## Decisions / Assumptions\n\n### Assumptions\n\n- Static checks are enough.\n\n## Non-Negotiable Guardrails\n\n- Keep this deterministic.\n\n## Scope\n\n### In Scope\n\n- Gate fixture.\n\n## Canonical References\n\n### Target Repository / Package\n\n- `Alive24/jade-symphony`\n\n### Relevant Knowledge Sources\n\n- `docs/missing-source-alignment.md`\n\n### Relevant Code Paths\n\n- `src/missing_source_alignment.rs`\n\n## Verification\n\n### Completion Criteria\n\n- Gate fails.\n\n### Functional Verification\n\n- manually inspect",
+    "url": "https://github.com/Alive24/jade-symphony/issues/1002",
+    "state": "Todo",
+    "labels": ["fixture"],
+    "assignees": ["codex"],
+    "priority": 2,
+    "branch_name": null,
+    "linked_pull_requests": [],
+    "blocked_by": [],
+    "project_fields": {
+      "Status": "Todo"
+    },
+    "created_at": "2026-05-13T01:01:00Z",
+    "updated_at": "2026-05-13T01:01:00Z"
+  }
+]

--- a/examples/source-alignment-workflow.md
+++ b/examples/source-alignment-workflow.md
@@ -1,0 +1,17 @@
+---
+tracker:
+  kind: github_project_v2
+  owner: Alive24
+  repo: jade-symphony
+  project_owner: Alive24
+  project_number: 1
+  fixture_path: fixtures/source-alignment-issues.json
+  assignee_filter:
+    allow_unassigned: true
+workspace:
+  root: /tmp/jade-symphony-source-alignment-workspaces
+agent:
+  backend: dry-run
+---
+
+Source-alignment gate fixture workflow.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,13 @@ use jade_symphony::event_log::{EventLog, EventRecord};
 use jade_symphony::handoff::{plan_issue_handoff, HandoffError, IssueHandoffPlan};
 use jade_symphony::issue_forge::{
     discover_candidates, draft_from_template, find_issue_skill, interactive_forge,
-    reflective_candidates_from_context, repair_markdown, validate_markdown, InteractiveForgeInput,
+    next_clarification_question, reflective_candidates_from_context, repair_markdown,
+    validate_markdown, InteractiveForgeInput,
 };
 use jade_symphony::model::{normalize_state, GateDecision, GateDecisionKind, TrackerIssue};
 use jade_symphony::orchestrator::Orchestrator;
 use jade_symphony::prompt::render_prompt;
-use jade_symphony::quality_gate::evaluate_issue;
+use jade_symphony::quality_gate::evaluate_issue_with_source_alignment;
 use jade_symphony::review::{
     classify_review_freshness, render_review_freshness_workpad, render_review_workpad,
     review_gate_decision, transition_allowed_for_main_agent, transition_allowed_for_review_agent,
@@ -187,7 +188,7 @@ fn quality_gate(
     let issue = adapter
         .get_issue(&issue_ref)?
         .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
-    let decision = evaluate_issue(&issue);
+    let decision = evaluate_issue_for_current_source(&config, &issue)?;
 
     println!(
         "gate={:?} dispatchable={}",
@@ -215,6 +216,27 @@ fn quality_gate(
     }
 
     Ok(())
+}
+
+fn evaluate_issue_for_current_source(
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+) -> Result<GateDecision, Box<dyn std::error::Error>> {
+    let repo_root = std::env::current_dir()?;
+    let expected_target = expected_target_repository(config);
+    Ok(evaluate_issue_with_source_alignment(
+        issue,
+        &repo_root,
+        expected_target.as_deref(),
+    ))
+}
+
+fn expected_target_repository(config: &RuntimeConfig) -> Option<String> {
+    Some(format!(
+        "{}/{}",
+        config.tracker.owner.as_ref()?,
+        config.tracker.repo.as_ref()?
+    ))
 }
 
 fn set_state(
@@ -282,12 +304,14 @@ fn forge_create(
     write: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     require_write_intent(write)?;
-    let report = validate_forge_create_contract(&title, &markdown).inspect_err(|_message| {
-        let report = validate_markdown(&title, &markdown);
-        print_forge_validation(&report);
-    })?;
-
     let config = load_config(&workflow_path)?;
+    let report =
+        validate_forge_create_contract(&title, &markdown, &config).inspect_err(|_message| {
+            let report = validate_forge_create_report(&title, &markdown, &config)
+                .unwrap_or_else(|_| validate_markdown(&title, &markdown));
+            print_forge_validation(&report);
+        })?;
+
     let adapter = adapter_from_config(&config);
     let issue_id = adapter.create_follow_up_issue(FollowUpIssueInput {
         title: report.title,
@@ -375,13 +399,47 @@ fn forge_reflect(
 fn validate_forge_create_contract(
     title: &str,
     markdown: &str,
+    config: &RuntimeConfig,
 ) -> Result<jade_symphony::issue_forge::ForgeValidationReport, String> {
-    let report = validate_markdown(title, markdown);
+    let report = validate_forge_create_report(title, markdown, config)
+        .map_err(|error| format!("source alignment failed: {error}"))?;
     if report.decision.is_dispatchable() {
         Ok(report)
     } else {
         Err("issue forge validation failed; tracker issue was not created".into())
     }
+}
+
+fn validate_forge_create_report(
+    title: &str,
+    markdown: &str,
+    config: &RuntimeConfig,
+) -> Result<jade_symphony::issue_forge::ForgeValidationReport, Box<dyn std::error::Error>> {
+    let issue = TrackerIssue {
+        tracker_kind: config.tracker.kind.clone(),
+        id: "forge-draft".into(),
+        item_id: None,
+        identifier: "#draft".into(),
+        title: title.into(),
+        description: Some(markdown.into()),
+        url: None,
+        state: config.tracker.state_map.todo.clone(),
+        labels: Vec::new(),
+        assignees: Vec::new(),
+        priority: None,
+        branch_name: None,
+        linked_pull_requests: Vec::new(),
+        blocked_by: Vec::new(),
+        project_fields: Default::default(),
+        created_at: None,
+        updated_at: None,
+    };
+    let decision = evaluate_issue_for_current_source(config, &issue)?;
+    Ok(jade_symphony::issue_forge::ForgeValidationReport {
+        title: title.to_string(),
+        question: next_clarification_question(&decision),
+        decision,
+    })
 }
 
 fn add_to_project(
@@ -570,7 +628,7 @@ fn inspect(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
 
     println!("issues={}", issues.len());
     for issue in issues {
-        let gate = evaluate_issue(&issue);
+        let gate = evaluate_issue_for_current_source(&config, &issue)?;
         println!(
             "- {} {} state={} gate={:?}",
             issue.identifier, issue.title, issue.state, gate.kind
@@ -726,7 +784,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        let decision = evaluate_issue(&issue);
+        let decision = evaluate_issue_for_current_source(&config, &issue)?;
         if !decision.is_dispatchable() {
             handle_run_loop_gate_failure(adapter.as_ref(), &issue, &decision, &options)?;
             continue;
@@ -762,7 +820,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         let latest = adapter
             .get_issue(&issue.identifier)?
             .ok_or_else(|| format!("issue disappeared before claim: {}", issue.identifier))?;
-        let latest_gate = evaluate_issue(&latest);
+        let latest_gate = evaluate_issue_for_current_source(&config, &latest)?;
         if !latest_gate.is_dispatchable() {
             handle_run_loop_gate_failure(adapter.as_ref(), &latest, &latest_gate, &options)?;
             continue;
@@ -1858,6 +1916,8 @@ mod tests {
             "## Verification",
             "### Completion Criteria",
             "- Pass.",
+            "### Functional Verification",
+            "- `cargo test`",
         ]
         .join("\n")
     }
@@ -2315,9 +2375,11 @@ mod tests {
 
     #[test]
     fn validates_forge_create_contract_before_tracker_write() {
-        assert!(validate_forge_create_contract("Create issue", &forge_contract()).is_ok());
+        let config = test_config();
+        assert!(validate_forge_create_contract("Create issue", &forge_contract(), &config).is_ok());
 
-        let error = validate_forge_create_contract("Thin issue", "make it better").unwrap_err();
+        let error =
+            validate_forge_create_contract("Thin issue", "make it better", &config).unwrap_err();
         assert!(error.contains("tracker issue was not created"));
     }
 

--- a/src/quality_gate.rs
+++ b/src/quality_gate.rs
@@ -1,3 +1,5 @@
+use std::path::{Path, PathBuf};
+
 use crate::model::{GateDecision, GateDecisionKind, TrackerIssue};
 
 const REQUIRED_SECTIONS: &[(&str, &str)] = &[
@@ -60,6 +62,64 @@ pub fn evaluate_issue(issue: &TrackerIssue) -> GateDecision {
     }
 }
 
+pub fn evaluate_issue_with_source_alignment(
+    issue: &TrackerIssue,
+    repo_root: &Path,
+    expected_target_repo: Option<&str>,
+) -> GateDecision {
+    let mut decision = evaluate_issue(issue);
+    if !decision.is_dispatchable() {
+        return decision;
+    }
+
+    let description = issue.description.as_deref().unwrap_or_default();
+    let mut missing = Vec::new();
+    let mut notes = Vec::new();
+
+    if let Some(expected) = expected_target_repo {
+        match first_bullet_in_section(description, "Target Repository / Package") {
+            Some(actual) if normalize_target_repo(&actual) == normalize_target_repo(expected) => {}
+            Some(actual) => missing.push(format!(
+                "target repository mismatch: expected `{expected}`, found `{actual}`"
+            )),
+            None => missing.push("target repository bullet".into()),
+        }
+    }
+
+    for path in referenced_paths(description) {
+        if !repo_root.join(&path).exists() {
+            missing.push(format!("referenced path missing: `{}`", path.display()));
+        }
+    }
+
+    let commands = verification_commands(description);
+    if commands.is_empty() {
+        missing.push("verification command".into());
+    } else {
+        for command in commands {
+            if !is_supported_verification_command(&command) {
+                missing.push(format!("unsupported verification command: `{command}`"));
+            }
+        }
+    }
+
+    if missing.is_empty() {
+        notes.push("Source alignment preflight passed.".into());
+        decision.notes.extend(notes);
+        decision
+    } else {
+        GateDecision {
+            kind: GateDecisionKind::NeedToClarify,
+            missing,
+            assumptions: decision.assumptions,
+            notes: vec![
+                "Source alignment preflight found missing or unsupported repository context."
+                    .into(),
+            ],
+        }
+    }
+}
+
 fn has_explicit_blocked_decision(markdown: &str) -> bool {
     markdown.lines().any(|line| {
         let normalized = line.trim().trim_start_matches('-').trim().to_lowercase();
@@ -101,6 +161,115 @@ fn extract_assumptions(markdown: &str) -> Vec<String> {
     }
 
     assumptions
+}
+
+fn first_bullet_in_section(markdown: &str, heading: &str) -> Option<String> {
+    section_lines(markdown, heading)
+        .into_iter()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix('-')
+                .map(clean_markdown_value)
+                .filter(|value| !value.is_empty())
+        })
+}
+
+fn referenced_paths(markdown: &str) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for heading in ["Relevant Knowledge Sources", "Relevant Code Paths"] {
+        for line in section_lines(markdown, heading) {
+            let Some(raw) = line.trim().strip_prefix('-') else {
+                continue;
+            };
+            let value = clean_markdown_value(raw);
+            if is_local_reference(&value) {
+                paths.push(PathBuf::from(value));
+            }
+        }
+    }
+    paths
+}
+
+fn verification_commands(markdown: &str) -> Vec<String> {
+    section_lines(markdown, "Functional Verification")
+        .into_iter()
+        .filter_map(|line| {
+            line.trim()
+                .strip_prefix('-')
+                .map(clean_markdown_value)
+                .filter(|value| looks_like_command(value))
+        })
+        .collect()
+}
+
+fn section_lines(markdown: &str, heading: &str) -> Vec<String> {
+    let mut in_section = false;
+    let mut lines = Vec::new();
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        let normalized_heading = trimmed.trim_start_matches('#').trim();
+        if normalized_heading.eq_ignore_ascii_case(heading) {
+            in_section = true;
+            continue;
+        }
+        if in_section && trimmed.starts_with('#') {
+            break;
+        }
+        if in_section {
+            lines.push(line.to_string());
+        }
+    }
+    lines
+}
+
+fn clean_markdown_value(raw: &str) -> String {
+    raw.trim()
+        .trim_matches('`')
+        .trim()
+        .trim_end_matches('.')
+        .to_string()
+}
+
+fn normalize_target_repo(value: &str) -> String {
+    clean_markdown_value(value)
+        .trim_start_matches("https://github.com/")
+        .trim_start_matches("github.com/")
+        .trim_matches('`')
+        .to_ascii_lowercase()
+}
+
+fn is_local_reference(value: &str) -> bool {
+    !value.starts_with("http://")
+        && !value.starts_with("https://")
+        && !value.starts_with('$')
+        && (value.contains('/')
+            || value.starts_with("Cargo.")
+            || value == "README.md"
+            || value.ends_with(".rs")
+            || value.ends_with(".md"))
+}
+
+fn looks_like_command(value: &str) -> bool {
+    matches!(
+        value.split_whitespace().next(),
+        Some("cargo" | "gh" | "git" | "pnpm" | "npm" | "node")
+    )
+}
+
+fn is_supported_verification_command(command: &str) -> bool {
+    let parts: Vec<_> = command.split_whitespace().collect();
+    matches!(
+        parts.as_slice(),
+        ["cargo", "test"]
+            | ["cargo", "fmt", "--check"]
+            | ["cargo", "clippy", ..]
+            | ["cargo", "run", ..]
+            | ["gh", ..]
+            | ["git", ..]
+            | ["pnpm", ..]
+            | ["npm", ..]
+            | ["node", ..]
+    )
 }
 
 #[cfg(test)]
@@ -215,5 +384,137 @@ mod tests {
 
         let decision = evaluate_issue(&issue(Some(body)));
         assert_eq!(decision.kind, GateDecisionKind::Blocked);
+    }
+
+    #[test]
+    fn source_alignment_accepts_existing_paths_and_supported_commands() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("src")).unwrap();
+        std::fs::write(temp.path().join("src/main.rs"), "").unwrap();
+        std::fs::create_dir_all(temp.path().join("docs")).unwrap();
+        std::fs::write(temp.path().join("docs/dogfood-readiness.md"), "").unwrap();
+        let body = aligned_body(
+            "Alive24/jade-symphony",
+            &["docs/dogfood-readiness.md"],
+            &["src/main.rs"],
+            &["cargo test", "cargo fmt --check"],
+        );
+
+        let decision = evaluate_issue_with_source_alignment(
+            &issue(Some(body)),
+            temp.path(),
+            Some("Alive24/jade-symphony"),
+        );
+
+        assert!(decision.is_dispatchable());
+        assert!(decision
+            .notes
+            .contains(&"Source alignment preflight passed.".to_string()));
+    }
+
+    #[test]
+    fn source_alignment_reports_missing_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let body = aligned_body(
+            "Alive24/jade-symphony",
+            &["docs/missing.md"],
+            &["src/main.rs"],
+            &["cargo test"],
+        );
+
+        let decision = evaluate_issue_with_source_alignment(
+            &issue(Some(body)),
+            temp.path(),
+            Some("Alive24/jade-symphony"),
+        );
+
+        assert_eq!(decision.kind, GateDecisionKind::NeedToClarify);
+        assert!(decision
+            .missing
+            .iter()
+            .any(|item| item.contains("referenced path missing")));
+    }
+
+    #[test]
+    fn source_alignment_reports_target_repo_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let body = aligned_body("Other/repo", &[], &[], &["cargo test"]);
+
+        let decision = evaluate_issue_with_source_alignment(
+            &issue(Some(body)),
+            temp.path(),
+            Some("Alive24/jade-symphony"),
+        );
+
+        assert_eq!(decision.kind, GateDecisionKind::NeedToClarify);
+        assert!(decision
+            .missing
+            .iter()
+            .any(|item| item.contains("target repository mismatch")));
+    }
+
+    #[test]
+    fn source_alignment_reports_weak_verification() {
+        let temp = tempfile::tempdir().unwrap();
+        let body = aligned_body("Alive24/jade-symphony", &[], &[], &["manually inspect"]);
+
+        let decision = evaluate_issue_with_source_alignment(
+            &issue(Some(body)),
+            temp.path(),
+            Some("Alive24/jade-symphony"),
+        );
+
+        assert_eq!(decision.kind, GateDecisionKind::NeedToClarify);
+        assert!(decision
+            .missing
+            .iter()
+            .any(|item| item == "verification command"));
+    }
+
+    fn aligned_body(target_repo: &str, docs: &[&str], paths: &[&str], commands: &[&str]) -> String {
+        let docs = docs
+            .iter()
+            .map(|path| format!("- `{path}`"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let paths = paths
+            .iter()
+            .map(|path| format!("- `{path}`"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let commands = commands
+            .iter()
+            .map(|command| format!("- `{command}`"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        [
+            "## Issue Goal",
+            "Ship a thing.",
+            "## Why Now",
+            "Now.",
+            "## Issue Context",
+            "Context.",
+            "## Decisions / Assumptions",
+            "### Assumptions",
+            "- Deterministic source checks are enough.",
+            "## Non-Negotiable Guardrails",
+            "- Guard.",
+            "## Scope",
+            "### In Scope",
+            "- Code.",
+            "## Canonical References",
+            "### Target Repository / Package",
+            &format!("- `{target_repo}`"),
+            "### Relevant Knowledge Sources",
+            &docs,
+            "### Relevant Code Paths",
+            &paths,
+            "## Verification",
+            "### Completion Criteria",
+            "- Pass.",
+            "### Functional Verification",
+            &commands,
+        ]
+        .join("\n")
     }
 }


### PR DESCRIPTION
## Summary

- adds deterministic source-alignment checks beside the existing issue heading gate
- verifies target repository, referenced local docs/code paths, and supported verification command shapes
- wires the stronger gate into `gate`, `gate-apply`, `forge-create`, and run-loop pre-dispatch
- adds valid/broken fixture issues and workflow for credential-free gate smoke tests
- updates README and dogfood readiness docs

## Validation

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- gate examples/source-alignment-workflow.md '#valid'`
- `cargo run -- gate examples/source-alignment-workflow.md '#broken'`

## Notes

This remains deterministic and non-LLM-based. Rich semantic validation stays as a follow-up.
