### PR TITLE
Add guarded doctor repair for invalid Human Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ worker supervision are still future work.
 - `doctor` / `audit-project` can read the configured tracker and report
   workflow invariant violations such as Agent Review without PR evidence, Human
   Review without review pass evidence, dirty Merging PRs, stale-looking In
-  Progress work, and queued issues with attached PRs.
+  Progress work, and queued issues with attached PRs. A guarded
+  `doctor-repair-human-review` command can repair the specific invalid Human
+  Review-without-pass-evidence case by writing workpad evidence and moving the
+  issue back to `Agent Review`.
 - JSONL event-log primitives exist and can record selected profile identity.
 - runtime state helpers can write, read, and clear a tracker-neutral
   `runtime/runtime-state.json` file under the configured logs root, including
@@ -168,6 +171,7 @@ cargo run -- validate examples/dry-run-workflow.md
 cargo run -- validate-workflow examples/dry-run-workflow.md
 cargo run -- inspect examples/dry-run-workflow.md
 cargo run -- doctor examples/dry-run-workflow.md
+cargo run -- doctor-repair-human-review examples/dry-run-workflow.md --dry-run
 cargo run -- plan examples/dry-run-workflow.md
 cargo run -- plan-dispatch examples/dry-run-workflow.md
 cargo run -- status examples/dry-run-workflow.md

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -24,7 +24,7 @@ yet.
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Prepared runs include selected profile/instance metadata and profile environment context. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings, review-freshness evidence for Merging conflict repair, bounded `review-loop` selection/reconciliation, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
 | Merging | `merge-once` can inspect issues already in `Merging`, require one linked PR, check live GitHub PR state/review/check/mergeability data where available, merge clean approved PRs only with explicit `--write`, and route blockers to `Rework` or `Need Human Input` with workpad evidence. Continuous merge polling and issue closing beyond Project `Done` are not implemented yet. |
-| Project doctor | Read-only `doctor` / `audit-project` reports workflow invariant violations from normalized tracker issues, including missing PR handoff evidence, missing review pass evidence, dirty Merging PRs, missing runtime ownership hints, and queued issues with PRs. Repair mode is not implemented yet. |
+| Project doctor | `doctor` / `audit-project` reports workflow invariant violations from normalized tracker issues, including missing PR handoff evidence, missing review pass evidence, dirty Merging PRs, missing runtime ownership hints, and queued issues with PRs. `doctor-repair-human-review` can repair the specific invalid Human Review-without-pass-evidence case with explicit `--write`; broader repair mode is not implemented yet. |
 | Observability | Operator-readable terminal snapshots report polling, running, retrying, skipped issues, gate details, token counters, event-log path, and integration gaps. JSONL event-log primitives exist and `run-once` writes dry-run events with actor and profile metadata. Runtime state files are written during write-mode `run-loop` issue execution, including actor role/label, git author, and optional profile/instance identity when configured; resume, retry, usage-limit pause, and stall supervision events are also recorded. No web/API surface yet. |
 | Usage-limit pause/resume | Conservative usage-limit/rate-limit/resource-exhausted classification exists for subprocess agent events and review job output. `run-loop` records usage-limit pauses in workpad/runtime retry state and does not advance to `Agent Review`; review workpads surface usage-limit failures without moving to `Human Review`. Vendor-specific quota management is not implemented. |
 | Tests | Unit tests cover the dry-run skeleton. No credential-gated integration tests yet. |
@@ -155,8 +155,10 @@ Project v2 issues:
      endpoint is still needed.
    - Clear integration-gap reporting when credentials are missing or unusable
      while avoiding false missing-token warnings when `gh api graphql` works.
-   - `doctor` / `audit-project` is available as a read-only project invariant
-     audit. Explicit-write repair mode remains a follow-up.
+   - `doctor` / `audit-project` is available as a project invariant audit.
+     Explicit-write repair currently covers only invalid `Human Review` issues
+     that lack independent Review Agent pass evidence; broader repair mode
+     remains a follow-up.
 
 9. Integration profile.
    - Credential-gated GitHub Project v2 smoke test.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::{normalize_state, LinkedPullRequest, TrackerIssue};
 
