### PR TITLE
#93: Block dirty or no-op PR handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ worker supervision are still future work.
   `Need Human Input` with a workpad diagnostic.
 - live GitHub `run-loop --write` can create or reuse the planned issue
   worktree/branch, run the configured backend inside that worktree, push the
-  branch, and create or reuse one GitHub PR after successful execution.
+  branch, and create or reuse one GitHub PR after successful execution; the
+  handoff helper blocks dirty worktrees and branches with no commits ahead of
+  the configured base before publishing.
 - terminal status output reports polling state, planned running/skipped/retrying
   issues, token counters, event-log path, gate details, and integration gaps.
 - `doctor` / `audit-project` can read the configured tracker and report
@@ -286,7 +288,7 @@ Merging role separation.
   current claim helper and resume preflight.
 - full multi-worker runtime-state resume reconciliation after interruption.
 - richer workspace-per-issue branch and PR reconciliation beyond current
-  create-or-reuse handoff.
+  dirty/no-op guarded create-or-reuse handoff.
 - continuation retries and automated stall restart.
 - richer vendor-specific quota handling beyond conservative usage-limit
   pattern matching.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -19,7 +19,7 @@ yet.
 | Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies target repository, referenced local paths, and supported verification command shapes. Optional local command-backed LLM gate mode exists as disabled/advisory/required; richer semantic validation and hosted providers are still follow-ups. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, resume preflight, retry backoff records, stall detection, live PR handoff in non-fixture GitHub mode, a guarded one-shot `merge-once` lane for `Merging` issues, a controlled `dogfood-smoke` preflight report, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, `merge-loop`, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Runtime reconciliation cleanup is not wired yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, dirty/no-op guards before branch push, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Runtime reconciliation cleanup is not wired yet. |
 | Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Prepared runs include selected profile/instance metadata and profile environment context. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings, review-freshness evidence for Merging conflict repair, bounded `review-loop` selection/reconciliation, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
@@ -131,9 +131,10 @@ Project v2 issues:
      reconciliation remains pending.
    - workspace/branch/PR handoff is recorded by `run-loop`; in live
      non-fixture GitHub mode the runtime can create/reuse the issue worktree and
-     branch, push the branch, and create/reuse one PR after successful backend
-     execution. Remaining work: cleanup, richer reconciliation, and stronger
-     verification command modeling.
+     branch, block dirty or no-op branch handoff, push the branch, and
+     create/reuse one PR after successful backend execution. Remaining work:
+     cleanup, richer reconciliation, and stronger verification command
+     modeling.
    - Local git identity application exists for prepared git repositories; the
      live worktree path must continue to apply it before commits and preserve the
      distinction between agent actors and human operators.
@@ -299,7 +300,8 @@ Acceptance:
 
 - reconciles existing worktrees with tracker state before reuse.
 - records PR URL and branch evidence in the tracker workpad.
-- detects missing remote commits or no-op branches before PR creation.
+- detects missing remote commits or no-op branches before PR creation. (First
+  dirty/no-op guard exists.)
 - adds configured verification command execution before push/PR handoff.
 - cleans terminal worktrees after tracker reconciliation.
 - keeps main implementation completion at `Agent Review`.

--- a/src/git_handoff.rs
+++ b/src/git_handoff.rs
@@ -75,6 +75,12 @@ pub enum GitHandoffError {
     },
     #[error("pull request command did not return a URL")]
     MissingPullRequestUrl,
