### PR TITLE
#57: Enforce Agent Review handoff evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ one-issue-one-PR automation are still future work.
 - workspace/branch/PR handoff planning can derive a deterministic issue
   workspace key, branch name, and PR handoff body, and can detect an existing
   branch that appears to belong to a different issue.
+- Agent Review handoff invariant helpers require durable issue, workspace,
+  branch, validation, transition, and PR URL evidence before the run-loop can
+  move completed work to `Agent Review`; missing PR evidence is routed to
+  `Need Human Input` with a workpad diagnostic.
 - terminal status output reports polling state, planned running/skipped/retrying
   issues, token counters, event-log path, gate details, and integration gaps.
 - JSONL event-log primitives exist.
@@ -179,6 +183,8 @@ claim reconciliation, resume state, and PR automation exist.
 
 - linked PR attachment/linking as a first-class relationship.
 - live git worktree creation and `gh pr create` from the runtime loop.
+- automatic repair of existing `Agent Review` items with missing PR evidence;
+  the current slice prevents new silent handoffs and records diagnostics.
 - rich interactive Issue Forge TUI; the current flow is CLI-first and
   command-step based.
 - Linear live adapter credential-gated smoke coverage.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -17,7 +17,7 @@ yet.
 | Issue Quality Gate | Implemented as a first-pass Markdown contract check. It is useful for dry-run classification, not yet a full source-alignment gate. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, and planned handoff evidence exists. No long-running worker supervision, retry timers, full runtime resume reconciliation, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, and run-loop handoff evidence exist. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, workspace/branch/PR handoff planning, run-loop handoff evidence, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review`. Live git worktree creation, PR creation, and runtime reconciliation cleanup are not wired yet. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, review-freshness evidence for Merging conflict repair, and workpad/status evidence helpers exist. Persistent review worker reconciliation is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events. Runtime state files are written during write-mode `run-loop` issue execution, but full resume reconciliation is still pending. No web/API surface yet. |
@@ -72,6 +72,10 @@ Project v2 issues:
      preserving prior Human Review. Mechanical conflict repair can preserve
      prior Human Review for an authorized merge/handoff flow; semantic or
      unknown rework requires the normal Agent Review and Human Review path.
+   - Main-agent completion should enter `Agent Review` only after durable
+     handoff evidence includes issue, workspace, branch, validation, transition,
+     and PR URL. Missing PR evidence should keep the issue out of
+     `Agent Review` with a workpad diagnostic.
 
 5. Linear integration hardening.
    - Add credential-gated live smoke tests for reads, state updates, and workpad
@@ -100,6 +104,9 @@ Project v2 issues:
    - workspace/branch/PR handoff planning is recorded by `run-loop`, but the
      runtime still needs live worktree creation, branch checkout, push, PR
      creation, and PR link recording.
+   - Existing `Agent Review` items with stale or missing PR evidence still need
+     a reconciliation/repair command; the current handoff invariant prevents
+     new silent transitions from passing without PR evidence.
    - continuation retry after normal active-state exits.
    - exponential backoff for failures.
    - stall detection.

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -28,6 +28,32 @@ pub struct PullRequestHandoffPlan {
     pub body: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentReviewHandoffEvidence {
+    pub issue_ref: String,
+    pub workspace_key: String,
+    pub workspace_path: PathBuf,
+    pub branch_name: String,
+    pub pull_request_url: Option<String>,
+    pub validation_summary: String,
+    pub last_transition: String,
+    pub no_pr_blocker: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentReviewHandoffStatus {
+    Ready,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentReviewHandoffReport {
+    pub status: AgentReviewHandoffStatus,
+    pub missing: Vec<String>,
+    pub target_state: Option<String>,
+    pub message: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum HandoffError {
     #[error("branch {branch_name} appears to belong to issue #{found_issue}, expected #{expected_issue}")]
@@ -43,6 +69,133 @@ pub enum BranchIssueCheck {
     Matches { issue_number: String },
     Mismatch { expected: String, found: String },
     Unknown,
+}
+
+impl AgentReviewHandoffReport {
+    pub fn is_ready(&self) -> bool {
+        self.status == AgentReviewHandoffStatus::Ready
+    }
+}
+
+impl AgentReviewHandoffEvidence {
+    pub fn from_plan(
+        plan: &IssueHandoffPlan,
+        validation_summary: impl Into<String>,
+        last_transition: impl Into<String>,
+    ) -> Self {
+        Self {
+            issue_ref: plan.issue_ref.clone(),
+            workspace_key: plan.workspace_key.clone(),
+            workspace_path: plan.workspace_path.clone(),
+            branch_name: plan.branch_name.clone(),
+            pull_request_url: None,
+            validation_summary: validation_summary.into(),
+            last_transition: last_transition.into(),
+            no_pr_blocker: None,
+        }
+    }
+}
+
+pub fn evaluate_agent_review_handoff(
+    evidence: &AgentReviewHandoffEvidence,
+) -> AgentReviewHandoffReport {
+    let mut missing = Vec::new();
+
+    if evidence.issue_ref.trim().is_empty() {
+        missing.push("issue id".into());
+    }
+    if evidence.workspace_key.trim().is_empty() {
+        missing.push("workspace key".into());
+    }
+    if evidence.branch_name.trim().is_empty() {
+        missing.push("branch name".into());
+    }
+    if evidence.validation_summary.trim().is_empty() {
+        missing.push("validation summary".into());
+    }
+    if evidence.last_transition.trim().is_empty() {
+        missing.push("last transition".into());
+    }
+
+    let has_pr = evidence
+        .pull_request_url
+        .as_deref()
+        .map(|url| !url.trim().is_empty())
+        .unwrap_or(false);
+    let has_no_pr_blocker = evidence
+        .no_pr_blocker
+        .as_deref()
+        .map(|blocker| !blocker.trim().is_empty())
+        .unwrap_or(false);
+
+    if !has_pr && !has_no_pr_blocker {
+        missing.push("pull request url or explicit no-PR blocker".into());
+    }
+
+    if missing.is_empty() && has_pr {
+        AgentReviewHandoffReport {
+            status: AgentReviewHandoffStatus::Ready,
+            missing,
+            target_state: Some("agent_review".into()),
+            message: "Agent Review handoff invariant passed.".into(),
+        }
+    } else {
+        AgentReviewHandoffReport {
+            status: AgentReviewHandoffStatus::Blocked,
+            missing,
+            target_state: Some("need_human_input".into()),
+            message: "Agent Review handoff invariant is not satisfied; keeping issue out of Agent Review.".into(),
+        }
+    }
+}
+
+pub fn render_agent_review_handoff_workpad(
+    issue: &TrackerIssue,
+    evidence: &AgentReviewHandoffEvidence,
+    report: &AgentReviewHandoffReport,
+) -> String {
+    let mut lines = vec![
+        "## Jade Symphony Workpad".to_string(),
+        String::new(),
+        "### Agent Review Handoff Invariant".to_string(),
+        format!("- Issue: {} {}", issue.identifier, issue.title),
+        format!("- Status: `{:?}`", report.status),
+        format!("- Message: {}", report.message),
+        format!(
+            "- Target state: `{}`",
+            report.target_state.as_deref().unwrap_or("none")
+        ),
+        String::new(),
+        "### Evidence".to_string(),
+        format!("- Workspace key: `{}`", evidence.workspace_key),
+        format!("- Workspace path: `{}`", evidence.workspace_path.display()),
+        format!("- Branch: `{}`", evidence.branch_name),
+        format!(
+            "- Pull request: `{}`",
+            evidence.pull_request_url.as_deref().unwrap_or("missing")
+        ),
+        format!("- Validation: {}", evidence.validation_summary),
+        format!("- Last transition: {}", evidence.last_transition),
+    ];
+
+    if let Some(blocker) = &evidence.no_pr_blocker {
+        lines.push(format!("- No-PR blocker: {}", blocker));
+    }
+
+    if !report.missing.is_empty() {
+        lines.push(String::new());
+        lines.push("### Missing Handoff Evidence".into());
+        for item in &report.missing {
+            lines.push(format!("- {item}"));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("### Boundary".into());
+    lines.push("- Main implementation agent may move complete work to `Agent Review` only after this invariant passes.".into());
+    lines.push("- Main implementation agent must never set `Human Review`.".into());
+
+    lines.join("\n")
 }
 
 pub fn plan_issue_handoff(
@@ -320,5 +473,50 @@ mod tests {
             .contains("cargo clippy --all-targets --all-features -- -D warnings"));
         assert!(pr.body.contains("stops at Agent Review"));
         assert!(pr.body.contains("Closes #21"));
+    }
+
+    #[test]
+    fn agent_review_handoff_requires_pr_url() {
+        let plan = plan_issue_handoff(Path::new("/tmp/jade-workspaces"), &issue(), "main").unwrap();
+        let evidence =
+            AgentReviewHandoffEvidence::from_plan(&plan, "cargo test passed", "completed");
+
+        let report = evaluate_agent_review_handoff(&evidence);
+
+        assert!(!report.is_ready());
+        assert_eq!(report.target_state.as_deref(), Some("need_human_input"));
+        assert!(report
+            .missing
+            .contains(&"pull request url or explicit no-PR blocker".to_string()));
+    }
+
+    #[test]
+    fn agent_review_handoff_passes_with_pr_url() {
+        let plan = plan_issue_handoff(Path::new("/tmp/jade-workspaces"), &issue(), "main").unwrap();
+        let mut evidence =
+            AgentReviewHandoffEvidence::from_plan(&plan, "cargo test passed", "completed");
+        evidence.pull_request_url = Some("https://github.com/Alive24/jade-symphony/pull/21".into());
+
+        let report = evaluate_agent_review_handoff(&evidence);
+
+        assert!(report.is_ready());
+        assert_eq!(report.target_state.as_deref(), Some("agent_review"));
+    }
+
+    #[test]
+    fn agent_review_handoff_workpad_names_missing_pr_evidence() {
+        let issue = issue();
+        let plan = plan_issue_handoff(Path::new("/tmp/jade-workspaces"), &issue, "main").unwrap();
+        let evidence =
+            AgentReviewHandoffEvidence::from_plan(&plan, "cargo test passed", "completed");
+        let report = evaluate_agent_review_handoff(&evidence);
+
+        let workpad = render_agent_review_handoff_workpad(&issue, &evidence, &report);
+
+        assert!(workpad.contains("## Jade Symphony Workpad"));
+        assert!(workpad.contains("Agent Review Handoff Invariant"));
+        assert!(workpad.contains("Pull request: `missing`"));
+        assert!(workpad.contains("pull request url or explicit no-PR blocker"));
+        assert!(workpad.contains("must never set `Human Review`"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@ use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum
 use jade_symphony::agent::backend_from_config;
 use jade_symphony::config::RuntimeConfig;
 use jade_symphony::event_log::{EventLog, EventRecord};
-use jade_symphony::handoff::{plan_issue_handoff, HandoffError, IssueHandoffPlan};
+use jade_symphony::handoff::{
+    evaluate_agent_review_handoff, plan_issue_handoff, render_agent_review_handoff_workpad,
+    AgentReviewHandoffEvidence, HandoffError, IssueHandoffPlan,
+};
 use jade_symphony::issue_forge::{
     discover_candidates, draft_from_template, find_issue_skill, interactive_forge,
     reflective_candidates_from_context, repair_markdown, validate_markdown, InteractiveForgeInput,
@@ -841,6 +844,27 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             if !transition_allowed_for_main_agent("agent_review") {
                 return Err("main implementation agent cannot set requested review state".into());
             }
+            let evidence = run_loop_agent_review_handoff_evidence(&latest, &result, &handoff);
+            let handoff_report = evaluate_agent_review_handoff(&evidence);
+            let handoff_workpad =
+                render_agent_review_handoff_workpad(&latest, &evidence, &handoff_report);
+            adapter.upsert_workpad(&latest.identifier, &handoff_workpad)?;
+            if !handoff_report.is_ready() {
+                runtime_state = run_loop_runtime_state_with_transition(
+                    runtime_state,
+                    Some(latest.state.clone()),
+                    "need_human_input",
+                    "agent review handoff invariant failed",
+                );
+                save_runtime_state(&config, &runtime_state)?;
+                adapter.set_state(&latest.identifier, "need_human_input")?;
+                clear_runtime_state(&config)?;
+                println!(
+                    "run_loop_action=blocked issue={} target_state=need_human_input reason=handoff_invariant_failed",
+                    latest.identifier
+                );
+                continue;
+            }
             runtime_state = run_loop_runtime_state_with_transition(
                 runtime_state,
                 Some(latest.state.clone()),
@@ -1100,6 +1124,34 @@ fn run_loop_handoff_workpad(
         "- `Human Review` is reserved for independent Review Agent pass evidence.".to_string(),
     ]
     .join("\n")
+}
+
+fn run_loop_agent_review_handoff_evidence(
+    issue: &TrackerIssue,
+    result: &IssueExecutionResult,
+    handoff: &IssueHandoffPlan,
+) -> AgentReviewHandoffEvidence {
+    let mut evidence = AgentReviewHandoffEvidence::from_plan(
+        handoff,
+        format!(
+            "backend={} success={} session={} message={}",
+            result.backend,
+            result.success,
+            result.session_id.as_deref().unwrap_or("n/a"),
+            result.message
+        ),
+        "main agent completed local run",
+    );
+    evidence.pull_request_url = issue
+        .linked_pull_requests
+        .iter()
+        .find_map(|pr| pr.url.clone());
+    if evidence.pull_request_url.is_none() {
+        evidence.no_pr_blocker = Some(
+            "No pull request URL was present in tracker data at handoff time; keeping issue out of Agent Review until PR evidence is durable.".into(),
+        );
+    }
+    evidence
 }
 
 fn run_loop_handoff_failure_workpad(issue: &TrackerIssue, error: &HandoffError) -> String {
@@ -2210,6 +2262,62 @@ mod tests {
         assert!(workpad
             .contains("Branch: `feature/issue-29-wire-runtime-state-persistence-into-run-loop`"));
         assert!(workpad.contains("PR title: `#29: Wire runtime state persistence into run-loop`"));
