### PR TITLE
#67: Bound one-issue Review Agent worker selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ worker supervision are still future work.
   evidence for confirmed review findings, merge conflicts, dirty PRs,
   validation failures, and runtime failures before a transition to `Rework`.
 - `review-loop` can discover `Agent Review` issues, avoid duplicate review
-  worker markers, run a configured independent review backend in bounded mode,
-  and reconcile pass/rework/inconclusive transitions through the Review Agent
-  authority boundary.
+  worker markers, select a bounded set of one-issue review worker jobs, run each
+  configured independent review backend from the issue workspace, and reconcile
+  pass/rework/inconclusive transitions through the Review Agent authority
+  boundary.
 - Issue Forge can discover local candidates from intent, ask one focused
   clarification question, draft from the quality template, validate Markdown,
   repair rough Markdown into an executable issue contract shape, and create a
@@ -234,7 +235,8 @@ review can move `Agent Review` to `Human Review`, confirmed findings move to
 `review-loop` is the first runtime-style Review Agent command: it selects
 eligible `Agent Review` issues, prints intended review work in dry-run mode, and
 in write mode records review evidence plus the allowed review transition. It is
-bounded by `--max-iterations` or `--once` and is not a persistent daemon yet.
+bounded by `--max-iterations` or `--once`, supports `--max-concurrent`, and is
+not a persistent daemon yet.
 `review-freshness` is an evidence command for Merging conflict repair: it does
 not mutate tracker state, does not approve a PR, and does not authorize the main
 implementation agent to set `Human Review`. Mechanical conflict repair can

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -22,7 +22,7 @@ yet.
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Runtime reconciliation cleanup is not wired yet. |
 | Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Prepared runs include selected profile/instance metadata and profile environment context. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
-| Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings, review-freshness evidence for Merging conflict repair, bounded `review-loop` selection/reconciliation, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
+| Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings, review-freshness evidence for Merging conflict repair, bounded `review-loop` worker selection/reconciliation with one issue per worker slot, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
 | Merging | `merge-once` can inspect issues already in `Merging`, require one linked PR, check live GitHub PR state/review/check/mergeability data where available, merge clean approved PRs only with explicit `--write`, and route blockers to `Rework` or `Need Human Input` with workpad evidence. Continuous merge polling and issue closing beyond Project `Done` are not implemented yet. |
 | Project doctor | Read-only `doctor` / `audit-project` reports workflow invariant violations from normalized tracker issues, including missing PR handoff evidence, missing review pass evidence, dirty Merging PRs, missing runtime ownership hints, and queued issues with PRs. Repair mode is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events with actor and profile metadata. Runtime state files are written during write-mode `run-loop` issue execution, including actor role/label, git author, and optional profile/instance identity when configured; resume, retry, and stall supervision events are also recorded. No web/API surface yet. |
@@ -74,8 +74,9 @@ Project v2 issues:
    - Independent Review Agent commands can set `Human Review` only after a
      passed review with evidence.
    - Bounded `review-loop` can discover eligible `Agent Review` issues, skip
-     existing review-worker markers, and apply the same independent Review Agent
-     transition rules as `review-once`.
+     existing review-worker markers, select up to the configured concurrent
+     worker limit, and apply the same independent Review Agent transition rules
+     as `review-once`.
    - Confirmed findings route to `Rework`.
    - Failed, timed out, inconclusive, or unavailable reviews remain out of
      `Human Review` and route to `Need Human Input` or stay in `Agent Review`.
@@ -307,8 +308,8 @@ Goal: evolve the bounded `review-loop` into persistent worker supervision.
 Acceptance:
 
 - reviewer backend is selected through config.
-- one review worker per issue/PR is started and reconciled without blocking the
-  main run-loop.
+- one review worker per issue/PR is started and reconciled without batching
+  unrelated issues into one prompt or blocking the main run-loop.
 - review job identity, backend, artifact path, and result evidence are persisted
   in workpad/runtime state.
 - duplicate review workers are prevented across repeated loop ticks.

--- a/examples/review-fixture-workflow.md
+++ b/examples/review-fixture-workflow.md
@@ -38,6 +38,7 @@ review:
   backend: fake
   gemini_command: gemini
   timeout_ms: 600000
