### PR TITLE
#85: Add credential-gated live GitHub smoke tests

### DIFF
--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -27,7 +27,7 @@ yet.
 | Project doctor | Read-only `doctor` / `audit-project` reports workflow invariant violations from normalized tracker issues, including missing PR handoff evidence, missing review pass evidence, dirty Merging PRs, missing runtime ownership hints, and queued issues with PRs. Repair mode is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events with actor and profile metadata. Runtime state files are written during write-mode `run-loop` issue execution, including actor role/label, git author, and optional profile/instance identity when configured; resume, retry, usage-limit pause, and stall supervision events are also recorded. No web/API surface yet. |
 | Usage-limit pause/resume | Conservative usage-limit/rate-limit/resource-exhausted classification exists for subprocess agent events and review job output. `run-loop` records usage-limit pauses in workpad/runtime retry state and does not advance to `Agent Review`; review workpads surface usage-limit failures without moving to `Human Review`. Vendor-specific quota management is not implemented. |
-| Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
+| Tests | Unit tests cover the dry-run skeleton. Read-only / dry-run live GitHub smoke tests exist behind explicit `JADE_LIVE_GITHUB_SMOKE=1` opt-in; mutation and Linear credential-gated smoke coverage are still missing. |
 
 The operator launcher runbook is in `docs/operator-dogfood.md`; it keeps write
 mode explicit through `scripts/jade-dogfood --write --confirm-write`.

--- a/docs/live-github-smoke-tests.md
+++ b/docs/live-github-smoke-tests.md
@@ -1,0 +1,38 @@
+# Live GitHub Smoke Tests
+
+These integration tests are opt-in checks for a real GitHub Project v2
+workflow. They are read-only / dry-run only in this slice, and ordinary
+`cargo test` skips them without credentials.
+
+## Prerequisites
+
+- `gh` is installed.
+- `gh auth status` succeeds for the `Alive24/jade-symphony` repository.
+- The workflow at `examples/github-project-workflow.md` points at the intended
+  GitHub Project v2 tracker.
+
+No tokens or secrets are printed by the tests.
+
+## Run
+
+```bash
+JADE_LIVE_GITHUB_SMOKE=1 cargo test --test live_github_smoke
+```
+
+The smoke runs:
+
+- `jade-symphony inspect examples/github-project-workflow.md`
+- `jade-symphony dogfood-smoke examples/github-project-workflow.md --dry-run`
+
+## Expected Behavior
+
+- Without `JADE_LIVE_GITHUB_SMOKE=1`, the tests print a skip message and pass.
+- With the flag set, missing or unusable `gh` authentication is a test failure.
+- The smoke must not mutate GitHub Project state, workpad comments, issues, or
+  PRs.
+
+## Follow-Ups
+
+Mutation smoke tests for status updates, workpad upsert, and controlled
+worktree/PR handoff should remain separate opt-in slices with their own
+guardrails.

--- a/tests/live_github_smoke.rs
+++ b/tests/live_github_smoke.rs
@@ -1,0 +1,82 @@
+use std::process::{Command, Output};
+
+const LIVE_SMOKE_ENV: &str = "JADE_LIVE_GITHUB_SMOKE";
+const WORKFLOW: &str = "examples/github-project-workflow.md";
+
+fn live_smoke_enabled() -> bool {
+    matches!(
+        std::env::var(LIVE_SMOKE_ENV).as_deref(),
+        Ok("1") | Ok("true") | Ok("yes")
+    )
+}
+
+fn repo_root() -> &'static str {
+    env!("CARGO_MANIFEST_DIR")
+}
+
+fn combined_output(output: &Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn require_live_smoke() -> bool {
+    if !live_smoke_enabled() {
+        eprintln!("skipping live GitHub smoke; set {LIVE_SMOKE_ENV}=1 to enable");
+        return false;
+    }
+
+    let output = Command::new("gh")
+        .args(["auth", "status"])
+        .current_dir(repo_root())
+        .output()
+        .expect("failed to execute `gh auth status`");
+    assert!(
+        output.status.success(),
+        "live smoke requires usable gh auth\n{}",
+        combined_output(&output)
+    );
+    true
+}
+
+fn run_jade(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_jade-symphony"))
+        .args(args)
+        .current_dir(repo_root())
+        .output()
+        .expect("failed to execute jade-symphony binary")
+}
+
+#[test]
+fn live_github_project_inspect_smoke() {
+    if !require_live_smoke() {
+        return;
+    }
+
+    let output = run_jade(&["inspect", WORKFLOW]);
+    let text = combined_output(&output);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("issues="), "{text}");
+    assert!(
+        !text.contains("no usable GitHub auth was detected"),
+        "inspect should not report missing auth when live smoke is enabled\n{text}"
+    );
+}
+
+#[test]
+fn live_github_dogfood_smoke_dry_run_is_read_only() {
+    if !require_live_smoke() {
+        return;
+    }
+
+    let output = run_jade(&["dogfood-smoke", WORKFLOW, "--dry-run"]);
+    let text = combined_output(&output);
+    assert!(output.status.success(), "{text}");
+    assert!(text.contains("dogfood_smoke="), "{text}");
+    assert!(
+        text.contains("dry_run") || text.contains("blocked"),
+        "dogfood smoke should remain dry-run/read-only in this smoke\n{text}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add skipped-by-default live GitHub smoke integration tests.
- Gate live execution behind `JADE_LIVE_GITHUB_SMOKE=1`.
- Exercise read-only `inspect` and dry-run `dogfood-smoke` against the live workflow.
- Add a short runbook for operators.

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `JADE_LIVE_GITHUB_SMOKE=1 cargo test --test live_github_smoke`

Closes #85
