### PR TITLE
#50: Add evidence-first Rework diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ one-issue-one-PR automation are still future work.
 - review freshness helpers can classify Merging-to-Rework repairs as
   mechanical, semantic, or unknown and render workpad evidence for whether prior
   Human Review remains valid.
+- structured Rework diagnostics can render compact, durable issue workpad
+  evidence for confirmed review findings, merge conflicts, dirty PRs,
+  validation failures, and runtime failures before a transition to `Rework`.
 - Issue Forge can discover local candidates from intent, ask one focused
   clarification question, draft from the quality template, validate Markdown,
   repair rough Markdown into an executable issue contract shape, and create a
@@ -171,6 +174,10 @@ implementation agent to set `Human Review`. Mechanical conflict repair can
 preserve prior Human Review evidence for an authorized merge/handoff flow;
 semantic or unknown rework requires the normal Agent Review and Human Review
 path.
+Confirmed Review Agent findings now route through an evidence-first Rework
+diagnostic path: Jade Symphony writes the structured diagnostic workpad before
+setting `Rework`, and it does not change state if the durable workpad write
+fails.
 These commands are adapter operations plus the first runtime-loop
 skeleton, not full autonomous orchestration. Use write mode carefully until
 claim reconciliation, resume state, and PR automation exist.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -19,7 +19,7 @@ yet.
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
-| Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, review-freshness evidence for Merging conflict repair, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
+| Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings, review-freshness evidence for Merging conflict repair, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
 
@@ -72,6 +72,9 @@ Project v2 issues:
      preserving prior Human Review. Mechanical conflict repair can preserve
      prior Human Review for an authorized merge/handoff flow; semantic or
      unknown rework requires the normal Agent Review and Human Review path.
+   - Rework transitions should remain evidence-first: write compact structured
+     diagnostics to the canonical issue workpad before setting `Rework`; if the
+     diagnostic write fails, stop before changing state.
 
 5. Linear integration hardening.
    - Add credential-gated live smoke tests for reads, state updates, and workpad

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod orchestrator;
 pub mod prompt;
 pub mod quality_gate;
 pub mod review;
+pub mod rework;
 pub mod runtime_state;
 pub mod status_surface;
 pub mod tracker;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,13 +21,17 @@ use jade_symphony::review::{
     FakeReviewBackend, FakeReviewOutcome, GeminiCliReviewBackend, ReviewBackend,
     ReviewFreshnessInput, ReviewJob, ReviewRequest, ReviewReworkClass, ReviewStaleReason,
 };
+use jade_symphony::rework::{
+    render_rework_diagnostic_workpad, rework_diagnostic_from_review, rework_transition_expected,
+    ReworkDiagnostic,
+};
 use jade_symphony::runtime_state::{
     clear_runtime_state, load_runtime_state, save_runtime_state, RuntimeIssueState, RuntimeState,
     RuntimeTransition,
 };
 use jade_symphony::status_surface::render_snapshot;
 use jade_symphony::tracker::{
-    adapter_from_config, claim_decision, ClaimDecision, FollowUpIssueInput,
+    adapter_from_config, claim_decision, ClaimDecision, FollowUpIssueInput, TrackerAdapter,
 };
 use jade_symphony::workflow::WorkflowDefinition;
 use jade_symphony::workspace::{prepare_workspace, run_after_run, run_before_run};
@@ -513,21 +517,39 @@ fn review_freshness(input: ReviewFreshnessInput) -> Result<(), Box<dyn std::erro
 }
 
 fn apply_review_result(
-    adapter: &dyn jade_symphony::tracker::TrackerAdapter,
+    adapter: &dyn TrackerAdapter,
     issue_ref: &str,
     issue: &TrackerIssue,
     job: &jade_symphony::review::ReviewJob,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let decision = review_gate_decision(job);
-    let workpad = render_review_workpad(issue, job);
-
-    adapter.upsert_workpad(issue_ref, &workpad)?;
     if let Some(target_state) = decision.target_state {
         if !transition_allowed_for_review_agent(target_state, &decision) {
             return Err("review agent transition is not allowed for this review decision".into());
         }
+        if rework_transition_expected(&decision) {
+            let diagnostic = rework_diagnostic_from_review(issue, job, &decision);
+            transition_issue_to_rework_with_diagnostic(adapter, issue, &diagnostic)?;
+            return Ok(());
+        }
+    }
+
+    let workpad = render_review_workpad(issue, job);
+    adapter.upsert_workpad(issue_ref, &workpad)?;
+    if let Some(target_state) = decision.target_state {
         adapter.set_state(issue_ref, target_state)?;
     }
+    Ok(())
+}
+
+fn transition_issue_to_rework_with_diagnostic(
+    adapter: &dyn TrackerAdapter,
+    issue: &TrackerIssue,
+    diagnostic: &ReworkDiagnostic,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let workpad = render_rework_diagnostic_workpad(issue, diagnostic);
+    adapter.upsert_workpad(&issue.identifier, &workpad)?;
+    adapter.set_state(&issue.identifier, "rework")?;
     Ok(())
 }
 
