### PR TITLE
Add explicit PR link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ usable GitHub auth through `GITHUB_TOKEN` / `GH_TOKEN` or `gh api graphql`:
 ```bash
 cargo run -- set-state path/to/WORKFLOW.md '#123' need_to_clarify --write
 cargo run -- workpad path/to/WORKFLOW.md '#123' path/to/workpad.md --write
+cargo run -- link-pr path/to/WORKFLOW.md '#123' https://github.com/OWNER/REPO/pull/456 --write
 cargo run -- create-follow-up --workflow path/to/WORKFLOW.md --title "Follow-up title" --body-file path/to/body.md --write
 cargo run -- add-to-project path/to/WORKFLOW.md <github-issue-node-id> --write
 cargo run -- gate-apply path/to/WORKFLOW.md '#123' --write
@@ -282,6 +283,10 @@ normalized tracker state machine. `forge-create --add-to-project` can set
 additional GitHub Project v2 single-select fields by name with repeatable
 `--project-field NAME=VALUE` flags. Text, number, date, and multi-step field
 editing remain follow-ups.
+
+`link-pr` records issue-to-PR evidence through the normalized tracker adapter.
+In GitHub Project v2 mode this currently writes a tracker comment, matching the
+adapter boundary; richer first-class PR reconciliation remains a follow-up.
 
 `set-state` is a main-implementation-agent command and refuses `Human Review`.
 `review-once` / `review-fake` are independent Review Agent commands: a passing

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             markdown_path,
             write,
         } => upsert_workpad(workflow_path, issue_ref, markdown_path, write),
+        Command::LinkPr {
+            workflow_path,
+            issue_ref,
+            pr_ref,
+            write,
+        } => link_pr(workflow_path, issue_ref, pr_ref, write),
         Command::CreateFollowUp {
             workflow_path,
             title,
@@ -405,6 +411,38 @@ fn upsert_workpad(
         markdown_path.display()
     );
     Ok(())
+}
+
+fn link_pr(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    pr_ref: String,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !write {
+        println!("link_pr_dry_run action=link_pull_request issue_ref={issue_ref} pr_ref={pr_ref}");
+        return Ok(());
+    }
+
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    link_pr_with_adapter(adapter.as_ref(), &issue_ref, &pr_ref, true)?;
+    println!("link_pr=ok issue_ref={issue_ref} pr_ref={pr_ref}");
+    Ok(())
+}
+
+fn link_pr_with_adapter(
+    adapter: &dyn TrackerAdapter,
+    issue_ref: &str,
+    pr_ref: &str,
+    write: bool,
+) -> Result<bool, TrackerError> {
+    if write {
+        adapter.link_pull_request(issue_ref, pr_ref)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }
 
 fn create_follow_up(
@@ -2982,6 +3020,12 @@ enum Command {
         markdown_path: PathBuf,
         write: bool,
     },
+    LinkPr {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        pr_ref: String,
+        write: bool,
+    },
     CreateFollowUp {
         workflow_path: PathBuf,
         title: String,
@@ -3186,6 +3230,8 @@ enum CliCommand {
     #[command(name = "set-state")]
     SetState(SetStateArgs),
     Workpad(WorkpadArgs),
+    #[command(name = "link-pr")]
+    LinkPr(LinkPrArgs),
     #[command(name = "create-follow-up")]
     CreateFollowUp(CreateFollowUpArgs),
     #[command(name = "add-to-project")]
@@ -3352,6 +3398,18 @@ struct WorkpadArgs {
     workflow_path: PathBuf,
     issue_ref: String,
     markdown_path: PathBuf,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct LinkPrArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    pr_ref: String,
     #[arg(long)]
     write: bool,
     #[arg(long = "dry-run")]
@@ -3684,6 +3742,12 @@ impl TryFrom<Cli> for Command {
                         workflow_path: args.workflow_path,
                         issue_ref: args.issue_ref,
                         markdown_path: args.markdown_path,
+                        write: args.write,
+                    }),
+                    CliCommand::LinkPr(args) => Ok(Self::LinkPr {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
+                        pr_ref: args.pr_ref,
                         write: args.write,
                     }),
                     CliCommand::CreateFollowUp(args) => Ok(Self::CreateFollowUp {
@@ -4099,9 +4163,12 @@ mod tests {
 
         fn link_pull_request(
             &self,
-            _issue_ref: &str,
-            _pr_ref: &str,
+            issue_ref: &str,
+            pr_ref: &str,
         ) -> Result<(), jade_symphony::tracker::TrackerError> {
+            self.operations
+                .borrow_mut()
+                .push(format!("link_pr:{issue_ref}:{pr_ref}"));
             Ok(())
         }
 
@@ -5404,6 +5471,47 @@ mod tests {
             error,
             "forge-create --project-field requires --add-to-project"
         );
+    }
+
+    #[test]
+    fn parses_link_pr_flags() {
+        let command = Command::parse(vec![
+            "link-pr".into(),
+            "examples/github-project-workflow.md".into(),
+            "#127".into(),
+            "https://github.com/Alive24/jade-symphony/pull/128".into(),
+            "--write".into(),
+        ])
+        .unwrap();
+
+        let Command::LinkPr {
+            workflow_path,
+            issue_ref,
+            pr_ref,
+            write,
+        } = command
+        else {
+            panic!("expected link-pr command");
+        };
+
+        assert_eq!(
+            workflow_path,
+            PathBuf::from("examples/github-project-workflow.md")
+        );
+        assert_eq!(issue_ref, "#127");
+        assert_eq!(pr_ref, "https://github.com/Alive24/jade-symphony/pull/128");
+        assert!(write);
+    }
+
+    #[test]
+    fn link_pr_helper_respects_write_intent() {
+        let adapter = RecordingAdapter::default();
+
+        assert!(!link_pr_with_adapter(&adapter, "#127", "PR_128", false).unwrap());
+        assert!(adapter.operations().is_empty());
+
+        assert!(link_pr_with_adapter(&adapter, "#127", "PR_128", true).unwrap());
+        assert_eq!(adapter.operations(), vec!["link_pr:#127:PR_128"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an explicit `link-pr` CLI command for recording issue-to-PR evidence through the normalized tracker adapter
- keep live mutation behind `--write`, with dry-run output for the intended link action
- add parser/write-intent tests and README command coverage

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Notes

This exposes the existing tracker adapter capability. It does not implement richer linked PR discovery or change review authority boundaries.

Closes #127
