### PR TITLE
#91: Run configured verification before PR handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ worker supervision are still future work.
   `Need Human Input` with a workpad diagnostic.
 - live GitHub `run-loop --write` can create or reuse the planned issue
   worktree/branch, run the configured backend inside that worktree, push the
-  branch, and create or reuse one GitHub PR after successful execution.
+  branch, run optional configured verification commands, and create or reuse
+  one GitHub PR after successful execution and verification.
 - live GitHub `run-loop --write` checks assignee ownership before claim:
   unassigned issues require an explicit workflow override, and assigned issues
   must match the current `gh` login or a selected profile login exposed through
@@ -298,6 +299,7 @@ Merging role separation.
 - full multi-worker runtime-state resume reconciliation after interruption.
 - richer workspace-per-issue branch and PR reconciliation beyond current
   create-or-reuse handoff.
+- richer verification modeling beyond the current workflow-level command list.
 - continuation retries and automated stall restart.
 - richer vendor-specific quota handling beyond conservative usage-limit
   pattern matching.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -19,7 +19,7 @@ yet.
 | Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies target repository, referenced local paths, and supported verification command shapes. Optional local command-backed LLM gate mode exists as disabled/advisory/required; richer semantic validation and hosted providers are still follow-ups. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, resume preflight, retry backoff records, stall detection, live PR handoff in non-fixture GitHub mode, guarded `merge-once` and bounded `merge-loop` lanes for `Merging` issues, a controlled `dogfood-smoke` preflight report, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, unbounded merge idle polling, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Runtime reconciliation cleanup is not wired yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, optional configured verification commands before PR handoff, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Runtime reconciliation cleanup is not wired yet. |
 | Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Prepared runs include selected profile/instance metadata and profile environment context. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings, review-freshness evidence for Merging conflict repair, bounded `review-loop` worker selection/reconciliation with one issue per worker slot, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
@@ -136,9 +136,9 @@ Project v2 issues:
      reconciliation remains pending.
    - workspace/branch/PR handoff is recorded by `run-loop`; in live
      non-fixture GitHub mode the runtime can create/reuse the issue worktree and
-     branch, push the branch, and create/reuse one PR after successful backend
-     execution. Remaining work: cleanup, richer reconciliation, and stronger
-     verification command modeling.
+     branch, run optional configured verification commands, push the branch, and
+     create/reuse one PR after successful backend execution. Remaining work:
+     cleanup, richer reconciliation, and richer verification modeling.
    - Local git identity application exists for prepared git repositories; the
      live worktree path must continue to apply it before commits and preserve the
      distinction between agent actors and human operators.
@@ -308,7 +308,8 @@ Acceptance:
 - reconciles existing worktrees with tracker state before reuse.
 - records PR URL and branch evidence in the tracker workpad.
 - detects missing remote commits or no-op branches before PR creation.
-- adds configured verification command execution before push/PR handoff.
+- adds configured verification command execution before push/PR handoff. (First
+  workflow-level command-list slice exists.)
 - cleans terminal worktrees after tracker reconciliation.
 - keeps main implementation completion at `Agent Review`.
 

--- a/examples/github-project-workflow.md
+++ b/examples/github-project-workflow.md
@@ -50,6 +50,9 @@ review:
   backend: fake
   gemini_command: gemini
   timeout_ms: 600000