+    #[error("worktree {path} has uncommitted changes before PR handoff: {status}")]
+    DirtyWorktree { path: PathBuf, status: String },
+    #[error("branch {branch} has no commits ahead of base {base} before PR handoff")]
+    NoCommitsAhead { branch: String, base: String },
+    #[error("git rev-list returned an invalid ahead count: {value}")]
+    InvalidAheadCount { value: String },
 }
 
 pub fn prepare_issue_worktree(
@@ -152,6 +158,8 @@ pub fn publish_issue_pull_request(
     plan: &IssueHandoffPlan,
     runner: &dyn HandoffCommandRunner,
 ) -> Result<PullRequestPublication, GitHandoffError> {
+    ensure_publishable_branch(plan, runner)?;
+
     require_success(
         "git",
         runner.run(
@@ -213,6 +221,48 @@ pub fn publish_issue_pull_request(
     })
 }
 
+fn ensure_publishable_branch(
+    plan: &IssueHandoffPlan,
+    runner: &dyn HandoffCommandRunner,
+) -> Result<(), GitHandoffError> {
+    let status = runner.run(
+        "git",
+        &["status".into(), "--porcelain".into()],
+        &plan.workspace_path,
+    )?;
+    require_success("git", status.clone())?;
+    if !status.stdout.trim().is_empty() {
+        return Err(GitHandoffError::DirtyWorktree {
+            path: plan.workspace_path.clone(),
+            status: compact_git_evidence(&status.stdout),
+        });
+    }
+
+    let range = format!("{}..HEAD", plan.pull_request.base_branch);
+    let ahead = runner.run(
+        "git",
+        &["rev-list".into(), "--count".into(), range],
+        &plan.workspace_path,
+    )?;
+    require_success("git", ahead.clone())?;
+    let count =
+        ahead
+            .stdout
+            .trim()
+            .parse::<u32>()
+            .map_err(|_| GitHandoffError::InvalidAheadCount {
+                value: ahead.stdout.trim().to_string(),
+            })?;
+    if count == 0 {
+        return Err(GitHandoffError::NoCommitsAhead {
+            branch: plan.branch_name.clone(),
+            base: plan.pull_request.base_branch.clone(),
+        });
+    }
+
+    Ok(())
+}
+
 fn current_branch(
     workspace_path: &Path,
     runner: &dyn HandoffCommandRunner,
@@ -257,6 +307,17 @@ fn extract_url(stdout: &str) -> Result<String, GitHandoffError> {
         .ok_or(GitHandoffError::MissingPullRequestUrl)
 }
 
+fn compact_git_evidence(value: &str) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    const LIMIT: usize = 240;
+    let truncated = compact.chars().take(LIMIT).collect::<String>();
+    if truncated.len() < compact.len() {
+        format!("{truncated}...")
+    } else {
+        compact
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -270,6 +331,17 @@ mod tests {
         existing_branch: bool,
         existing_pr_url: Option<String>,
         worktree_branch: Option<String>,
+        dirty_status: Option<String>,
+        ahead_count: u32,
+    }
+
+    impl FakeRunner {
+        fn clean_with_commits() -> Self {
+            Self {
+                ahead_count: 1,
+                ..Default::default()
+            }
+        }
     }
 
     impl HandoffCommandRunner for FakeRunner {
@@ -293,6 +365,20 @@ mod tests {
                 return Ok(CommandOutput {
                     status: 0,
                     stdout: self.worktree_branch.clone().unwrap_or_default(),
+                    stderr: String::new(),
+                });
+            }
+            if command.contains("status --porcelain") {
+                return Ok(CommandOutput {
+                    status: 0,
+                    stdout: self.dirty_status.clone().unwrap_or_default(),
+                    stderr: String::new(),
+                });
+            }
+            if command.contains("rev-list --count") {
+                return Ok(CommandOutput {
+                    status: 0,
+                    stdout: format!("{}\n", self.ahead_count),
                     stderr: String::new(),
                 });
             }
@@ -387,6 +473,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let plan = plan_issue_handoff(temp.path(), &issue(), "main").unwrap();
         let runner = FakeRunner {
+            ahead_count: 1,
             existing_pr_url: Some("https://github.com/Alive24/jade-symphony/pull/45".into()),
             ..Default::default()
         };
@@ -408,7 +495,7 @@ mod tests {
     fn creates_pull_request_when_none_exists() {
         let temp = tempfile::tempdir().unwrap();
         let plan = plan_issue_handoff(temp.path(), &issue(), "main").unwrap();
-        let runner = FakeRunner::default();
+        let runner = FakeRunner::clean_with_commits();
 
         let result = publish_issue_pull_request(&plan, &runner).unwrap();
 
@@ -419,6 +506,43 @@ mod tests {
             "https://github.com/Alive24/jade-symphony/pull/99"
         );
         let commands = runner.commands.borrow().join("\n");
+        assert!(commands.contains("git status --porcelain"));
+        assert!(commands.contains("git rev-list --count main..HEAD"));
         assert!(commands.contains("gh pr create"));
+    }
+
+    #[test]
+    fn blocks_dirty_worktree_before_push() {
+        let temp = tempfile::tempdir().unwrap();
+        let plan = plan_issue_handoff(temp.path(), &issue(), "main").unwrap();
+        let runner = FakeRunner {
+            dirty_status: Some(" M src/main.rs\n".into()),
+            ahead_count: 1,
+            ..Default::default()
+        };
+
+        let error = publish_issue_pull_request(&plan, &runner).unwrap_err();
+
+        assert!(matches!(error, GitHandoffError::DirtyWorktree { .. }));
+        let commands = runner.commands.borrow().join("\n");
+        assert!(commands.contains("git status --porcelain"));
+        assert!(!commands.contains("git push -u origin"));
+    }
+
+    #[test]
+    fn blocks_noop_branch_before_push() {
+        let temp = tempfile::tempdir().unwrap();
+        let plan = plan_issue_handoff(temp.path(), &issue(), "main").unwrap();
+        let runner = FakeRunner {
+            ahead_count: 0,
+            ..Default::default()
+        };
+
+        let error = publish_issue_pull_request(&plan, &runner).unwrap_err();
+
+        assert!(matches!(error, GitHandoffError::NoCommitsAhead { .. }));
+        let commands = runner.commands.borrow().join("\n");
+        assert!(commands.contains("git rev-list --count main..HEAD"));
+        assert!(!commands.contains("git push -u origin"));
     }
 }


### PR DESCRIPTION
## Summary

- Blocks live PR handoff when the issue worktree has uncommitted changes.
- Blocks PR publication when the issue branch has no commits ahead of the configured base branch.
- Keeps clean branches flowing through the existing push and create-or-reuse PR path.
- Updates README and dogfood readiness to reflect the dirty/no-op handoff guard.

## Verification

- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

Closes #93