+    }
+
+    #[test]
+    fn run_loop_agent_review_handoff_blocks_missing_pr_url() {
+        let config = test_config();
+        let issue = tracker_issue("In Progress");
+        let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+        let result = IssueExecutionResult {
+            workspace_path: handoff.workspace_path.clone(),
+            backend: "dry-run".into(),
+            success: true,
+            session_id: Some("session-57".into()),
+            message: "ok".into(),
+        };
+
+        let evidence = run_loop_agent_review_handoff_evidence(&issue, &result, &handoff);
+        let report = evaluate_agent_review_handoff(&evidence);
+
+        assert!(!report.is_ready());
+        assert_eq!(report.target_state.as_deref(), Some("need_human_input"));
+        assert!(evidence
+            .no_pr_blocker
+            .unwrap()
+            .contains("No pull request URL"));
+    }
+
+    #[test]
+    fn run_loop_agent_review_handoff_passes_with_pr_url() {
+        let config = test_config();
+        let mut issue = tracker_issue("In Progress");
+        issue
+            .linked_pull_requests
+            .push(jade_symphony::model::LinkedPullRequest {
+                id: Some("PR_57".into()),
+                number: Some(57),
+                url: Some("https://github.com/Alive24/jade-symphony/pull/57".into()),
+                state: Some("OPEN".into()),
+            });
+        let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+        let result = IssueExecutionResult {
+            workspace_path: handoff.workspace_path.clone(),
+            backend: "dry-run".into(),
+            success: true,
+            session_id: Some("session-57".into()),
+            message: "ok".into(),
+        };
+
+        let evidence = run_loop_agent_review_handoff_evidence(&issue, &result, &handoff);
+        let report = evaluate_agent_review_handoff(&evidence);
+
+        assert!(report.is_ready());
+        assert_eq!(report.target_state.as_deref(), Some("agent_review"));
+        assert_eq!(
+            evidence.pull_request_url.as_deref(),
+            Some("https://github.com/Alive24/jade-symphony/pull/57")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- adds an Agent Review handoff invariant requiring issue, workspace, branch, validation, transition, and PR URL evidence
- blocks successful run-loop completion to `Need Human Input` when PR evidence is missing instead of silently entering `Agent Review`
- renders a durable handoff-invariant workpad diagnostic for missing PR evidence
- adds tests for missing-PR blocking and passing handoff evidence with a PR URL
- updates README and dogfood readiness docs

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## UAT Note

- Attempted `cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --write`; existing GitHub fixture mode refuses live-style status writes, so the missing-PR block is covered by unit/fixture tests in this slice.

## Handoff

Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #57
