### PR TITLE
#95: Plan terminal workspace cleanup from tracker state

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ worker supervision are still future work.
   the built binary, git, `gh`, auth, and workflow validation.
 - workspace identifiers are sanitized; local workspace paths stay under the
   configured root; hooks support timeouts, stdout/stderr capture,
-  `before_remove`, and safe cleanup helpers.
+  `before_remove`, safe cleanup helpers, and a guarded terminal workspace
+  cleanup planner.
 - workflow identity config can distinguish the acting role/label from the human
   operator and can apply configured git author metadata with repository-local
   `git config --local` only.
@@ -280,7 +281,8 @@ Merging role separation.
   is currently read-only fixture/path parsing for Codex instance names.
 - automatic repair of existing `Agent Review` items with missing PR evidence;
   the current slice prevents new silent handoffs and records diagnostics.
-- robust cleanup for live git worktrees after terminal tracker reconciliation.
+- automatic cleanup for live git worktrees after terminal tracker
+  reconciliation.
 - profile-specific account/token routing for git hosts or agent backends.
 - rich interactive Issue Forge TUI; the current flow is CLI-first and
   command-step based.
@@ -303,9 +305,9 @@ Merging role separation.
 - continuation retries and automated stall restart.
 - richer vendor-specific quota handling beyond conservative usage-limit
   pattern matching.
-- terminal workspace cleanup tied to tracker state.
-- full profile-specific account/token switching for tracker claim ownership
-  beyond login comparison.
+- automatic terminal workspace cleanup inside the runtime loop.
+- profile-aware tracker claim ownership beyond namespaced runtime/log/workspace
+  metadata.
 - live token/rate-limit accounting beyond the current snapshot counters.
 - persistent background Agent Review worker supervision beyond bounded
   `review-loop` ticks.
@@ -357,6 +359,7 @@ cargo run -- run-loop examples/usage-limit-workflow.md --max-iterations 1 --writ
 cargo run -- dogfood-smoke examples/github-project-workflow.md --dry-run
 cargo run -- merge-once examples/github-project-workflow.md --dry-run
 cargo run -- merge-loop examples/github-project-workflow.md --max-iterations 3 --dry-run
