### PR TITLE
Record run-loop PR links through tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ worker supervision are still future work.
   `Need Human Input` with a workpad diagnostic.
 - live GitHub `run-loop --write` can create or reuse the planned issue
   worktree/branch, run the configured backend inside that worktree, push the
-  branch, and create or reuse one GitHub PR after successful execution.
+  branch, create or reuse one GitHub PR after successful execution, and record
+  that PR through the normalized tracker adapter before Agent Review handoff.
 - terminal status output reports polling state, planned running/skipped/retrying
   issues, token counters, event-log path, gate details, and integration gaps.
 - `doctor` / `audit-project` can read the configured tracker and report
@@ -135,8 +136,8 @@ worker supervision are still future work.
   workspace/branch/PR handoff plans, use tracker claim helpers to
   claim/resume/skip externally changed issues, and in explicit `--write` mode
   run one issue at a time, record handoff evidence, create a live PR handoff in
-  non-fixture GitHub Project v2 mode, and stop main-agent completion at
-  `Agent Review`;
+  non-fixture GitHub Project v2 mode, link that PR through the tracker adapter,
+  and stop main-agent completion at `Agent Review`;
   unbounded write mode sleeps on idle polls using the workflow polling interval.
 
 ## Dry-Run Only

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -18,7 +18,7 @@ yet.
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies target repository, referenced local paths, and supported verification command shapes. Optional local command-backed LLM gate mode exists as disabled/advisory/required; richer semantic validation and hosted providers are still follow-ups. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping, conservative reflective follow-up candidate generation, and explicit `forge-create` tracker issue creation from quality-gated Markdown. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path; arbitrary Project field setup after creation is not implemented yet. |
-| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, resume preflight, retry backoff records, stall detection, live PR handoff in non-fixture GitHub mode, a guarded one-shot `merge-once` lane for `Merging` issues, a controlled `dogfood-smoke` preflight report, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, `merge-loop`, or full state reconciliation yet. |
+| Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, runtime-state persistence, resume preflight, retry backoff records, stall detection, live PR handoff plus tracker PR link recording in non-fixture GitHub mode, a guarded one-shot `merge-once` lane for `Merging` issues, a controlled `dogfood-smoke` preflight report, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, `merge-loop`, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, branch push, PR create-or-reuse, run-loop handoff evidence, profile-scoped workspace keys, and an Agent Review handoff invariant that blocks missing PR evidence before `Agent Review` exist. Runtime reconciliation cleanup is not wired yet. |
 | Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
 | Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Prepared runs include selected profile/instance metadata and profile environment context. Full Codex app-server and Claude Code protocol parity are not implemented yet. |
@@ -131,9 +131,10 @@ Project v2 issues:
      reconciliation remains pending.
    - workspace/branch/PR handoff is recorded by `run-loop`; in live
      non-fixture GitHub mode the runtime can create/reuse the issue worktree and
-     branch, push the branch, and create/reuse one PR after successful backend
-     execution. Remaining work: cleanup, richer reconciliation, and stronger
-     verification command modeling.
+     branch, push the branch, create/reuse one PR after successful backend
+     execution, and record the PR link through the tracker adapter before
+     Agent Review handoff. Remaining work: cleanup, richer reconciliation, and
+     stronger verification command modeling.
    - Local git identity application exists for prepared git repositories; the
      live worktree path must continue to apply it before commits and preserve the
      distinction between agent actors and human operators.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1499,6 +1499,16 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             }
+            if result.success {
+                let linked =
+                    apply_live_handoff_pr_link(adapter.as_ref(), &latest.identifier, &mut result);
+                if linked {
+                    println!(
+                        "run_loop_action=link_pr issue={} evidence=live_handoff",
+                        latest.identifier
+                    );
+                }
+            }
         }
         runtime_state = run_loop_runtime_state_with_result(runtime_state, &result);
         mark_runtime_state_updated(&mut runtime_state, current_time_ms());
@@ -2060,6 +2070,39 @@ fn live_handoff_workpad_line(result: &IssueExecutionResult) -> String {
             handoff.verification
         ),
         None => "- Live PR: `not-created`".to_string(),
+    }
+}
+
+fn record_live_handoff_pr_link(
+    adapter: &dyn TrackerAdapter,
+    issue_ref: &str,
+    result: &IssueExecutionResult,
+) -> Result<(), String> {
+    let Some(handoff) = &result.live_handoff else {
+        return Ok(());
+    };
+
+    adapter
+        .link_pull_request(issue_ref, &handoff.publication.pr_url)
+        .map_err(|error| format!("handoff PR link failed: {error}"))
+}
+
+fn apply_live_handoff_pr_link(
+    adapter: &dyn TrackerAdapter,
+    issue_ref: &str,
+    result: &mut IssueExecutionResult,
+) -> bool {
+    if result.live_handoff.is_none() {
+        return false;
+    }
+
+    match record_live_handoff_pr_link(adapter, issue_ref, result) {
+        Ok(()) => true,
+        Err(error) => {
+            result.success = false;
+            result.message = error;
+            false
+        }
     }
 }
 
