### PR TITLE
#48: Replace dogfood workflow prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The repo currently proves the core shape and has a small operator CLI: workflow
 parsing, typed config, normalized tracker issues, fixture-backed and `gh`-backed
 read-only GitHub Project v2 issue loading, dispatch planning, quality-gate
 checks, backend abstractions, workspace safety helpers, event-log primitives,
-and an operator-readable status snapshot with event-log and integration-gap
-links.
+an operator-readable status snapshot with event-log and integration-gap links,
+and a real dogfood workflow prompt for GitHub Project v2 runs.
 
 It does **not** yet fully autonomously execute GitHub Project v2 issues,
 run Codex/Claude through the final app-server flow, or supervise long-running
@@ -57,6 +57,9 @@ one-issue-one-PR automation are still future work.
   creating tracker issues.
 - basic strict prompt rendering supports known `issue.*` fields, `attempt`, and
   simple `{% if %}` / `{% else %}` blocks.
+- `examples/github-project-workflow.md` now contains an inline Jade execution
+  prompt with the operating loop, workpad discipline, review boundary, stop
+  conditions, and one issue / one branch / one PR handoff rules.
 - workspace identifiers are sanitized; local workspace paths stay under the
   configured root; hooks support timeouts, stdout/stderr capture,
   `before_remove`, and safe cleanup helpers.
@@ -175,6 +178,12 @@ These commands are adapter operations plus the first runtime-loop
 skeleton, not full autonomous orchestration. Use write mode carefully until
 claim reconciliation, resume state, and PR automation exist.
 
+The live GitHub Project workflow template includes the actual Jade operating
+prompt used for dogfooding. It is intentionally more than tracker config: the
+rendered prompt embeds the issue body, quality-gate expectation, workpad
+requirements, main-agent `Agent Review` boundary, Review Agent boundary, and
+Merging role separation.
+
 ## Stubbed
 
 - linked PR attachment/linking as a first-class relationship.
@@ -254,7 +263,9 @@ For a real GitHub Project v2 read/write workflow template, copy and edit:
 - `examples/github-project-workflow.md`
 
 Update `owner`, `repo`, `project_owner`, `project_number`, and `state_map` before
-using it with a live project.
+using it with a live project. The prompt body is the current Jade dogfood
+operator prompt; keep it aligned with `docs/bootstrap/JADE_WORKFLOW.md` when
+the workflow contract changes.
 
 ## Bootstrap Sources
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -2,7 +2,8 @@
 
 Status: dry-run dogfood baseline with read-only GitHub Project v2 loading through
 the `gh` CLI and a `run-loop` skeleton that can idle-poll in unbounded write
-mode. Jade Symphony is not ready for unattended live GitHub Project v2 execution
+mode. The live GitHub Project workflow now carries a real Jade operating prompt,
+but Jade Symphony is not ready for unattended live GitHub Project v2 execution
 yet.
 
 ## Current Capability Status
@@ -10,6 +11,7 @@ yet.
 | Capability | Current Status |
 | --- | --- |
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. Runtime reload is not implemented. |
+| Dogfood workflow prompt | `examples/github-project-workflow.md` includes the Jade operating loop, issue quality gate expectation, workpad discipline, role boundaries, stop conditions, and one issue / one branch / one PR handoff rules. Tests guard against reverting to a placeholder-thin prompt. |
 | Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
@@ -82,6 +84,11 @@ Project v2 issues:
    - Preserve fixture mode for credential-free development.
 
 6. Live agent execution.
+   - The live dogfood workflow prompt now embeds enough Jade protocol for an
+     isolated backend agent to understand the issue work cycle, workpad, review
+     boundary, and stop conditions.
+   - Keep the prompt aligned with `docs/bootstrap/JADE_WORKFLOW.md` as the
+     bootstrap contract evolves.
    - Harden the Codex and Claude Code subprocess backends, then implement full
      protocol transports.
    - Keep Claude Code as a peer backend path.
@@ -316,7 +323,8 @@ GitHub Project v2 execution is hardened.
 
 `examples/github-project-workflow.md` is a non-fixture workflow template for
 manual live Project v2 reads and explicit tracker writes through `gh`. It still
-uses the `dry-run` backend by default. `run-loop --write` is available only as a
-bounded runtime skeleton and should not be treated as full autonomous agent
-execution until claim reconciliation, full runtime resume reconciliation, and
-live PR automation wiring exist.
+uses the `dry-run` backend by default, but the prompt body is now the real Jade
+dogfood operating prompt rather than a placeholder. `run-loop --write` is
+available only as a bounded runtime skeleton and should not be treated as full
+autonomous agent execution until claim reconciliation, full runtime resume
+reconciliation, and live PR automation wiring exist.