+cargo run -- cleanup-workspaces examples/github-project-workflow.md --dry-run
 cargo run -- gate examples/llm-gate-workflow.md '#1'
 ```
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -19,7 +19,7 @@ yet.
 | Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies target repository, referenced local paths, and supported verification command shapes. Optional local command-backed LLM gate mode exists as disabled/advisory/required; richer semantic validation and hosted providers are still follow-ups. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, resume preflight, retry backoff records, stall detection, live PR handoff in non-fixture GitHub mode, guarded `merge-once` and bounded `merge-loop` lanes for `Merging` issues, a controlled `dogfood-smoke` preflight report, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, unbounded merge idle polling, or full state reconciliation yet. |
-| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, optional configured verification commands before PR handoff, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Runtime reconciliation cleanup is not wired yet. |
+| Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, guarded terminal cleanup planning, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, optional configured verification commands before PR handoff, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Automatic runtime cleanup is not wired yet. |
 | Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Prepared runs include selected profile/instance metadata and profile environment context. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings, review-freshness evidence for Merging conflict repair, bounded `review-loop` worker selection/reconciliation with one issue per worker slot, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
@@ -152,7 +152,8 @@ Project v2 issues:
    - exponential backoff for failures.
    - stall detection.
    - terminal/non-active reconciliation.
-- terminal workspace cleanup wiring in the runtime loop.
+- terminal workspace cleanup planning exists as an explicit dry-run/write
+  command; automatic cleanup wiring in the runtime loop remains pending.
 
 8. Observability.
    - Structured logs for dispatch, retry, state transition, backend session, and
@@ -295,7 +296,8 @@ Acceptance:
 - hook timeout is enforced.
 - `after_create`, `before_run`, `after_run`, and `before_remove` behavior match
   the parity roadmap.
-- terminal cleanup is tied to tracker reconciliation.
+- terminal cleanup can be planned from tracker reconciliation; automatic runtime
+  cleanup remains pending.
 - path escape tests cover symlink and non-directory cases.
 
 ### 6. Harden Workspace Branch And PR Handoff Reconciliation

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,8 +57,8 @@ use jade_symphony::tracker::{
 };
 use jade_symphony::workflow::WorkflowDefinition;
 use jade_symphony::workspace::{
-    apply_local_git_identity, prepare_workspace, profile_scoped_identifier, run_after_run,
-    run_before_run, run_workspace_command, GitIdentityApplyResult,
+    apply_local_git_identity, prepare_workspace, profile_scoped_identifier, remove_issue_workspace,
+    run_after_run, run_before_run, run_workspace_command, GitIdentityApplyResult,
 };
 
 const DEFAULT_RUN_LOOP_BASE_BRANCH: &str = "main";
@@ -86,6 +86,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } => dogfood_smoke(workflow_path, write),
         Command::RunOnce { workflow_path } => run_once(workflow_path),
         Command::RunLoop { options } => run_loop(options),
+        Command::CleanupWorkspaces {
+            workflow_path,
+            write,
+        } => cleanup_workspaces(workflow_path, write),
         Command::MergeOnce {
             workflow_path,
             write,
@@ -1262,6 +1266,149 @@ fn dogfood_smoke(workflow_path: PathBuf, write: bool) -> Result<(), Box<dyn std:
     }
 
     Ok(())
+}
+
+fn cleanup_workspaces(
+    workflow_path: PathBuf,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let issues = adapter.fetch_issues_by_states(&config.tracker.terminal_states)?;
+    let entries = workspace_cleanup_plan(&config, &issues)?;
+    let eligible = entries
+        .iter()
+        .filter(|entry| matches!(entry.action, WorkspaceCleanupAction::Eligible))
+        .count();
+
+    println!(
+        "workspace_cleanup mode={} terminal_issues={} eligible={eligible}",
+        if write { "write" } else { "dry-run" },
+        issues.len()
+    );
+
+    for entry in &entries {
+        println!(
+            "workspace_cleanup issue={} state={:?} action={} workspace_key={} path={}",
+            entry.issue_ref,
+            entry.state,
+            entry.action.label(),
+            entry.workspace_key,
+            entry.workspace_path.display()
+        );
+        if let WorkspaceCleanupAction::Skipped { reason } = &entry.action {
+            println!(
+                "workspace_cleanup_skip issue={} reason={}",
+                entry.issue_ref, reason
+            );
+        }
+    }
+
+    if write {
+        for entry in entries
+            .iter()
+            .filter(|entry| matches!(entry.action, WorkspaceCleanupAction::Eligible))
+        {
+            remove_issue_workspace(&config.workspace.root, &entry.workspace_key, &config.hooks)?;
+            println!(
+                "workspace_cleanup_removed issue={} path={}",
+                entry.issue_ref,
+                entry.workspace_path.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkspaceCleanupEntry {
+    issue_ref: String,
+    state: String,
+    workspace_key: String,
+    workspace_path: PathBuf,
+    action: WorkspaceCleanupAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WorkspaceCleanupAction {
+    Eligible,
+    Skipped { reason: String },
+}
+
+impl WorkspaceCleanupAction {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Eligible => "eligible",
+            Self::Skipped { .. } => "skipped",
+        }
+    }
+}
+
+fn workspace_cleanup_plan(
+    config: &RuntimeConfig,
+    issues: &[TrackerIssue],
+) -> Result<Vec<WorkspaceCleanupEntry>, Box<dyn std::error::Error>> {
+    let terminal_states = config.terminal_state_set();
+    let profile = selected_execution_profile(&config.profiles)?;
+    let profile_namespace = profile
+        .as_ref()
+        .map(|profile| profile.workspace_namespace.as_str());
+
+    let mut entries = Vec::new();
+    for issue in issues {
+        if !terminal_states.contains(&issue.normalized_state()) {
+            entries.push(WorkspaceCleanupEntry {
+                issue_ref: issue.identifier.clone(),
+                state: issue.state.clone(),
+                workspace_key: "n/a".into(),
+                workspace_path: config.workspace.root.clone(),
+                action: WorkspaceCleanupAction::Skipped {
+                    reason: "non_terminal_state".into(),
+                },
+            });
+            continue;
+        }
+
+        let plan = match plan_issue_handoff_for_profile(
+            &config.workspace.root,
+            issue,
+            DEFAULT_RUN_LOOP_BASE_BRANCH,
+            profile_namespace,
+        ) {
+            Ok(plan) => plan,
+            Err(error) => {
+                entries.push(WorkspaceCleanupEntry {
+                    issue_ref: issue.identifier.clone(),
+                    state: issue.state.clone(),
+                    workspace_key: "n/a".into(),
+                    workspace_path: config.workspace.root.clone(),
+                    action: WorkspaceCleanupAction::Skipped {
+                        reason: format!("handoff_plan_failed:{error}"),
+                    },
+                });
+                continue;
+            }
+        };
+
+        let action = if plan.workspace_path.exists() {
+            WorkspaceCleanupAction::Eligible
+        } else {
+            WorkspaceCleanupAction::Skipped {
+                reason: "workspace_missing".into(),
+            }
+        };
+
+        entries.push(WorkspaceCleanupEntry {
+            issue_ref: issue.identifier.clone(),
+            state: issue.state.clone(),
+            workspace_key: plan.workspace_key,
+            workspace_path: plan.workspace_path,
+            action,
+        });
+    }
+
+    Ok(entries)
 }
 
 fn is_controlled_dogfood_smoke_issue(issue: &TrackerIssue) -> bool {
@@ -2565,6 +2712,10 @@ enum Command {
     RunLoop {
         options: RunLoopOptions,
     },
+    CleanupWorkspaces {
+        workflow_path: PathBuf,
+        write: bool,
+    },
     MergeOnce {
         workflow_path: PathBuf,
         write: bool,
@@ -2771,6 +2922,8 @@ enum CliCommand {
     RunOnce(WorkflowPathArgs),
     #[command(name = "run-loop")]
     RunLoop(RunLoopArgs),
+    #[command(name = "cleanup-workspaces", alias = "workspace-cleanup")]
+    CleanupWorkspaces(CleanupWorkspacesArgs),
     #[command(name = "merge-once", alias = "land")]
     MergeOnce(MergeOnceArgs),
     #[command(name = "merge-loop")]
@@ -2851,6 +3004,16 @@ struct RunLoopArgs {
 
 #[derive(Debug, Args)]
 struct DogfoodSmokeArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
+    workflow_path: PathBuf,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct CleanupWorkspacesArgs {
     #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
     workflow_path: PathBuf,
     #[arg(long)]
@@ -3196,6 +3359,10 @@ impl TryFrom<Cli> for Command {
                             },
                         })
                     }
+                    CliCommand::CleanupWorkspaces(args) => Ok(Self::CleanupWorkspaces {
+                        workflow_path: args.workflow_path,
+                        write: args.write,
+                    }),
                     CliCommand::MergeOnce(args) => Ok(Self::MergeOnce {
                         workflow_path: args.workflow_path,
                         write: args.write,
@@ -3745,6 +3912,74 @@ mod tests {
             Command::DogfoodSmoke {
                 workflow_path: PathBuf::from("examples/github-project-workflow.md"),
                 write: true
+            }
+        );
+    }
+
+    #[test]
+    fn parses_cleanup_workspaces_command() {
+        assert_eq!(
+            parse(&[
+                "cleanup-workspaces",
+                "examples/github-project-workflow.md",
+                "--write"
+            ]),
+            Command::CleanupWorkspaces {
+                workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                write: true,
+            }
+        );
+        assert_eq!(
+            parse(&["workspace-cleanup", "examples/github-project-workflow.md"]),
+            Command::CleanupWorkspaces {
+                workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                write: false,
+            }
+        );
+    }
+
+    #[test]
+    fn workspace_cleanup_plan_marks_terminal_existing_workspace_eligible() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut config = test_config();
+        config.workspace.root = temp.path().join("workspaces");
+        let issue = tracker_issue("Done");
+        let handoff =
+            plan_issue_handoff_for_profile(&config.workspace.root, &issue, "main", None).unwrap();
+        std::fs::create_dir_all(&handoff.workspace_path).unwrap();
+
+        let entries = workspace_cleanup_plan(&config, &[issue]).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].issue_ref, "#29");
+        assert_eq!(entries[0].workspace_key, handoff.workspace_key);
+        assert_eq!(entries[0].action, WorkspaceCleanupAction::Eligible);
+    }
+
+    #[test]
+    fn workspace_cleanup_plan_skips_non_terminal_and_missing_workspaces() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut config = test_config();
+        config.workspace.root = temp.path().join("workspaces");
+        let mut active = tracker_issue("In Progress");
+        active.identifier = "#30".into();
+        active.title = "Active workspace".into();
+        active.branch_name = None;
+        let missing_terminal = tracker_issue("Done");
+
+        let entries = workspace_cleanup_plan(&config, &[active, missing_terminal]).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries[0].action,
+            WorkspaceCleanupAction::Skipped {
+                reason: "non_terminal_state".into()
+            }
+        );
+        assert_eq!(
+            entries[1].action,
+            WorkspaceCleanupAction::Skipped {
+                reason: "workspace_missing".into()
             }
         );
     }


### PR DESCRIPTION
## Summary

- Adds `cleanup-workspaces` / `workspace-cleanup` as a dry-run-first CLI command.
- Plans terminal issue workspace cleanup from tracker state and skips non-terminal or missing workspaces with reasons.
- Uses existing guarded workspace removal helpers only when `--write` is explicitly present.
- Updates README and dogfood readiness to reflect cleanup planning while keeping automatic runtime cleanup as future work.

## Verification

- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- cleanup-workspaces examples/github-project-workflow.md --dry-run

Closes #95
