### PR TITLE
Gate dogfood launcher writes with smoke preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ For a compact source-linked view of what is landed, what is waiting in
   conditions, and one issue / one branch / one PR handoff rules.
 - `scripts/jade-dogfood` provides a bounded operator launcher for the GitHub
   Project workflow with explicit dry-run/write modes and preflight checks for
-  the built binary, git, `gh`, auth, and workflow validation.
+  the built binary, git, `gh`, auth, workflow validation, and controlled
+  dogfood smoke readiness before write-mode mutation.
 - workspace identifiers are sanitized; local workspace paths stay under the
   configured root; hooks support timeouts, stdout/stderr capture,
   `before_remove`, safe cleanup helpers, and a guarded terminal workspace
@@ -407,8 +408,9 @@ cargo run -- plan examples/dry-run-workflow.md
 cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
 scripts/jade-dogfood --dry-run
-cargo run -- run-loop examples/usage-limit-workflow.md --max-iterations 1 --write
 cargo run -- dogfood-smoke examples/github-project-workflow.md --dry-run
+scripts/jade-dogfood --write --confirm-write --max-iterations 1
+cargo run -- run-loop examples/usage-limit-workflow.md --max-iterations 1 --write
 cargo run -- merge-once examples/github-project-workflow.md --dry-run
 cargo run -- merge-loop examples/github-project-workflow.md --max-iterations 3 --dry-run
 cargo run -- cleanup-workspaces examples/github-project-workflow.md --dry-run

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -31,7 +31,8 @@ yet.
 | Tests | Unit tests cover the dry-run skeleton. Read-only / dry-run live GitHub smoke tests exist behind explicit `JADE_LIVE_GITHUB_SMOKE=1` opt-in; mutation and Linear credential-gated smoke coverage are still missing. |
 
 The operator launcher runbook is in `docs/operator-dogfood.md`; it keeps write
-mode explicit through `scripts/jade-dogfood --write --confirm-write`.
+mode explicit through `scripts/jade-dogfood --write --confirm-write` and runs
+the controlled dogfood smoke preflight before a mutating tick.
 
 The controlled live smoke runbook is in `docs/dogfood-smoke.md`. It keeps the
 first dogfood acceptance path supervised and bounded to one controlled issue.

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -26,6 +26,7 @@ The launcher checks:
 - `gh` exists;
 - `gh auth status` succeeds;
 - the workflow validates.
+- in write mode, the controlled dogfood smoke preflight passes.
 
 After preflight, dry-run mode executes:
 
@@ -40,7 +41,14 @@ scripts/jade-dogfood --write --confirm-write --max-iterations 1
 ```
 
 Write mode is intentionally bounded. It runs one `run-loop` tick only after the
-explicit confirmation flag is present.
+explicit confirmation flag is present. Before that mutating tick, the launcher
+runs:
+
+```bash
+target/debug/jade-symphony dogfood-smoke examples/github-project-workflow.md --dry-run
+```
+
+If the smoke preflight fails, the launcher exits before claiming tracker work.
 
 ## Inspect And Resume
 

--- a/scripts/jade-dogfood
+++ b/scripts/jade-dogfood
@@ -94,6 +94,9 @@ check "gh auth status" gh auth status
 
 if [ -x "$BIN" ]; then
   check "workflow validates" "$BIN" validate "$WORKFLOW"
+  if [ "$MODE" = "write" ]; then
+    check "controlled dogfood smoke preflight" "$BIN" dogfood-smoke "$WORKFLOW" --dry-run
+  fi
 fi
 
 echo
@@ -101,6 +104,7 @@ echo "Recommended commands:"
 echo "- preview: scripts/jade-dogfood --dry-run"
 echo "- supervised write: scripts/jade-dogfood --write --confirm-write --max-iterations 1"
 echo "- inspect: $BIN inspect $WORKFLOW"
+echo "- smoke preflight: $BIN dogfood-smoke $WORKFLOW --dry-run"
 echo "- resume tick: $BIN run-loop $WORKFLOW --max-iterations 1 --write"
 
 if [ "$FAILED" = "true" ]; then


### PR DESCRIPTION
Closes #137.

## Summary
- Gate `scripts/jade-dogfood --write --confirm-write` with the existing `dogfood-smoke <workflow> --dry-run` preflight before any write-mode `run-loop`.
- Keep dry-run mode non-mutating and preserve the explicit `--confirm-write` mutation guard.
- Update README/readiness/operator docs to describe the smoke gate.

## Verification
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `scripts/jade-dogfood --dry-run`
- `scripts/jade-dogfood --write` exits before mutation because `--confirm-write` is required.