+verification:
+  timeout_ms: 600000
+  commands: []
 observability:
   logs_root: /tmp/jade-symphony-logs
 ---

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct RuntimeConfig {
     pub claude: ClaudeConfig,
     pub review: ReviewConfig,
     pub quality_gate: QualityGateConfig,
+    pub verification: VerificationConfig,
     pub profiles: ProfilesConfig,
     pub identity: IdentityConfig,
     pub observability: ObservabilityConfig,
@@ -135,6 +136,12 @@ pub struct ReviewConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QualityGateConfig {
     pub llm: LlmQualityGateConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct VerificationConfig {
+    pub commands: Vec<String>,
+    pub timeout_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -299,6 +306,7 @@ impl RuntimeConfig {
                 .max(1) as usize,
         };
         let quality_gate = parse_quality_gate(root.get("quality_gate"));
+        let verification = parse_verification(root.get("verification"));
         let profiles = parse_profiles(root.get("profiles"), workflow_dir);
         let identity = parse_identity(root.get("identity"));
         let observability = ObservabilityConfig {
@@ -329,6 +337,7 @@ impl RuntimeConfig {
             claude,
             review,
             quality_gate,
+            verification,
             profiles,
             identity,
             observability,
@@ -386,6 +395,7 @@ impl RuntimeConfig {
             "quality_gate.llm.timeout_ms",
             self.quality_gate.llm.timeout_ms,
         )?;
+        require_positive("verification.timeout_ms", self.verification.timeout_ms)?;
 
         if self.tracker.kind == "github_project_v2" {
             require_present("tracker.owner", self.tracker.owner.as_deref())?;
@@ -522,6 +532,13 @@ fn parse_quality_gate(value: Option<&Value>) -> QualityGateConfig {
             command: get_string(llm, "command"),
             timeout_ms: get_u64(llm, "timeout_ms").unwrap_or(120_000),
         },
+    }
+}
+
+fn parse_verification(value: Option<&Value>) -> VerificationConfig {
+    VerificationConfig {
+        commands: get_string_vec(value, "commands").unwrap_or_default(),
+        timeout_ms: get_u64(value, "timeout_ms").unwrap_or(600_000),
     }
 }
 
@@ -852,6 +869,24 @@ mod tests {
             Some("sh examples/fixtures/llm-gate-ready.sh")
         );
         assert_eq!(config.quality_gate.llm.timeout_ms, 5_000);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn parses_handoff_verification_config() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nverification:\n  timeout_ms: 15000\n  commands:\n    - cargo test\n    - cargo fmt --check\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert_eq!(config.verification.timeout_ms, 15_000);
+        assert_eq!(
+            config.verification.commands,
+            vec!["cargo test".to_string(), "cargo fmt --check".to_string()]
+        );
         assert!(config.validate().is_ok());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ use jade_symphony::tracker::{
 use jade_symphony::workflow::WorkflowDefinition;
 use jade_symphony::workspace::{
     apply_local_git_identity, prepare_workspace, profile_scoped_identifier, run_after_run,
-    run_before_run, GitIdentityApplyResult,
+    run_before_run, run_workspace_command, GitIdentityApplyResult,
 };
 
 const DEFAULT_RUN_LOOP_BASE_BRANCH: &str = "main";
@@ -1327,6 +1327,7 @@ struct IssueExecutionResult {
     git_author: Option<String>,
     git_identity: GitIdentityApplyResult,
     live_handoff: Option<RunLoopLiveHandoff>,
+    handoff_verification: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1334,6 +1335,12 @@ struct RunLoopLiveHandoff {
     worktree: LiveWorktreeResult,
     publication: PullRequestPublication,
     verification: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HandoffVerification {
+    success: bool,
+    summary: String,
 }
 
 fn execute_issue_once(
@@ -1406,6 +1413,7 @@ fn execute_issue_once_with_workspace_key(
         git_author: config.identity.git.author(),
         git_identity,
         live_handoff: None,
+        handoff_verification: None,
     })
 }
 
@@ -1668,22 +1676,34 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         if result.success {
             if let Some(worktree) = live_worktree {
                 let runner = ProcessHandoffCommandRunner;
-                match publish_issue_pull_request(&handoff, &runner) {
-                    Ok(publication) => {
-                        println!(
-                            "run_loop_action=pr issue={} url={} created={}",
-                            latest.identifier, publication.pr_url, publication.pr_created
-                        );
-                        result.live_handoff = Some(RunLoopLiveHandoff {
-                            worktree,
-                            publication,
-                            verification: "skipped:not_configured".into(),
-                        });
+                let verification = run_handoff_verification(&handoff.workspace_path, &config);
+                println!(
+                    "run_loop_action=verify issue={} success={} summary={}",
+                    latest.identifier, verification.success, verification.summary
+                );
+                result.handoff_verification = Some(verification.summary.clone());
+                if verification.success {
+                    match publish_issue_pull_request(&handoff, &runner) {
+                        Ok(publication) => {
+                            println!(
+                                "run_loop_action=pr issue={} url={} created={}",
+                                latest.identifier, publication.pr_url, publication.pr_created
+                            );
+                            result.live_handoff = Some(RunLoopLiveHandoff {
+                                worktree,
+                                publication,
+                                verification: verification.summary,
+                            });
+                        }
+                        Err(error) => {
+                            result.success = false;
+                            result.message = format!("handoff publication failed: {error}");
+                        }
                     }
-                    Err(error) => {
-                        result.success = false;
-                        result.message = format!("handoff publication failed: {error}");
-                    }
+                } else {
+                    result.success = false;
+                    result.message =
+                        format!("handoff verification failed: {}", verification.summary);
                 }
             }
         }
@@ -2161,6 +2181,56 @@ fn run_loop_live_handoff_enabled(config: &RuntimeConfig) -> bool {
     config.tracker.kind == "github_project_v2" && config.tracker.fixture_path.is_none()
 }
 
+fn run_handoff_verification(workspace_path: &Path, config: &RuntimeConfig) -> HandoffVerification {
+    if config.verification.commands.is_empty() {
+        return HandoffVerification {
+            success: true,
+            summary: "skipped:not_configured".into(),
+        };
+    }
+
+    for (index, command) in config.verification.commands.iter().enumerate() {
+        let label = format!("verification:{}", index + 1);
+        if let Err(error) = run_workspace_command(
+            &label,
+            command,
+            workspace_path,
+            config.verification.timeout_ms,
+        ) {
+            return HandoffVerification {
+                success: false,
+                summary: format!(
+                    "failed command={} index={} error={}",
+                    shell_summary(command),
+                    index + 1,
+                    compact_evidence(&error.to_string())
+                ),
+            };
+        }
+    }
+
+    HandoffVerification {
+        success: true,
+        summary: format!("passed:{} command(s)", config.verification.commands.len()),
+    }
+}
+
+fn shell_summary(command: &str) -> String {
+    let compact = compact_evidence(command);
+    format!("`{compact}`")
+}
+
+fn compact_evidence(value: &str) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    const LIMIT: usize = 240;
+    let truncated = compact.chars().take(LIMIT).collect::<String>();
+    if truncated.len() < compact.len() {
+        format!("{truncated}...")
+    } else {
+        compact
+    }
+}
+
 fn handle_run_loop_gate_failure(
     adapter: &dyn jade_symphony::tracker::TrackerAdapter,
     issue: &TrackerIssue,
@@ -2260,6 +2330,18 @@ fn print_run_loop_dry_run_actions(
         handoff.workspace_path.display(),
         handoff.branch_name
     );
+    let verification_summary = if config.verification.commands.is_empty() {
+        "skipped:not_configured".to_string()
+    } else {
+        format!(
+            "configured:{} command(s)",
+            config.verification.commands.len()
+        )
+    };
+    println!(
+        "run_loop_dry_run action=verify issue={} summary={}",
+        issue.identifier, verification_summary
+    );
     println!(
         "run_loop_dry_run action=pr issue={} head={} base={}",
         issue.identifier, handoff.branch_name, handoff.pull_request.base_branch
@@ -2319,6 +2401,7 @@ fn run_loop_handoff_workpad(
         format!("- PR title: `{}`", handoff.pull_request.title),
         format!("- PR base branch: `{}`", handoff.pull_request.base_branch),
         rework_continuation_workpad_line(handoff),
+        handoff_verification_workpad_line(result),
         live_handoff_workpad_line(result),
         String::new(),
         "### Main-Agent Boundary".to_string(),
@@ -2336,6 +2419,16 @@ fn rework_continuation_workpad_line(handoff: &IssueHandoffPlan) -> String {
         ),
         None => "- Rework continuation: `not-used`".to_string(),
     }
+}
+
+fn handoff_verification_workpad_line(result: &IssueExecutionResult) -> String {
+    format!(
+        "- Handoff verification: `{}`",
+        result
+            .handoff_verification
+            .as_deref()
+            .unwrap_or("skipped:not_run")
+    )
 }
 
 fn live_handoff_workpad_line(result: &IssueExecutionResult) -> String {
@@ -4234,6 +4327,7 @@ mod tests {
                 applied_keys: vec!["user.name".into(), "user.email".into()],
             },
             live_handoff: None,
+            handoff_verification: None,
         };
 
         let state = run_loop_runtime_state_with_result(state, &result);
@@ -4341,6 +4435,7 @@ mod tests {
                 },
                 verification: "skipped:not_configured".into(),
             }),
+            handoff_verification: Some("skipped:not_configured".into()),
         };
 
         let workpad = run_loop_handoff_workpad(&issue, &result, &handoff);
@@ -4355,7 +4450,50 @@ mod tests {
         assert!(workpad
             .contains("Branch: `feature/issue-29-wire-runtime-state-persistence-into-run-loop`"));
         assert!(workpad.contains("PR title: `#29: Wire runtime state persistence into run-loop`"));
+        assert!(workpad.contains("Handoff verification: `skipped:not_configured`"));
         assert!(workpad.contains("Live PR: `https://github.com/Alive24/jade-symphony/pull/45`"));
+    }
+
+    #[test]
+    fn handoff_verification_skips_when_not_configured() {
+        let config = test_config();
+        let temp = tempfile::tempdir().unwrap();
+
+        let verification = run_handoff_verification(temp.path(), &config);
+
+        assert!(verification.success);
+        assert_eq!(verification.summary, "skipped:not_configured");
+    }
+
+    #[test]
+    fn handoff_verification_runs_configured_commands() {
+        let mut config = test_config();
+        config.verification.commands = vec!["printf verified > verification.txt".into()];
+        config.verification.timeout_ms = 5_000;
+        let temp = tempfile::tempdir().unwrap();
+
+        let verification = run_handoff_verification(temp.path(), &config);
+
+        assert!(verification.success);
+        assert_eq!(verification.summary, "passed:1 command(s)");
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("verification.txt")).unwrap(),
+            "verified"
+        );
+    }
+
+    #[test]
+    fn handoff_verification_failure_blocks_success() {
+        let mut config = test_config();
+        config.verification.commands = vec!["echo nope >&2; exit 7".into()];
+        config.verification.timeout_ms = 5_000;
+        let temp = tempfile::tempdir().unwrap();
+
+        let verification = run_handoff_verification(temp.path(), &config);
+
+        assert!(!verification.success);
+        assert!(verification.summary.contains("failed command=`echo nope"));
+        assert!(verification.summary.contains("status 7"));
     }
 
     #[test]
@@ -4382,6 +4520,7 @@ mod tests {
                 applied_keys: Vec::new(),
             },
             live_handoff: None,
+            handoff_verification: None,
         };
         let pause = result.usage_limit_pause.as_ref().unwrap();
         let workpad = run_loop_usage_limit_pause_workpad(&issue, &result, pause, 20_000);
@@ -4453,6 +4592,7 @@ mod tests {
                 applied_keys: vec!["user.name".into(), "user.email".into()],
             },
             live_handoff: None,
+            handoff_verification: None,
         };
 
         let evidence = run_loop_agent_review_handoff_evidence(&issue, &result, &handoff);
@@ -4497,6 +4637,7 @@ mod tests {
                 applied_keys: vec!["user.name".into(), "user.email".into()],
             },
             live_handoff: None,
+            handoff_verification: None,
         };
 
         let evidence = run_loop_agent_review_handoff_evidence(&issue, &result, &handoff);

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -197,6 +197,15 @@ pub fn run_after_run(path: &Path, hooks: &HooksConfig) {
     }
 }
 
+pub fn run_workspace_command(
+    label: &str,
+    command: &str,
+    path: &Path,
+    timeout_ms: u64,
+) -> Result<HookResult, WorkspaceError> {
+    run_hook(label, command, path, timeout_ms)
+}
+
 pub fn remove_issue_workspace(
     root: &Path,
     identifier: &str,


### PR DESCRIPTION
## Summary

- Adds optional workflow-level `verification.commands` for live run-loop handoff.
- Runs configured verification commands inside the issue worktree before branch push / PR publication.
- Records verification evidence in dry-run output and workpad handoff evidence, while preserving `skipped:not_configured` for workflows without commands.
- Blocks PR publication and `Agent Review` transition when configured handoff verification fails.

## Verification

- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

Closes #91