@@ -1839,6 +1861,7 @@ fn usage() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
 
     fn forge_contract() -> String {
         [
@@ -1894,6 +1917,106 @@ mod tests {
             project_fields: Default::default(),
             created_at: None,
             updated_at: None,
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingAdapter {
+        operations: RefCell<Vec<String>>,
+        fail_workpad: bool,
+    }
+
+    impl RecordingAdapter {
+        fn operations(&self) -> Vec<String> {
+            self.operations.borrow().clone()
+        }
+    }
+
+    impl TrackerAdapter for RecordingAdapter {
+        fn kind(&self) -> &'static str {
+            "recording"
+        }
+
+        fn list_dispatchable_issues(
+            &self,
+        ) -> Result<Vec<TrackerIssue>, jade_symphony::tracker::TrackerError> {
+            Ok(Vec::new())
+        }
+
+        fn get_issue(
+            &self,
+            _issue_ref: &str,
+        ) -> Result<Option<TrackerIssue>, jade_symphony::tracker::TrackerError> {
+            Ok(None)
+        }
+
+        fn fetch_issues_by_states(
+            &self,
+            _states: &[String],
+        ) -> Result<Vec<TrackerIssue>, jade_symphony::tracker::TrackerError> {
+            Ok(Vec::new())
+        }
+
+        fn set_state(
+            &self,
+            issue_ref: &str,
+            normalized_state: &str,
+        ) -> Result<(), jade_symphony::tracker::TrackerError> {
+            self.operations
+                .borrow_mut()
+                .push(format!("set_state:{issue_ref}:{normalized_state}"));
+            Ok(())
+        }
+
+        fn upsert_workpad(
+            &self,
+            issue_ref: &str,
+            markdown: &str,
+        ) -> Result<(), jade_symphony::tracker::TrackerError> {
+            if self.fail_workpad {
+                return Err(
+                    jade_symphony::tracker::TrackerError::IntegrationUnavailable(
+                        "workpad failed".into(),
+                    ),
+                );
+            }
+            assert!(markdown.contains("## Rework Diagnostic"));
+            self.operations
+                .borrow_mut()
+                .push(format!("workpad:{issue_ref}"));
+            Ok(())
+        }
+
+        fn create_follow_up_issue(
+            &self,
+            _input: FollowUpIssueInput,
+        ) -> Result<String, jade_symphony::tracker::TrackerError> {
+            Ok("dry-run:follow-up".into())
+        }
+
+        fn add_issue_to_project(
+            &self,
+            _issue_id: &str,
+        ) -> Result<(), jade_symphony::tracker::TrackerError> {
+            Ok(())
+        }
+
+        fn link_pull_request(
+            &self,
+            _issue_ref: &str,
+            _pr_ref: &str,
+        ) -> Result<(), jade_symphony::tracker::TrackerError> {
+            Ok(())
+        }
+
+        fn list_linked_pull_requests(
+            &self,
+            _issue_ref: &str,
+        ) -> Result<
+            Vec<jade_symphony::model::LinkedPullRequest>,
+            jade_symphony::tracker::TrackerError,
+        > {
+            Ok(Vec::new())
         }
     }
 
@@ -2210,6 +2333,44 @@ mod tests {
         assert!(workpad
             .contains("Branch: `feature/issue-29-wire-runtime-state-persistence-into-run-loop`"));
         assert!(workpad.contains("PR title: `#29: Wire runtime state persistence into run-loop`"));
+    }
+
+    #[test]
+    fn rework_transition_writes_diagnostic_before_state_change() {
+        let adapter = RecordingAdapter::default();
+        let issue = tracker_issue("Agent Review");
+        let diagnostic = ReworkDiagnostic::validation_failure(
+            issue.identifier.clone(),
+            "cargo test",
+            "failing test output",
+        );
+
+        transition_issue_to_rework_with_diagnostic(&adapter, &issue, &diagnostic).unwrap();
+
+        assert_eq!(
+            adapter.operations(),
+            vec![
+                "workpad:#29".to_string(),
+                "set_state:#29:rework".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn rework_transition_does_not_set_state_when_workpad_write_fails() {
+        let adapter = RecordingAdapter {
+            operations: RefCell::new(Vec::new()),
+            fail_workpad: true,
+        };
+        let issue = tracker_issue("Agent Review");
+        let diagnostic = ReworkDiagnostic::validation_failure(
+            issue.identifier.clone(),
+            "cargo test",
+            "failing test output",
+        );
+
+        assert!(transition_issue_to_rework_with_diagnostic(&adapter, &issue, &diagnostic).is_err());
+        assert!(adapter.operations().is_empty());
     }
 
     #[test]

--- a/src/rework.rs
+++ b/src/rework.rs
@@ -1,0 +1,330 @@
+use serde::{Deserialize, Serialize};
+
+use crate::model::TrackerIssue;
+use crate::review::{ReviewFindingClass, ReviewGateDecision, ReviewJob, ReviewOutcome};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReworkDiagnosticKind {
+    ReviewFinding,
+    MergeConflict,
+    DirtyPullRequest,
+    ValidationFailure,
+    RuntimeFailure,
+    Other,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReworkFinding {
+    pub class: String,
+    pub title: String,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReworkDiagnostic {
+    pub issue_ref: String,
+    pub source: String,
+    pub kind: ReworkDiagnosticKind,
+    pub summary: String,
+    pub next_action: String,
+    pub command: Option<String>,
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
+    pub pr_ref: Option<String>,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    #[serde(default)]
+    pub findings: Vec<ReworkFinding>,
+}
+
+impl ReworkDiagnostic {
+    pub fn validation_failure(
+        issue_ref: impl Into<String>,
+        command: impl Into<String>,
+        stderr: impl Into<String>,
+    ) -> Self {
+        Self {
+            issue_ref: issue_ref.into(),
+            source: "validation".into(),
+            kind: ReworkDiagnosticKind::ValidationFailure,
+            summary: "Verification failed before handoff.".into(),
+            next_action: "Inspect the failing command output, repair within issue scope, and rerun verification.".into(),
+            command: Some(command.into()),
+            stdout: None,
+            stderr: Some(stderr.into()),
+            pr_ref: None,
+            changed_files: Vec::new(),
+            findings: Vec::new(),
+        }
+    }
+
+    pub fn merge_conflict(
+        issue_ref: impl Into<String>,
+        pr_ref: impl Into<String>,
+        changed_files: Vec<String>,
+        summary: impl Into<String>,
+    ) -> Self {
+        Self {
+            issue_ref: issue_ref.into(),
+            source: "merging".into(),
+            kind: ReworkDiagnosticKind::MergeConflict,
+            summary: summary.into(),
+            next_action: "Resolve the conflict in the issue branch and preserve review freshness evidence when applicable.".into(),
+            command: None,
+            stdout: None,
+            stderr: None,
+            pr_ref: Some(pr_ref.into()),
+            changed_files,
+            findings: Vec::new(),
+        }
+    }
+}
+
+pub fn rework_diagnostic_from_review(
+    issue: &TrackerIssue,
+    job: &ReviewJob,
+    decision: &ReviewGateDecision,
+) -> ReworkDiagnostic {
+    let mut findings = Vec::new();
+    let mut stdout = None;
+    let mut stderr = None;
+    let mut summary = decision.message.clone();
+
+    if let Some(report) = &job.report {
+        if let Some(report_summary) = &report.summary {
+            summary = report_summary.clone();
+        }
+        stdout = report.stdout.clone();
+        stderr = report.stderr.clone();
+        findings = report
+            .findings
+            .iter()
+            .filter(|finding| finding.class == ReviewFindingClass::Confirmed)
+            .map(|finding| ReworkFinding {
+                class: "Confirmed".into(),
+                title: finding.title.clone(),
+                body: finding.body.clone(),
+            })
+            .collect();
+    }
+
+    ReworkDiagnostic {
+        issue_ref: issue.identifier.clone(),
+        source: format!("agent_review:{}", job.backend),
+        kind: ReworkDiagnosticKind::ReviewFinding,
+        summary,
+        next_action:
+            "Address confirmed review findings, rerun required verification, and hand back to Agent Review."
+                .into(),
+        command: None,
+        stdout,
+        stderr,
+        pr_ref: issue
+            .linked_pull_requests
+            .iter()
+            .find_map(|pr| pr.url.clone()),
+        changed_files: Vec::new(),
+        findings,
+    }
+}
+
+pub fn render_rework_diagnostic_workpad(
+    issue: &TrackerIssue,
+    diagnostic: &ReworkDiagnostic,
+) -> String {
+    let mut lines = vec![
+        "## Rework Diagnostic".to_string(),
+        String::new(),
+        format!("- Issue: {} {}", issue.identifier, issue.title),
+        format!("- Source: `{}`", diagnostic.source),
+        format!("- Kind: `{:?}`", diagnostic.kind),
+        format!("- Summary: {}", diagnostic.summary),
+        format!("- Next action: {}", diagnostic.next_action),
+        "- Evidence was recorded before moving the issue to `Rework`.".to_string(),
+    ];
+
+    if let Some(pr_ref) = &diagnostic.pr_ref {
+        lines.push(format!("- Pull request: `{pr_ref}`"));
+        lines.push("- PR-specific context is captured here; mirror this note to the PR conversation when the active adapter supports PR comments.".into());
+    }
+
+    if !diagnostic.changed_files.is_empty() {
+        lines.push(String::new());
+        lines.push("### Changed Files".into());
+        for path in &diagnostic.changed_files {
+            lines.push(format!("- `{path}`"));
+        }
+    }
+
+    if !diagnostic.findings.is_empty() {
+        lines.push(String::new());
+        lines.push("### Findings".into());
+        for finding in &diagnostic.findings {
+            lines.push(format!(
+                "- {}: {} - {}",
+                finding.class, finding.title, finding.body
+            ));
+        }
+    }
+
+    if let Some(command) = &diagnostic.command {
+        lines.push(String::new());
+        lines.push("### Command".into());
+        lines.push(format!("- `{command}`"));
+    }
+
+    push_log_block(&mut lines, "Stdout", diagnostic.stdout.as_deref());
+    push_log_block(&mut lines, "Stderr", diagnostic.stderr.as_deref());
+
+    lines.push(String::new());
+    lines.push("### Role Boundary".into());
+    lines.push(
+        "- Main implementation agent repairs confirmed Rework and then stops at `Agent Review`."
+            .into(),
+    );
+    lines.push(
+        "- `Human Review` remains reserved for independent Review Agent pass evidence.".into(),
+    );
+
+    lines.join("\n")
+}
+
+fn push_log_block(lines: &mut Vec<String>, label: &str, content: Option<&str>) {
+    let Some(content) = content else {
+        return;
+    };
+    if content.trim().is_empty() {
+        return;
+    }
+
+    lines.push(String::new());
+    lines.push(format!("### {label}"));
+    lines.push("```text".into());
+    lines.push(truncate_log(content));
+    lines.push("```".into());
+}
+
+fn truncate_log(content: &str) -> String {
+    const LIMIT: usize = 2_000;
+    if content.len() <= LIMIT {
+        content.to_string()
+    } else {
+        format!("{} [... truncated]", &content[..LIMIT])
+    }
+}
+
+pub fn rework_transition_expected(decision: &ReviewGateDecision) -> bool {
+    decision.outcome == ReviewOutcome::NeedsRework && decision.target_state == Some("rework")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::TrackerIssue;
+    use crate::review::{
+        AgentReviewReport, ReviewFinding, ReviewFindingClass, ReviewGateDecision, ReviewJob,
+        ReviewJobState, ReviewOutcome,
+    };
+
+    fn issue() -> TrackerIssue {
+        TrackerIssue {
+            tracker_kind: "github_project_v2".into(),
+            id: "ISSUE_50".into(),
+            item_id: None,
+            identifier: "#50".into(),
+            title: "Persist Rework diagnostics".into(),
+            description: None,
+            url: None,
+            state: "Agent Review".into(),
+            labels: Vec::new(),
+            assignees: Vec::new(),
+            priority: None,
+            branch_name: None,
+            linked_pull_requests: Vec::new(),
+            blocked_by: Vec::new(),
+            project_fields: Default::default(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    #[test]
+    fn review_diagnostic_keeps_confirmed_findings_and_logs() {
+        let issue = issue();
+        let job = ReviewJob {
+            id: "review-1".into(),
+            issue_ref: "#50".into(),
+            backend: "fake-reviewer".into(),
+            state: ReviewJobState::Completed,
+            artifact_path: None,
+            report: Some(AgentReviewReport {
+                reviewer_backend: "fake-reviewer".into(),
+                findings: vec![ReviewFinding {
+                    class: ReviewFindingClass::Confirmed,
+                    title: "Missing test".into(),
+                    body: "Add ordering coverage.".into(),
+                }],
+                summary: Some("Confirmed finding requires rework.".into()),
+                stdout: Some("review stdout".into()),
+                stderr: Some("review stderr".into()),
+            }),
+            error: None,
+        };
+        let decision = ReviewGateDecision {
+            outcome: ReviewOutcome::NeedsRework,
+            target_state: Some("rework"),
+            message: "Confirmed findings require Rework.".into(),
+        };
+
+        let diagnostic = rework_diagnostic_from_review(&issue, &job, &decision);
+        let workpad = render_rework_diagnostic_workpad(&issue, &diagnostic);
+
+        assert_eq!(diagnostic.kind, ReworkDiagnosticKind::ReviewFinding);
+        assert!(workpad.contains("Evidence was recorded before moving the issue to `Rework`"));
+        assert!(workpad.contains("Confirmed: Missing test - Add ordering coverage."));
+        assert!(workpad.contains("review stdout"));
+        assert!(workpad.contains("review stderr"));
+    }
+
+    #[test]
+    fn merge_conflict_diagnostic_records_pr_specific_context() {
+        let issue = issue();
+        let diagnostic = ReworkDiagnostic::merge_conflict(
+            "#50",
+            "https://github.com/Alive24/jade-symphony/pull/99",
+            vec!["src/main.rs".into()],
+            "PR no longer merges cleanly.",
+        );
+
+        let workpad = render_rework_diagnostic_workpad(&issue, &diagnostic);
+
+        assert!(
+            workpad.contains("Pull request: `https://github.com/Alive24/jade-symphony/pull/99`")
+        );
+        assert!(workpad.contains("src/main.rs"));
+        assert!(workpad.contains("mirror this note to the PR conversation"));
+    }
+
+    #[test]
+    fn validation_failure_diagnostic_keeps_actionable_stderr() {
+        let issue = issue();
+        let diagnostic =
+            ReworkDiagnostic::validation_failure("#50", "cargo test", "test failure details");
+
+        let workpad = render_rework_diagnostic_workpad(&issue, &diagnostic);
+
+        assert!(workpad.contains("Verification failed before handoff."));
+        assert!(workpad.contains("`cargo test`"));
+        assert!(workpad.contains("test failure details"));
+    }
+
+    #[test]
+    fn detects_rework_transition_decisions() {
+        let decision = ReviewGateDecision {
+            outcome: ReviewOutcome::NeedsRework,
+            target_state: Some("rework"),
+            message: "confirmed".into(),
+        };
+        assert!(rework_transition_expected(&decision));
+    }
+}


### PR DESCRIPTION
## Summary

- adds a structured Rework diagnostic model and renderer for review findings, merge conflicts, dirty PRs, validation failures, and runtime failures
- routes confirmed Review Agent findings through an evidence-first Rework transition helper
- guarantees the issue workpad write happens before `Rework` state mutation and stops state mutation when the workpad write fails
- documents Rework evidence requirements in README and dogfood readiness docs

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Handoff

Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #50