@@ -3035,6 +3078,7 @@ mod tests {
     struct RecordingAdapter {
         operations: RefCell<Vec<String>>,
         fail_workpad: bool,
+        fail_link_pr: bool,
     }
 
     impl RecordingAdapter {
@@ -3114,9 +3158,19 @@ mod tests {
 
         fn link_pull_request(
             &self,
-            _issue_ref: &str,
-            _pr_ref: &str,
+            issue_ref: &str,
+            pr_ref: &str,
         ) -> Result<(), jade_symphony::tracker::TrackerError> {
+            if self.fail_link_pr {
+                return Err(
+                    jade_symphony::tracker::TrackerError::IntegrationUnavailable(
+                        "link failed".into(),
+                    ),
+                );
+            }
+            self.operations
+                .borrow_mut()
+                .push(format!("link_pr:{issue_ref}:{pr_ref}"));
             Ok(())
         }
 
@@ -3728,6 +3782,83 @@ mod tests {
     }
 
     #[test]
+    fn live_run_loop_handoff_records_pr_link_through_tracker() {
+        let config = test_config();
+        let issue = tracker_issue("In Progress");
+        let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+        let mut result = successful_live_handoff_result(&handoff);
+        let adapter = RecordingAdapter::default();
+
+        assert!(apply_live_handoff_pr_link(
+            &adapter,
+            &issue.identifier,
+            &mut result
+        ));
+
+        assert!(result.success);
+        assert_eq!(
+            adapter.operations(),
+            vec!["link_pr:#29:https://github.com/Alive24/jade-symphony/pull/45"]
+        );
+    }
+
+    #[test]
+    fn live_run_loop_handoff_link_failure_blocks_agent_review() {
+        let config = test_config();
+        let issue = tracker_issue("In Progress");
+        let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+        let mut result = successful_live_handoff_result(&handoff);
+        let adapter = RecordingAdapter {
+            operations: RefCell::new(Vec::new()),
+            fail_workpad: false,
+            fail_link_pr: true,
+        };
+
+        assert!(!apply_live_handoff_pr_link(
+            &adapter,
+            &issue.identifier,
+            &mut result
+        ));
+
+        assert!(!result.success);
+        assert!(result.message.contains("handoff PR link failed"));
+    }
+
+    fn successful_live_handoff_result(handoff: &IssueHandoffPlan) -> IssueExecutionResult {
+        IssueExecutionResult {
+            workspace_path: handoff.workspace_path.clone(),
+            backend: "dry-run".into(),
+            profile_id: None,
+            instance_name: None,
+            success: true,
+            session_id: Some("session-33".into()),
+            message: "ok".into(),
+            usage_limit_pause: None,
+            actor_role: "implementation_agent".into(),
+            actor_label: "Jade Symphony Agent".into(),
+            git_author: Some("Jade Symphony Agent <jade@example.invalid>".into()),
+            git_identity: GitIdentityApplyResult {
+                status: jade_symphony::workspace::GitIdentityApplyStatus::Applied,
+                author: Some("Jade Symphony Agent <jade@example.invalid>".into()),
+                applied_keys: vec!["user.name".into(), "user.email".into()],
+            },
+            live_handoff: Some(RunLoopLiveHandoff {
+                worktree: LiveWorktreeResult {
+                    workspace_path: handoff.workspace_path.clone(),
+                    branch_name: handoff.branch_name.clone(),
+                    created: true,
+                },
+                publication: PullRequestPublication {
+                    branch_pushed: true,
+                    pr_url: "https://github.com/Alive24/jade-symphony/pull/45".into(),
+                    pr_created: true,
+                },
+                verification: "skipped:not_configured".into(),
+            }),
+        }
+    }
+
+    #[test]
     fn usage_limit_pause_workpad_preserves_tracker_state_boundary() {
         let issue = tracker_issue("In Progress");
         let result = IssueExecutionResult {
@@ -3787,6 +3918,7 @@ mod tests {
         let adapter = RecordingAdapter {
             operations: RefCell::new(Vec::new()),
             fail_workpad: true,
+            fail_link_pr: false,
         };
         let issue = tracker_issue("Agent Review");
         let diagnostic = ReworkDiagnostic::validation_failure(


### PR DESCRIPTION
## Summary

- record live run-loop PR handoffs through `TrackerAdapter::link_pull_request`
- treat PR link failures as handoff failures so main-agent work does not silently advance
- update README and dogfood readiness to document tracker PR link recording

## Verification

- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Notes

This uses the existing normalized tracker adapter operation. It does not implement richer linked PR discovery or change review authority boundaries.

Closes #129