+pub const HUMAN_REVIEW_MISSING_REVIEW_EVIDENCE: &str = "human_review_missing_review_evidence";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AuditSeverity {
     Warning,
@@ -56,7 +58,7 @@ pub fn audit_project_issues(issues: &[TrackerIssue]) -> ProjectAuditReport {
                 violations.push(violation(
                     issue,
                     AuditSeverity::Blocker,
-                    "human_review_missing_review_evidence",
+                    HUMAN_REVIEW_MISSING_REVIEW_EVIDENCE,
                     "Human Review issue has no independent review pass evidence.",
                     "Return to Agent Review until Review Agent pass evidence is recorded.",
                 ));
@@ -139,6 +141,35 @@ pub fn render_project_audit_report(report: &ProjectAuditReport) -> String {
     }
 
     lines.join("\n")
+}
+
+pub fn human_review_repair_candidates(report: &ProjectAuditReport) -> Vec<&ProjectAuditViolation> {
+    report
+        .violations
+        .iter()
+        .filter(|violation| {
+            violation.severity == AuditSeverity::Blocker
+                && violation.code == HUMAN_REVIEW_MISSING_REVIEW_EVIDENCE
+        })
+        .collect()
+}
+
+pub fn render_human_review_repair_workpad(violation: &ProjectAuditViolation) -> String {
+    [
+        "## Jade Symphony Workpad".to_string(),
+        String::new(),
+        "### Project Doctor Repair".to_string(),
+        format!("- Issue: {} {}", violation.issue_ref, violation.title),
+        format!("- Violation: `{}`", violation.code),
+        format!("- Previous state: `{}`", violation.state),
+        format!("- Message: {}", violation.message),
+        format!("- Repair: {}", violation.suggestion),
+        String::new(),
+        "### State Boundary".to_string(),
+        "- Main implementation agent is moving this issue back to `Agent Review`.".to_string(),
+        "- This repair does not set `Human Review`; that state requires independent Review Agent pass evidence.".to_string(),
+    ]
+    .join("\n")
 }
 
 fn violation(
@@ -282,8 +313,29 @@ mod tests {
 
         assert_eq!(
             report.violations[0].code,
-            "human_review_missing_review_evidence"
+            HUMAN_REVIEW_MISSING_REVIEW_EVIDENCE
         );
+    }
+
+    #[test]
+    fn human_review_repair_candidates_are_specific_to_missing_review_evidence() {
+        let report =
+            audit_project_issues(&[issue("#41", "Human Review"), issue("#57", "Agent Review")]);
+
+        let candidates = human_review_repair_candidates(&report);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].issue_ref, "#41");
+    }
+
+    #[test]
+    fn human_review_repair_workpad_preserves_authority_boundary() {
+        let report = audit_project_issues(&[issue("#41", "Human Review")]);
+        let workpad = render_human_review_repair_workpad(&report.violations[0]);
+
+        assert!(workpad.contains("Project Doctor Repair"));
+        assert!(workpad.contains("moving this issue back to `Agent Review`"));
+        assert!(workpad.contains("does not set `Human Review`"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use jade_symphony::agent::{backend_from_config, usage_limit_pause_from_events, UsageLimitPause};
 use jade_symphony::config::RuntimeConfig;
-use jade_symphony::doctor::{audit_project_issues, render_project_audit_report};
+use jade_symphony::doctor::{
+    audit_project_issues, human_review_repair_candidates, render_human_review_repair_workpad,
+    render_project_audit_report,
+};
 use jade_symphony::event_log::{EventLog, EventRecord};
 use jade_symphony::git_handoff::{
     prepare_issue_worktree, publish_issue_pull_request, LiveWorktreeResult,
@@ -76,6 +79,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Command::Validate { workflow_path } => validate(workflow_path),
         Command::Inspect { workflow_path } => inspect(workflow_path),
         Command::Doctor { workflow_path } => doctor(workflow_path),
+        Command::DoctorRepairHumanReview {
+            workflow_path,
+            write,
+        } => doctor_repair_human_review(workflow_path, write),
         Command::Profiles { workflow_path } => list_profiles(workflow_path),
         Command::DogfoodSmoke {
             workflow_path,
@@ -1005,6 +1012,47 @@ fn doctor(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
 
     for gap in adapter.integration_gaps() {
         println!("integration_gap={gap}");
+    }
+
+    Ok(())
+}
+
+fn doctor_repair_human_review(
+    workflow_path: PathBuf,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let workflow = WorkflowDefinition::load(&workflow_path)?;
+    let config = RuntimeConfig::from_workflow(&workflow, &workflow_path)?;
+    config.validate()?;
+
+    let adapter = adapter_from_config(&config);
+    let issues = adapter.list_dispatchable_issues()?;
+    let report = audit_project_issues(&issues);
+    let candidates = human_review_repair_candidates(&report);
+
+    println!(
+        "doctor_repair_human_review candidates={} write={write}",
+        candidates.len()
+    );
+    for violation in candidates {
+        println!(
+            "doctor_repair_human_review action=move issue={} from={:?} to=agent_review",
+            violation.issue_ref, violation.state
+        );
+        if write {
+            let workpad = render_human_review_repair_workpad(violation);
+            adapter.upsert_workpad(&violation.issue_ref, &workpad)?;
+            adapter.set_state(&violation.issue_ref, "agent_review")?;
+        } else {
+            println!(
+                "doctor_repair_human_review_dry_run action=workpad issue={} evidence=human_review_missing_review_evidence",
+                violation.issue_ref
+            );
+            println!(
+                "doctor_repair_human_review_dry_run action=set_state issue={} target_state=agent_review",
+                violation.issue_ref
+            );
+        }
     }
 
     Ok(())
@@ -2155,6 +2203,10 @@ enum Command {
     Doctor {
         workflow_path: PathBuf,
     },
+    DoctorRepairHumanReview {
+        workflow_path: PathBuf,
+        write: bool,
+    },
     Profiles {
         workflow_path: PathBuf,
     },
@@ -2332,6 +2384,8 @@ enum CliCommand {
     Inspect(WorkflowPathArgs),
     #[command(alias = "audit-project")]
     Doctor(WorkflowPathArgs),
+    #[command(name = "doctor-repair-human-review")]
+    DoctorRepairHumanReview(DoctorRepairArgs),
     Profiles(WorkflowPathArgs),
     #[command(name = "dogfood-smoke")]
     DogfoodSmoke(DogfoodSmokeArgs),
@@ -2385,6 +2439,16 @@ struct WorkflowPathArgs {
     _dry_run: bool,
     #[arg(long = "write")]
     _write: bool,
+}
+
+#[derive(Debug, Args)]
+struct DoctorRepairArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
+    workflow_path: PathBuf,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
 }
 
 #[derive(Debug, Args)]
@@ -2705,6 +2769,12 @@ impl TryFrom<Cli> for Command {
                     CliCommand::Doctor(args) => Ok(Self::Doctor {
                         workflow_path: args.workflow_path,
                     }),
+                    CliCommand::DoctorRepairHumanReview(args) => {
+                        Ok(Self::DoctorRepairHumanReview {
+                            workflow_path: args.workflow_path,
+                            write: args.write,
+                        })
+                    }
                     CliCommand::Profiles(args) => Ok(Self::Profiles {
                         workflow_path: args.workflow_path,
                     }),
@@ -3183,6 +3253,32 @@ mod tests {
             parse(&["profiles", "examples/dry-run-workflow.md"]),
             Command::Profiles {
                 workflow_path: PathBuf::from("examples/dry-run-workflow.md")
+            }
+        );
+    }
+
+    #[test]
+    fn parses_doctor_repair_human_review_command() {
+        assert_eq!(
+            parse(&[
+                "doctor-repair-human-review",
+                "examples/github-project-workflow.md",
+                "--dry-run"
+            ]),
+            Command::DoctorRepairHumanReview {
+                workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                write: false
+            }
+        );
+        assert_eq!(
+            parse(&[
+                "doctor-repair-human-review",
+                "examples/github-project-workflow.md",
+                "--write"
+            ]),
+            Command::DoctorRepairHumanReview {
+                workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                write: true
             }
         );
     }


### PR DESCRIPTION
## Summary
- add doctor-repair-human-review as a dry-run-first, write-gated repair command
- reuse doctor audit violations for the specific Human Review without review evidence invariant
- write workpad evidence before moving affected issues back to Agent Review
- update README and dogfood readiness docs

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- doctor-repair-human-review examples/github-project-workflow.md --dry-run

Closes #101