--- a/examples/github-project-workflow.md
+++ b/examples/github-project-workflow.md
@@ -58,6 +58,118 @@ You are working on Jade Symphony issue {{ issue.identifier }}.
 
 Title: {{ issue.title }}
 State: {{ issue.state }}
+{% if issue.url %}
+URL: {{ issue.url }}
+{% endif %}
 
-Read the issue contract, respect the Jade bootstrap guardrails, and stop before
-making live agent changes unless the operator explicitly moves beyond dry-run.
+{% if attempt %}
+This is attempt {{ attempt }}. Resume from the existing issue workspace and
+preserve prior evidence unless it is stale or incorrect.
+{% endif %}
+
+## Mission
+
+You are the main implementation agent for Jade Symphony. Use GitHub Project v2
+project #9 as the tracker state machine and implement the current issue exactly
+as contracted. Jade Symphony is orchestration infrastructure, not downstream
+product business logic.
+
+Read these canonical sources before changing code:
+
+- `docs/bootstrap/JADE_WORKFLOW.md`
+- `docs/bootstrap/JADE_SYMPHONY_SPEC.md`
+- `docs/bootstrap/TRACKER_GITHUB_PROJECT_V2.md`
+- `docs/bootstrap/ISSUE_QUALITY_GATE_TEMPLATE.md`
+- the current issue body and its Jade Symphony workpad
+
+Also consult the official reference tree when a protocol capability is in
+question, but do not edit files under
+`docs/bootstrap/references/openai-symphony`.
+
+## Current Issue Contract
+
+{{ issue.description }}
+
+## Operating Loop
+
+1. Refresh tracker state, linked PR state, local git state, and any existing
+   issue workpad before implementation.
+2. Confirm the issue is still executable with the Issue Quality Gate. If the
+   issue is not executable, leave a precise workpad note, move it to
+   `Need to Clarify`, and stop this issue.
+3. Work in exactly one isolated workspace and branch for this issue. Do not mix
+   unrelated issue scopes in this branch or PR.
+4. Capture a short implementation plan in the workpad before significant edits.
+5. Implement only the accepted issue scope. Keep tracker, backend,
+   observability, Issue Forge, quality gate, and review boundaries normalized
+   and traceable to the bootstrap docs.
+6. Run the verification required by the issue. Repair failures that are within
+   scope, then rerun the relevant checks.
+7. Update the workpad with context, decisions or assumptions, changed surfaces,
+   verification evidence, and handoff notes.
+8. Open or update exactly one PR for this issue with concise validation
+   evidence.
+9. Move locally complete main-agent work to `Agent Review` only.
+10. Return to tracker selection only after this issue has a PR/workpad handoff
+    or a documented blocked state.
+
+## State And Role Boundaries
+
+- `Todo` and `Rework` are claimable only after the quality gate passes.
+- `In Progress` means the main implementation agent is actively working or
+  safely resuming the issue.
+- `Need to Clarify` is for an issue contract that cannot be executed.
+- `Need Human Input` is for missing decisions, credentials, destructive
+  approval, unavailable external services with no safe fallback, or locally
+  undiagnosable verification failure.
+- `Agent Review` is the main-agent completion target.
+- The main implementation agent must never set `Human Review`.
+- The independent Review Agent may set `Human Review` only after async review
+  passes and evidence is recorded.
+- Confirmed review findings go to `Rework`.
+- Failed, timed out, inconclusive, or unavailable review must not set
+  `Human Review`.
+- `Merging` is a separate land flow for PRs already approved by the review and
+  human gates. Do not merge from the implementation role.
+
+## Workpad Discipline
+
+Use the configured workpad marker and keep durable evidence in the issue
+workpad. Record:
+
+- environment and workspace path.
+- issue status and linked PR status at start.
+- quality gate result and assumptions.
+- plan and changed files.
+- verification commands and results.
+- PR URL and handoff summary.
+- any blocker and the exact next human or agent action needed.
+
+## Git And PR Discipline
+
+- Base the issue branch on the current `origin/main` unless the issue says
+  otherwise.
+- Use a branch name that includes the issue number.
+- Keep one issue per branch and one branch per PR.
+- Do not rewrite or revert unrelated user changes.
+- If the branch or worktree appears to belong to another issue, stop and move
+  to `Need Human Input` with evidence.
+- PR handoff must explain scope, validation, and the state boundary that main
+  work stops at `Agent Review`.
+
+## Stop Conditions
+
+Stop this issue and record evidence when:
+
+- no executable Todo, Rework, or resumable In Progress work remains.
+- the issue belongs in `Need to Clarify`.
+- the issue needs a human decision, credential, secret, destructive approval,
+  or external service with no safe fallback.
+- verification fails and cannot be locally diagnosed or repaired within scope.
+- continuing would require unrelated work, downstream product logic, or changing
+  files explicitly outside the issue contract.
+- the environment blocks required tracker/PR mutation and continuing would
+  violate the one issue / one branch / one PR rule.
+
+When locally complete, leave the issue in `Agent Review` with workpad and PR
+evidence. Do not set `Human Review`.

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -89,6 +89,8 @@ fn parse_front_matter(front_matter: &str) -> Result<Value, WorkflowError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::TrackerIssue;
+    use crate::prompt::render_prompt;
 
     #[test]
     fn parses_front_matter_and_prompt() {
@@ -107,5 +109,73 @@ mod tests {
         let workflow = WorkflowDefinition::parse("WORKFLOW.md", "Only prompt").unwrap();
         assert!(workflow.config.as_object().unwrap().is_empty());
         assert_eq!(workflow.prompt_template, "Only prompt");
+    }
+
+    fn fixture_issue() -> TrackerIssue {
+        TrackerIssue {
+            tracker_kind: "github_project_v2".into(),
+            id: "ISSUE_48".into(),
+            item_id: Some("PROJECT_ITEM_48".into()),
+            identifier: "#48".into(),
+            title: "Replace placeholder dogfood workflow with real Jade prompt".into(),
+            description: Some(
+                [
+                    "## Issue Goal",
+                    "Replace the placeholder live workflow prompt.",
+                    "## Verification",
+                    "- cargo test",
+                ]
+                .join("\n"),
+            ),
+            url: Some("https://github.com/Alive24/jade-symphony/issues/48".into()),
+            state: "Todo".into(),
+            labels: Vec::new(),
+            assignees: Vec::new(),
+            priority: None,
+            branch_name: None,
+            linked_pull_requests: Vec::new(),
+            blocked_by: Vec::new(),
+            project_fields: Default::default(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    fn github_project_workflow() -> WorkflowDefinition {
+        let path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/github-project-workflow.md");
+        WorkflowDefinition::load(path).unwrap()
+    }
+
+    #[test]
+    fn github_project_workflow_prompt_is_not_placeholder_thin() {
+        let workflow = github_project_workflow();
+
+        assert!(workflow.prompt_template.len() > 3_000);
+        assert!(workflow.prompt_template.contains("## Operating Loop"));
+        assert!(workflow.prompt_template.contains("## Workpad Discipline"));
+        assert!(workflow.prompt_template.contains("Issue Quality Gate"));
+        assert!(workflow.prompt_template.contains("one issue per branch"));
+        assert!(workflow
+            .prompt_template
+            .contains("The main implementation agent must never set `Human Review`."));
+        assert!(!workflow
+            .prompt_template
+            .contains("stop before\nmaking live agent changes"));
+    }
+
+    #[test]
+    fn github_project_workflow_prompt_renders_for_fixture_issue() {
+        let workflow = github_project_workflow();
+        let rendered = render_prompt(&workflow.prompt_template, &fixture_issue(), Some(2)).unwrap();
+
+        assert!(rendered.contains("Jade Symphony issue #48"));
+        assert!(rendered.contains("Replace placeholder dogfood workflow"));
+        assert!(rendered.contains("This is attempt 2."));
+        assert!(rendered.contains("## Issue Goal\nReplace the placeholder live workflow prompt."));
+        assert!(rendered.contains("Move locally complete main-agent work to `Agent Review` only."));
+        assert!(rendered.contains("Do not set `Human Review`."));
+        assert!(!rendered.contains("{{"));
+        assert!(!rendered.contains("{%"));
     }
 }


### PR DESCRIPTION
## Summary

- replaces the placeholder live GitHub Project workflow prompt with a concrete Jade operating prompt
- embeds the issue contract, quality-gate expectation, workpad discipline, role boundaries, stop conditions, and one issue / one branch / one PR rules
- adds tests that prevent the dogfood workflow from regressing to a placeholder-thin prompt and verify fixture rendering
- updates README and dogfood readiness docs to describe the current prompt capability honestly

## Validation

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- run-once examples/github-project-workflow.md`
- inspected `/private/tmp/jade-symphony-github-workspaces/_49/JADE_SYMPHONY_PROMPT.md` for Jade workflow essentials

## Handoff

Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #48
