### PR TITLE
Add optional LLM issue quality gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ worker supervision are still future work.
 - Issue Quality Gate classifies executable versus underspecified issue bodies
   and, where workflow/repo context is available, runs deterministic
   source-alignment checks for target repository, referenced local paths, and
-  verification command shapes.
+  verification command shapes. An optional command-backed LLM gate can run in
+  `disabled`, `advisory`, or `required` mode after deterministic checks.
 - review freshness helpers can classify Merging-to-Rework repairs as
   mechanical, semantic, or unknown and render workpad evidence for whether prior
   Human Review remains valid.
@@ -277,7 +278,8 @@ Merging role separation.
 - Issue Forge Project field setup after issue creation.
 - autonomous Issue Forge issue creation from reflective mode without explicit
   operator confirmation.
-- richer semantic or LLM-assisted Issue Quality Gate analysis.
+- hosted-provider LLM gate integrations beyond the local command adapter.
+- richer semantic Issue Quality Gate analysis beyond the structured LLM result.
 - full Liquid-compatible prompt renderer.
 - credential-gated integration tests.
 
@@ -314,6 +316,7 @@ Dry-run dispatch:
 cargo run -- plan examples/dry-run-workflow.md
 cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
+cargo run -- gate examples/llm-gate-workflow.md '#1'
 ```
 
 The dry-run workflow uses:
@@ -322,6 +325,10 @@ The dry-run workflow uses:
 - `examples/fixtures/dry-run-issues.json`
 - `examples/linear-fixture-workflow.md`
 - `examples/fixtures/linear-issues.json`
+- `examples/llm-gate-workflow.md`
+- `examples/fixtures/llm-gate-ready.sh`
+- `examples/fixtures/llm-gate-clarify.sh`
+- `examples/fixtures/llm-gate-malformed.sh`
 
 For a real GitHub Project v2 read/write workflow template, copy and edit:
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -16,7 +16,7 @@ yet.
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
-| Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies target repository, referenced local paths, and supported verification command shapes; richer semantic validation is still a follow-up. |
+| Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies target repository, referenced local paths, and supported verification command shapes. Optional local command-backed LLM gate mode exists as disabled/advisory/required; richer semantic validation and hosted providers are still follow-ups. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, resume preflight, retry backoff records, stall detection, and live PR handoff in non-fixture GitHub mode exists. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Runtime reconciliation cleanup is not wired yet. |
@@ -228,17 +228,17 @@ Acceptance:
   be overwritten, retry backoff must be visible, and stalled work must stop the
   loop safely.
 
-### 3b. Add LLM-Assisted Issue Quality Gate
+### 3b. Harden LLM-Assisted Issue Quality Gate
 
-Goal: augment the deterministic source-alignment gate with optional local model
-review while preserving explainable, non-mutating defaults.
+Goal: evolve the optional local command-backed LLM gate into a stronger
+dogfood path without weakening deterministic checks.
 
 Acceptance:
 
-- keeps deterministic checks as the first gate.
-- runs only when explicitly configured.
-- records model findings in the workpad.
-- routes missing or inconclusive model output to clarification, not dispatch.
+- add credential-gated or local-model smoke coverage for a real reviewer.
+- refine the prompt/output schema from dogfood evidence.
+- add hosted-provider adapters only behind explicit configuration.
+- preserve required-mode blocking for malformed or unavailable model output.
 
 ### 4. Implement Full Codex App-Server Backend
 

--- a/examples/fixtures/llm-gate-clarify.sh
+++ b/examples/fixtures/llm-gate-clarify.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{"decision":"NeedToClarify","missing":["narrow the implementation surface"],"assumptions":[],"notes":["LLM gate fixture requested clarification"]}'

--- a/examples/fixtures/llm-gate-issues.json
+++ b/examples/fixtures/llm-gate-issues.json
@@ -1,0 +1,23 @@
+[
+  {
+    "tracker_kind": "github_project_v2",
+    "id": "GHI_llm_ready",
+    "item_id": "PVTI_llm_ready",
+    "identifier": "#1",
+    "title": "Exercise fixture LLM quality gate",
+    "description": "## Issue Goal\n\nExercise the optional LLM-assisted Issue Quality Gate fixture path.\n\n## Why Now\n\nJade Symphony needs deterministic local coverage for the LLM gate contract without hosted credentials.\n\n## Issue Context\n\nThe deterministic gate should pass first, then the configured fixture command should return structured LLM output.\n\n## Decisions / Assumptions\n\n### Decisions\n\n- Keep deterministic checks authoritative.\n\n### Assumptions\n\n- A shell fixture is enough for local LLM gate contract tests.\n\n## Non-Negotiable Guardrails\n\n- Do not call a hosted LLM provider.\n\n## Scope\n\n### In Scope\n\n- Run the fixture LLM gate command.\n\n### Out of Scope\n\n- Hosted provider SDK integration.\n\n## Canonical References\n\n### Target Repository / Package\n\n- Alive24/jade-symphony\n\n### Relevant Knowledge Sources\n\n- README.md\n\n### Relevant Code Paths\n\n- src/quality_gate.rs\n\n## Current State\n\nThe deterministic gate and LLM gate fixture command exist.\n\n## Deliverable Shape\n\nFixture verification only.\n\n## Risks or Constraints\n\n- The LLM gate must not bypass deterministic failures.\n\n## Expected Outcome\n\nThe fixture issue remains dispatchable and records LLM gate notes.\n\n## Verification\n\n### Completion Criteria\n\n- LLM fixture gate returns structured output.\n\n### Functional Verification\n\n- cargo test\n\n### UAT\n\n- Run `cargo run -- gate examples/llm-gate-workflow.md '#1'`.\n\n### Context Verification\n\n- Confirm deterministic checks run before LLM output is applied.",
+    "url": "https://github.com/Alive24/jade-symphony/issues/1",
+    "state": "Todo",
+    "labels": ["quality-gate"],
+    "assignees": ["codex"],
+    "priority": 1,
+    "branch_name": null,
+    "linked_pull_requests": [],
+    "blocked_by": [],
+    "project_fields": {
+      "Status": "Todo"
+    },
+    "created_at": "2026-05-13T00:00:00Z",
+    "updated_at": "2026-05-13T00:00:00Z"
+  }
+]

--- a/examples/fixtures/llm-gate-malformed.sh
+++ b/examples/fixtures/llm-gate-malformed.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat >/dev/null
+printf '%s\n' 'not-json'

--- a/examples/fixtures/llm-gate-ready.sh
+++ b/examples/fixtures/llm-gate-ready.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat >/dev/null
+printf '%s\n' '{"decision":"ReadyWithAssumptions","assumptions":["LLM fixture says scope is coherent"],"missing":[],"notes":["LLM gate fixture passed"]}'

--- a/examples/llm-gate-workflow.md
+++ b/examples/llm-gate-workflow.md
@@ -1,0 +1,30 @@
+---
+tracker:
+  kind: github_project_v2
+  owner: Alive24
+  repo: jade-symphony
+  project_owner: Alive24
+  project_number: 1
+  status_field: Status
+  fixture_path: fixtures/llm-gate-issues.json
+  state_map:
+    backlog: Backlog
+    todo: Todo
+    need_to_clarify: Need to Clarify
+    in_progress: In Progress
+    need_human_input: Need Human Input
+    agent_review: Agent Review
+    human_review: Human Review
+    rework: Rework
+    merging: Merging
+    done: Done
+quality_gate:
+  llm:
+    mode: required
+    command: sh examples/fixtures/llm-gate-ready.sh
+    timeout_ms: 5000
+agent:
+  backend: dry-run
+---
+
+You are checking issue {{ issue.identifier }} with the fixture LLM gate.

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct RuntimeConfig {
     pub codex: CodexConfig,
     pub claude: ClaudeConfig,
     pub review: ReviewConfig,
+    pub quality_gate: QualityGateConfig,
     pub profiles: ProfilesConfig,
     pub identity: IdentityConfig,
     pub observability: ObservabilityConfig,
@@ -127,6 +128,18 @@ pub struct ClaudeConfig {
 pub struct ReviewConfig {
     pub backend: String,
     pub gemini_command: String,
+    pub timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QualityGateConfig {
+    pub llm: LlmQualityGateConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmQualityGateConfig {
+    pub mode: String,
+    pub command: Option<String>,
     pub timeout_ms: u64,
 }
 
@@ -281,6 +294,7 @@ impl RuntimeConfig {
                 .unwrap_or_else(|| "gemini".to_string()),
             timeout_ms: get_u64(root.get("review"), "timeout_ms").unwrap_or(600_000),
         };
+        let quality_gate = parse_quality_gate(root.get("quality_gate"));
         let profiles = parse_profiles(root.get("profiles"), workflow_dir);
         let identity = parse_identity(root.get("identity"));
         let observability = ObservabilityConfig {
@@ -310,6 +324,7 @@ impl RuntimeConfig {
             codex,
             claude,
             review,
+            quality_gate,
             profiles,
             identity,
             observability,
@@ -332,6 +347,20 @@ impl RuntimeConfig {
             "fake" | "gemini-cli" => {}
             other => return Err(ConfigError::UnsupportedBackend(other.to_string())),
         }
+        match self.quality_gate.llm.mode.as_str() {
+            "disabled" | "advisory" | "required" => {}
+            other => {
+                return Err(ConfigError::Invalid(format!(
+                    "quality_gate.llm.mode must be disabled, advisory, or required; got {other}"
+                )))
+            }
+        }
+        if self.quality_gate.llm.mode == "required" {
+            require_present(
+                "quality_gate.llm.command",
+                self.quality_gate.llm.command.as_deref(),
+            )?;
+        }
 
         require_positive("polling.interval_ms", self.polling.interval_ms)?;
         require_positive("hooks.timeout_ms", self.hooks.timeout_ms)?;
@@ -345,6 +374,10 @@ impl RuntimeConfig {
             self.agent.max_retry_backoff_ms,
         )?;
         require_positive("review.timeout_ms", self.review.timeout_ms)?;
+        require_positive(
+            "quality_gate.llm.timeout_ms",
+            self.quality_gate.llm.timeout_ms,
+        )?;
 
         if self.tracker.kind == "github_project_v2" {
             require_present("tracker.owner", self.tracker.owner.as_deref())?;
@@ -470,6 +503,17 @@ fn parse_profiles(value: Option<&Value>, workflow_dir: &Path) -> ProfilesConfig 
             .map(|path| resolve_path(Some(&path), workflow_dir, Path::new(""))),
         },
         entries: parse_execution_profiles(get_value(value, "entries"), workflow_dir),
+    }
+}
+
+fn parse_quality_gate(value: Option<&Value>) -> QualityGateConfig {
+    let llm = get_value(value, "llm");
+    QualityGateConfig {
+        llm: LlmQualityGateConfig {
+            mode: get_string(llm, "mode").unwrap_or_else(|| "disabled".to_string()),
+            command: get_string(llm, "command"),
+            timeout_ms: get_u64(llm, "timeout_ms").unwrap_or(120_000),
+        },
     }
 }
 
@@ -782,5 +826,37 @@ mod tests {
             config.profiles.entries[0].user_data_dir.as_deref(),
             Some(Path::new("/tmp/config/profiles/fallback"))
         );
+    }
+
+    #[test]
+    fn parses_llm_quality_gate_config() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nquality_gate:\n  llm:\n    mode: required\n    command: sh examples/fixtures/llm-gate-ready.sh\n    timeout_ms: 5000\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert_eq!(config.quality_gate.llm.mode, "required");
+        assert_eq!(
+            config.quality_gate.llm.command.as_deref(),
+            Some("sh examples/fixtures/llm-gate-ready.sh")
+        );
+        assert_eq!(config.quality_gate.llm.timeout_ms, 5_000);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn required_llm_quality_gate_requires_command() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nquality_gate:\n  llm:\n    mode: required\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert!(config.validate().is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,9 @@ use jade_symphony::model::{normalize_state, GateDecision, GateDecisionKind, Trac
 use jade_symphony::orchestrator::Orchestrator;
 use jade_symphony::profiles::{discover_execution_profiles, selected_execution_profile};
 use jade_symphony::prompt::render_prompt;
-use jade_symphony::quality_gate::evaluate_issue_with_source_alignment;
+use jade_symphony::quality_gate::{
+    evaluate_issue_with_llm_gate, evaluate_issue_with_source_alignment, LlmGateMode, LlmGateOptions,
+};
 use jade_symphony::review::{
     classify_review_freshness, render_review_freshness_workpad, render_review_workpad,
     review_gate_decision, review_run_eligibility, transition_allowed_for_main_agent,
@@ -244,10 +246,16 @@ fn evaluate_issue_for_current_source(
 ) -> Result<GateDecision, Box<dyn std::error::Error>> {
     let repo_root = std::env::current_dir()?;
     let expected_target = expected_target_repository(config);
-    Ok(evaluate_issue_with_source_alignment(
+    let deterministic =
+        evaluate_issue_with_source_alignment(issue, &repo_root, expected_target.as_deref());
+    Ok(evaluate_issue_with_llm_gate(
         issue,
-        &repo_root,
-        expected_target.as_deref(),
+        deterministic,
+        &LlmGateOptions {
+            mode: LlmGateMode::parse(&config.quality_gate.llm.mode),
+            command: config.quality_gate.llm.command.clone(),
+            timeout_ms: config.quality_gate.llm.timeout_ms,
+        },
     ))
 }
 

--- a/src/quality_gate.rs
+++ b/src/quality_gate.rs
@@ -1,4 +1,8 @@
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 use crate::model::{GateDecision, GateDecisionKind, TrackerIssue};
 
@@ -118,6 +122,217 @@ pub fn evaluate_issue_with_source_alignment(
             ],
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LlmGateMode {
+    Disabled,
+    Advisory,
+    Required,
+}
+
+impl LlmGateMode {
+    pub fn parse(value: &str) -> Self {
+        match value {
+            "advisory" => Self::Advisory,
+            "required" => Self::Required,
+            _ => Self::Disabled,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LlmGateOptions {
+    pub mode: LlmGateMode,
+    pub command: Option<String>,
+    pub timeout_ms: u64,
+}
+
+pub fn evaluate_issue_with_llm_gate(
+    issue: &TrackerIssue,
+    deterministic: GateDecision,
+    options: &LlmGateOptions,
+) -> GateDecision {
+    if !deterministic.is_dispatchable() {
+        let mut decision = deterministic;
+        if !matches!(options.mode, LlmGateMode::Disabled) {
+            decision
+                .notes
+                .push("LLM gate skipped because deterministic gate failed.".into());
+        }
+        return decision;
+    }
+
+    match options.mode {
+        LlmGateMode::Disabled => deterministic,
+        LlmGateMode::Advisory => match run_llm_gate_command(issue, &deterministic, options) {
+            Ok(report) => advisory_decision(deterministic, report),
+            Err(error) => {
+                let mut decision = deterministic;
+                decision
+                    .notes
+                    .push(format!("LLM advisory gate unavailable: {error}"));
+                decision
+            }
+        },
+        LlmGateMode::Required => match run_llm_gate_command(issue, &deterministic, options) {
+            Ok(report) => report.into_gate_decision(),
+            Err(error) => GateDecision {
+                kind: GateDecisionKind::NeedToClarify,
+                missing: vec!["required LLM quality gate result".into()],
+                assumptions: deterministic.assumptions,
+                notes: vec![format!("Required LLM quality gate failed: {error}")],
+            },
+        },
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LlmGateReport {
+    kind: GateDecisionKind,
+    missing: Vec<String>,
+    assumptions: Vec<String>,
+    notes: Vec<String>,
+}
+
+impl LlmGateReport {
+    fn into_gate_decision(self) -> GateDecision {
+        GateDecision {
+            kind: self.kind,
+            missing: self.missing,
+            assumptions: self.assumptions,
+            notes: self.notes,
+        }
+    }
+}
+
+fn advisory_decision(mut deterministic: GateDecision, report: LlmGateReport) -> GateDecision {
+    deterministic
+        .notes
+        .push(format!("LLM advisory decision: {:?}", report.kind));
+    deterministic.notes.extend(
+        report
+            .missing
+            .into_iter()
+            .map(|item| format!("LLM finding: {item}")),
+    );
+    deterministic.assumptions.extend(
+        report
+            .assumptions
+            .into_iter()
+            .map(|item| format!("LLM: {item}")),
+    );
+    deterministic.notes.extend(report.notes);
+    deterministic
+}
+
+fn run_llm_gate_command(
+    issue: &TrackerIssue,
+    deterministic: &GateDecision,
+    options: &LlmGateOptions,
+) -> Result<LlmGateReport, String> {
+    let Some(command) = options
+        .command
+        .as_deref()
+        .filter(|command| !command.trim().is_empty())
+    else {
+        return Err("command not configured".into());
+    };
+
+    let request = serde_json::json!({
+        "title": issue.title,
+        "identifier": issue.identifier,
+        "body": issue.description.as_deref().unwrap_or_default(),
+        "deterministic": deterministic,
+    });
+    let mut child = Command::new("sh")
+        .arg("-lc")
+        .arg(command)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(request.to_string().as_bytes())
+            .map_err(|error| error.to_string())?;
+    }
+
+    let started = Instant::now();
+    let timeout = Duration::from_millis(options.timeout_ms.max(1));
+    loop {
+        if child
+            .try_wait()
+            .map_err(|error| error.to_string())?
+            .is_some()
+        {
+            let output = child
+                .wait_with_output()
+                .map_err(|error| error.to_string())?;
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(format!(
+                    "command exited with status {}: {}",
+                    output.status.code().unwrap_or(-1),
+                    stderr.trim()
+                ));
+            }
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            return parse_llm_gate_response(&stdout);
+        }
+
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("command timed out after {}ms", options.timeout_ms));
+        }
+
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn parse_llm_gate_response(raw: &str) -> Result<LlmGateReport, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(raw).map_err(|error| format!("malformed JSON: {error}"))?;
+    let decision = value
+        .get("decision")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| "missing `decision`".to_string())?;
+    let kind = parse_gate_kind(decision)
+        .ok_or_else(|| format!("unsupported LLM gate decision `{decision}`"))?;
+
+    Ok(LlmGateReport {
+        kind,
+        missing: string_array(value.get("missing")),
+        assumptions: string_array(value.get("assumptions")),
+        notes: string_array(value.get("notes")),
+    })
+}
+
+fn parse_gate_kind(value: &str) -> Option<GateDecisionKind> {
+    match value {
+        "Ready" => Some(GateDecisionKind::Ready),
+        "ReadyWithAssumptions" => Some(GateDecisionKind::ReadyWithAssumptions),
+        "NeedToClarify" => Some(GateDecisionKind::NeedToClarify),
+        "TooBroad" => Some(GateDecisionKind::TooBroad),
+        "Blocked" => Some(GateDecisionKind::Blocked),
+        "DuplicateAlreadyCovered" => Some(GateDecisionKind::DuplicateAlreadyCovered),
+        _ => None,
+    }
+}
+
+fn string_array(value: Option<&serde_json::Value>) -> Vec<String> {
+    value
+        .and_then(|value| value.as_array())
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.as_str().map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn has_explicit_blocked_decision(markdown: &str) -> bool {
@@ -469,6 +684,102 @@ mod tests {
             .missing
             .iter()
             .any(|item| item == "verification command"));
+    }
+
+    #[test]
+    fn required_llm_gate_can_pass_with_structured_output() {
+        let deterministic = GateDecision::ready();
+        let decision = evaluate_issue_with_llm_gate(
+            &issue(Some(aligned_body(
+                "Alive24/jade-symphony",
+                &[],
+                &[],
+                &["cargo test"],
+            ))),
+            deterministic,
+            &LlmGateOptions {
+                mode: LlmGateMode::Required,
+                command: Some("sh examples/fixtures/llm-gate-ready.sh".into()),
+                timeout_ms: 5_000,
+            },
+        );
+
+        assert_eq!(decision.kind, GateDecisionKind::ReadyWithAssumptions);
+        assert!(decision
+            .assumptions
+            .contains(&"LLM fixture says scope is coherent".to_string()));
+    }
+
+    #[test]
+    fn required_llm_gate_blocks_on_malformed_output() {
+        let decision = evaluate_issue_with_llm_gate(
+            &issue(Some(aligned_body(
+                "Alive24/jade-symphony",
+                &[],
+                &[],
+                &["cargo test"],
+            ))),
+            GateDecision::ready(),
+            &LlmGateOptions {
+                mode: LlmGateMode::Required,
+                command: Some("sh examples/fixtures/llm-gate-malformed.sh".into()),
+                timeout_ms: 5_000,
+            },
+        );
+
+        assert_eq!(decision.kind, GateDecisionKind::NeedToClarify);
+        assert!(decision
+            .notes
+            .iter()
+            .any(|note| note.contains("Required LLM quality gate failed")));
+    }
+
+    #[test]
+    fn advisory_llm_gate_records_finding_without_blocking() {
+        let decision = evaluate_issue_with_llm_gate(
+            &issue(Some(aligned_body(
+                "Alive24/jade-symphony",
+                &[],
+                &[],
+                &["cargo test"],
+            ))),
+            GateDecision::ready(),
+            &LlmGateOptions {
+                mode: LlmGateMode::Advisory,
+                command: Some("sh examples/fixtures/llm-gate-clarify.sh".into()),
+                timeout_ms: 5_000,
+            },
+        );
+
+        assert_eq!(decision.kind, GateDecisionKind::Ready);
+        assert!(decision
+            .notes
+            .iter()
+            .any(|note| note.contains("LLM advisory decision: NeedToClarify")));
+    }
+
+    #[test]
+    fn deterministic_failure_precedes_llm_gate() {
+        let deterministic = GateDecision {
+            kind: GateDecisionKind::NeedToClarify,
+            missing: vec!["verification command".into()],
+            assumptions: Vec::new(),
+            notes: Vec::new(),
+        };
+        let decision = evaluate_issue_with_llm_gate(
+            &issue(Some("thin".into())),
+            deterministic,
+            &LlmGateOptions {
+                mode: LlmGateMode::Required,
+                command: Some("sh examples/fixtures/llm-gate-ready.sh".into()),
+                timeout_ms: 5_000,
+            },
+        );
+
+        assert_eq!(decision.kind, GateDecisionKind::NeedToClarify);
+        assert!(decision
+            .notes
+            .contains(&"LLM gate skipped because deterministic gate failed.".to_string()));
     }
 
     fn aligned_body(target_repo: &str, docs: &[&str], paths: &[&str], commands: &[&str]) -> String {


### PR DESCRIPTION
## Summary
- add optional command-backed LLM Issue Quality Gate modes: disabled, advisory, required
- keep deterministic source-alignment failures ahead of LLM review
- add fixture-backed workflow/scripts and docs for dry-run use

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- gate examples/llm-gate-workflow.md '#1'

Closes #49