+  max_concurrent_workers: 2
 observability:
   logs_root: /tmp/jade-symphony-review-log
 ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,6 +129,7 @@ pub struct ReviewConfig {
     pub backend: String,
     pub gemini_command: String,
     pub timeout_ms: u64,
+    pub max_concurrent_workers: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -293,6 +294,9 @@ impl RuntimeConfig {
             gemini_command: get_string(root.get("review"), "gemini_command")
                 .unwrap_or_else(|| "gemini".to_string()),
             timeout_ms: get_u64(root.get("review"), "timeout_ms").unwrap_or(600_000),
+            max_concurrent_workers: get_u64(root.get("review"), "max_concurrent_workers")
+                .unwrap_or(1)
+                .max(1) as usize,
         };
         let quality_gate = parse_quality_gate(root.get("quality_gate"));
         let profiles = parse_profiles(root.get("profiles"), workflow_dir);
@@ -374,6 +378,10 @@ impl RuntimeConfig {
             self.agent.max_retry_backoff_ms,
         )?;
         require_positive("review.timeout_ms", self.review.timeout_ms)?;
+        require_positive(
+            "review.max_concurrent_workers",
+            self.review.max_concurrent_workers as u64,
+        )?;
         require_positive(
             "quality_gate.llm.timeout_ms",
             self.quality_gate.llm.timeout_ms,

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,88 +630,136 @@ fn review_loop(options: ReviewLoopOptions) -> Result<(), Box<dyn std::error::Err
         let issues = adapter
             .fetch_issues_by_states(std::slice::from_ref(&config.tracker.state_map.agent_review))?;
 
-        let Some(issue) = issues.first().cloned() else {
+        if issues.is_empty() {
             println!("review_loop=stopped reason=no_agent_review_issue iterations={iterations}");
             break;
         };
 
         let backend_kind = review_backend_kind(&config, options.fake_outcome.as_ref());
-        match review_run_eligibility(
-            &issue,
+        let selected = select_review_worker_issues(
+            &issues,
             &config.tracker.state_map.agent_review,
             &backend_kind,
-        ) {
-            ReviewRunEligibility::Eligible { worker_key } => {
-                println!(
-                    "review_loop_iteration={iterations} issue={} worker_key={worker_key} mode={}",
-                    issue.identifier,
-                    if options.write { "write" } else { "dry-run" }
-                );
-                if !options.write {
-                    println!(
-                        "review_loop_dry_run action=start issue={} backend={backend_kind}",
-                        issue.identifier
-                    );
-                    println!(
-                        "review_loop_dry_run action=workpad issue={} evidence=review_job",
-                        issue.identifier
-                    );
-                    println!(
-                        "review_loop_dry_run action=reconcile issue={} actor=independent_review_agent",
-                        issue.identifier
-                    );
-                    if limit.is_none() {
-                        println!(
-                            "review_loop=stopped reason=dry_run_would_repeat_without_mutation iterations={iterations}"
-                        );
-                        break;
-                    }
-                    continue;
-                }
+            options.worker_limit(&config),
+        );
 
-                let latest = adapter.get_issue(&issue.identifier)?.ok_or_else(|| {
-                    format!("issue disappeared before review: {}", issue.identifier)
-                })?;
+        if selected.is_empty() {
+            for issue in issues {
                 match review_run_eligibility(
-                    &latest,
+                    &issue,
                     &config.tracker.state_map.agent_review,
                     &backend_kind,
                 ) {
-                    ReviewRunEligibility::Eligible { .. } => {
-                        let job = run_review_job(&config, &latest, options.fake_outcome.clone())?;
-                        apply_review_result(adapter.as_ref(), &latest.identifier, &latest, &job)?;
-                        let decision = review_gate_decision(&job);
-                        println!(
-                            "review_loop_action=reconciled issue={} backend={} outcome={:?} target_state={:?}",
-                            latest.identifier, job.backend, decision.outcome, decision.target_state
-                        );
-                    }
                     ReviewRunEligibility::AlreadyQueued { worker_key } => {
                         println!(
                             "review_loop_action=skip issue={} reason=review_worker_exists worker_key={worker_key}",
-                            latest.identifier
+                            issue.identifier
                         );
                     }
                     ReviewRunEligibility::NotInAgentReview { current_state } => {
                         println!(
                             "review_loop_action=skip issue={} reason=state_changed current_state={current_state:?}",
-                            latest.identifier
+                            issue.identifier
                         );
                     }
+                    ReviewRunEligibility::Eligible { .. } => {}
                 }
             }
-            ReviewRunEligibility::AlreadyQueued { worker_key } => {
-                println!(
+            continue;
+        }
+
+        for (slot, selected_issue) in selected.into_iter().enumerate() {
+            let worker_slot = slot + 1;
+            match review_run_eligibility(
+                &selected_issue,
+                &config.tracker.state_map.agent_review,
+                &backend_kind,
+            ) {
+                ReviewRunEligibility::Eligible { worker_key } => {
+                    println!(
+                    "review_loop_iteration={iterations} worker_slot={worker_slot} issue={} worker_key={worker_key} mode={}",
+                    selected_issue.identifier,
+                    if options.write { "write" } else { "dry-run" }
+                );
+                    if !options.write {
+                        println!(
+                            "review_loop_dry_run action=start issue={} backend={backend_kind}",
+                            selected_issue.identifier
+                        );
+                        println!(
+                            "review_loop_dry_run action=workpad issue={} evidence=review_job",
+                            selected_issue.identifier
+                        );
+                        println!(
+                        "review_loop_dry_run action=reconcile issue={} actor=independent_review_agent",
+                        selected_issue.identifier
+                    );
+                        continue;
+                    }
+
+                    let latest =
+                        adapter
+                            .get_issue(&selected_issue.identifier)?
+                            .ok_or_else(|| {
+                                format!(
+                                    "issue disappeared before review: {}",
+                                    selected_issue.identifier
+                                )
+                            })?;
+                    match review_run_eligibility(
+                        &latest,
+                        &config.tracker.state_map.agent_review,
+                        &backend_kind,
+                    ) {
+                        ReviewRunEligibility::Eligible { .. } => {
+                            let job =
+                                run_review_job(&config, &latest, options.fake_outcome.clone())?;
+                            apply_review_result(
+                                adapter.as_ref(),
+                                &latest.identifier,
+                                &latest,
+                                &job,
+                            )?;
+                            let decision = review_gate_decision(&job);
+                            println!(
+                            "review_loop_action=reconciled issue={} backend={} outcome={:?} target_state={:?}",
+                            latest.identifier, job.backend, decision.outcome, decision.target_state
+                        );
+                        }
+                        ReviewRunEligibility::AlreadyQueued { worker_key } => {
+                            println!(
+                            "review_loop_action=skip issue={} reason=review_worker_exists worker_key={worker_key}",
+                            latest.identifier
+                        );
+                        }
+                        ReviewRunEligibility::NotInAgentReview { current_state } => {
+                            println!(
+                            "review_loop_action=skip issue={} reason=state_changed current_state={current_state:?}",
+                            latest.identifier
+                        );
+                        }
+                    }
+                }
+                ReviewRunEligibility::AlreadyQueued { worker_key } => {
+                    println!(
                     "review_loop_action=skip issue={} reason=review_worker_exists worker_key={worker_key}",
-                    issue.identifier
+                    selected_issue.identifier
                 );
-            }
-            ReviewRunEligibility::NotInAgentReview { current_state } => {
-                println!(
+                }
+                ReviewRunEligibility::NotInAgentReview { current_state } => {
+                    println!(
                     "review_loop_action=skip issue={} reason=state_changed current_state={current_state:?}",
-                    issue.identifier
+                    selected_issue.identifier
                 );
+                }
             }
+        }
+
+        if !options.write && limit.is_none() {
+            println!(
+                "review_loop=stopped reason=dry_run_would_repeat_without_mutation iterations={iterations}"
+            );
+            break;
         }
     }
 
@@ -855,6 +903,25 @@ fn review_backend_kind(config: &RuntimeConfig, fake_outcome: Option<&FakeReviewO
     }
 }
 
+fn select_review_worker_issues(
+    issues: &[TrackerIssue],
+    agent_review_state: &str,
+    backend_kind: &str,
+    max_concurrent: usize,
+) -> Vec<TrackerIssue> {
+    issues
+        .iter()
+        .filter(|issue| {
+            matches!(
+                review_run_eligibility(issue, agent_review_state, backend_kind),
+                ReviewRunEligibility::Eligible { .. }
+            )
+        })
+        .take(max_concurrent.max(1))
+        .cloned()
+        .collect()
+}
+
 fn run_review_job(
     config: &RuntimeConfig,
     issue: &TrackerIssue,
@@ -868,7 +935,7 @@ fn run_review_job(
             issue.title,
             issue.description.as_deref().unwrap_or_default()
         ),
-        workspace: config.workspace.root.clone(),
+        workspace: review_workspace_for_issue(config, issue),
         artifact_root: config.observability.logs_root.join("reviews"),
     };
 
@@ -894,6 +961,12 @@ fn run_review_job(
             Ok(backend.poll(backend.start(request)?)?)
         }
     }
+}
+
+fn review_workspace_for_issue(config: &RuntimeConfig, issue: &TrackerIssue) -> PathBuf {
+    run_loop_handoff_plan(config, issue)
+        .map(|handoff| handoff.workspace_path)
+        .unwrap_or_else(|_| config.workspace.root.clone())
 }
 
 fn apply_review_result(
@@ -2204,6 +2277,7 @@ struct ReviewLoopOptions {
     once: bool,
     write: bool,
     fake_outcome: Option<FakeReviewOutcome>,
+    max_concurrent: Option<usize>,
 }
 
 impl ReviewLoopOptions {
@@ -2213,6 +2287,12 @@ impl ReviewLoopOptions {
         } else {
             self.max_iterations
         }
+    }
+
+    fn worker_limit(&self, config: &RuntimeConfig) -> usize {
+        self.max_concurrent
+            .unwrap_or(config.review.max_concurrent_workers)
+            .max(1)
     }
 }
 
@@ -2471,6 +2551,8 @@ struct ReviewLoopArgs {
     once: bool,
     #[arg(long)]
     write: bool,
+    #[arg(long = "max-concurrent")]
+    max_concurrent: Option<usize>,
     #[arg(long = "dry-run")]
     _dry_run: bool,
     #[arg(long = "fake-outcome", value_enum)]
@@ -2714,7 +2796,7 @@ impl TryFrom<Cli> for Command {
                         },
                     }),
                     CliCommand::ReviewLoop(args) => {
-                        if args.max_iterations == Some(0) {
+                        if args.max_iterations == Some(0) || args.max_concurrent == Some(0) {
                             return Err(usage());
                         }
                         Ok(Self::ReviewLoop {
@@ -2724,6 +2806,7 @@ impl TryFrom<Cli> for Command {
                                 once: args.once,
                                 write: args.write,
                                 fake_outcome: args.fake_outcome.map(Into::into),
+                                max_concurrent: args.max_concurrent,
                             },
                         })
                     }
@@ -2963,6 +3046,14 @@ mod tests {
             created_at: None,
             updated_at: None,
         }
+    }
+
+    fn tracker_issue_with_ref(identifier: &str, title: &str, state: &str) -> TrackerIssue {
+        let mut issue = tracker_issue(state);
+        issue.identifier = identifier.into();
+        issue.title = title.into();
+        issue.branch_name = None;
+        issue
     }
 
     #[derive(Default)]
@@ -3253,6 +3344,8 @@ mod tests {
             "2".into(),
             "--fake-outcome".into(),
             "confirmed".into(),
+            "--max-concurrent".into(),
+            "2".into(),
             "--write".into(),
         ])
         .unwrap();
@@ -3270,6 +3363,7 @@ mod tests {
             options.fake_outcome,
             Some(FakeReviewOutcome::ConfirmedFinding)
         );
+        assert_eq!(options.max_concurrent, Some(2));
         assert!(options.write);
     }
 
@@ -3289,6 +3383,55 @@ mod tests {
         };
 
         assert_eq!(options.iteration_limit(), Some(1));
+    }
+
+    #[test]
+    fn review_worker_selection_respects_concurrency_limit() {
+        let selected = select_review_worker_issues(
+            &[
+                tracker_issue_with_ref("#67", "First review", "Agent Review"),
+                tracker_issue_with_ref("#68", "Second review", "Agent Review"),
+                tracker_issue_with_ref("#69", "Third review", "Agent Review"),
+            ],
+            "Agent Review",
+            "fake-reviewer",
+            2,
+        );
+
+        assert_eq!(
+            selected
+                .iter()
+                .map(|issue| issue.identifier.as_str())
+                .collect::<Vec<_>>(),
+            vec!["#67", "#68"]
+        );
+    }
+
+    #[test]
+    fn review_worker_selection_skips_existing_worker_marker() {
+        let mut queued = tracker_issue_with_ref("#67", "Queued review", "Agent Review");
+        queued.project_fields.insert(
+            "Review Worker".into(),
+            serde_json::Value::String("queued review:#67:fake-reviewer".into()),
+        );
+        let ready = tracker_issue_with_ref("#68", "Ready review", "Agent Review");
+
+        let selected =
+            select_review_worker_issues(&[queued, ready], "Agent Review", "fake-reviewer", 2);
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].identifier, "#68");
+    }
+
+    #[test]
+    fn review_workspace_uses_issue_handoff_workspace() {
+        let config = test_config();
+        let issue =
+            tracker_issue_with_ref("#67", "Add parallel review worker pool", "Agent Review");
+
+        let workspace = review_workspace_for_issue(&config, &issue);
+
+        assert!(workspace.ends_with("issue-67-add-parallel-review-worker-pool"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add configurable review-loop concurrency via review.max_concurrent_workers and --max-concurrent
- select a bounded set of eligible Agent Review issues while skipping existing worker markers
- run each review job with the issue handoff workspace as current_dir input
- document the bounded worker-slot behavior without claiming persistent supervision

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

Closes #67