### PR TITLE
Add fixture-backed dogfood smoke workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
 scripts/jade-dogfood --dry-run
 cargo run -- run-loop examples/usage-limit-workflow.md --max-iterations 1 --write
+cargo run -- dogfood-smoke examples/dogfood-smoke-workflow.md --dry-run
 cargo run -- dogfood-smoke examples/github-project-workflow.md --dry-run
 cargo run -- merge-once examples/github-project-workflow.md --dry-run
 cargo run -- gate examples/llm-gate-workflow.md '#1'
@@ -351,6 +352,8 @@ The dry-run workflow uses:
 - `examples/fixtures/dry-run-issues.json`
 - `examples/usage-limit-workflow.md`
 - `examples/fixtures/usage-limit-issues.json`
+- `examples/dogfood-smoke-workflow.md`
+- `examples/fixtures/dogfood-smoke-issues.json`
 - `examples/linear-fixture-workflow.md`
 - `examples/fixtures/linear-issues.json`
 - `examples/llm-gate-workflow.md`

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -33,7 +33,9 @@ The operator launcher runbook is in `docs/operator-dogfood.md`; it keeps write
 mode explicit through `scripts/jade-dogfood --write --confirm-write`.
 
 The controlled live smoke runbook is in `docs/dogfood-smoke.md`. It keeps the
-first dogfood acceptance path supervised and bounded to one controlled issue.
+first dogfood acceptance path supervised and bounded to one controlled issue;
+`examples/dogfood-smoke-workflow.md` provides a credential-free fixture
+rehearsal of the same candidate filtering path.
 
 ## Before Executing GitHub Project Issues
 

--- a/docs/dogfood-smoke.md
+++ b/docs/dogfood-smoke.md
@@ -19,6 +19,18 @@ Create or select exactly one non-production issue that:
 
 ## Preflight
 
+Local fixture rehearsal:
+
+```bash
+cargo run -- dogfood-smoke examples/dogfood-smoke-workflow.md --dry-run
+```
+
+This fixture should report one controlled executable candidate while remaining
+in fixture mode with `write_ready=false`. It does not prove live GitHub Project
+v2 readiness.
+
+Live Project preflight:
+
 ```bash
 cargo run -- dogfood-smoke examples/github-project-workflow.md --dry-run
 ```

--- a/examples/dogfood-smoke-workflow.md
+++ b/examples/dogfood-smoke-workflow.md
@@ -1,0 +1,63 @@
+---
+tracker:
+  kind: github_project_v2
+  owner: Alive24
+  repo: jade-symphony
+  project_owner: Alive24
+  project_number: 9
+  status_field: Status
+  fixture_path: fixtures/dogfood-smoke-issues.json
+  state_map:
+    backlog: Backlog
+    todo: Todo
+    need_to_clarify: Need to Clarify
+    in_progress: In Progress
+    need_human_input: Need Human Input
+    agent_review: Agent Review
+    human_review: Human Review
+    rework: Rework
+    merging: Merging
+    done: Done
+  active_states:
+    - Todo
+    - Rework
+  terminal_states:
+    - Done
+    - Closed
+    - Cancelled
+    - Canceled
+    - Duplicate
+  assignee_filter:
+    source: issue_assignees
+    allow_unassigned: true
+    assignees: []
+  workpad:
+    source: issue_comment
+    marker: "<!-- jade-symphony-workpad -->"
+polling:
+  interval_ms: 5000
+workspace:
+  root: /tmp/jade-symphony-dogfood-smoke-workspaces
+agent:
+  backend: dry-run
+  max_concurrent_agents: 1
+  max_turns: 1
+  max_retry_backoff_ms: 300000
+codex:
+  command: codex app-server
+claude:
+  command: claude
+review:
+  backend: fake
+  gemini_command: gemini
+  timeout_ms: 600000
+observability:
+  logs_root: /tmp/jade-symphony-dogfood-smoke-logs
+---
+
+You are running the fixture-backed controlled dogfood smoke workflow for
+{{ issue.identifier }}.
+
+Keep this workflow credential-free. It exists to exercise controlled smoke
+candidate filtering, Issue Quality Gate evaluation, and operator reporting
+without live GitHub Project v2 writes.

--- a/examples/fixtures/dogfood-smoke-issues.json
+++ b/examples/fixtures/dogfood-smoke-issues.json
@@ -1,0 +1,44 @@
+[
+  {
+    "tracker_kind": "github_project_v2",
+    "id": "GHI_dogfood_smoke_controlled",
+    "item_id": "PVTI_dogfood_smoke_controlled",
+    "identifier": "#9001",
+    "title": "[dogfood-smoke] Controlled fixture smoke candidate",
+    "description": "## Issue Setup\n\n- UAT Required: No\n\n## Issue Goal\n\nExercise the controlled dogfood smoke preflight path in fixture mode.\n\n## Why Now\n\nOperators need a deterministic credential-free way to verify the controlled dogfood smoke candidate path before running the live GitHub Project v2 smoke.\n\n## Issue Context\n\nThis issue is loaded by `examples/dogfood-smoke-workflow.md`. It intentionally carries the `dogfood-smoke` label and a `[dogfood-smoke]` title marker so `dogfood-smoke` can count it as the one controlled candidate.\n\n## Decisions / Assumptions\n\n### Decisions\n\n- Keep this issue fixture-only and dry-run only.\n- Use one controlled candidate so the preflight can report the expected count.\n\n### Assumptions\n\n- Fixture mode is enough to rehearse candidate filtering and quality-gate evaluation.\n\n## Non-Negotiable Guardrails\n\n- Do not perform live GitHub Project v2 writes from this fixture.\n- Do not treat fixture readiness as supervised live dogfood completion.\n- Do not move work to Human Review.\n\n## Scope\n\n### In Scope\n\n- Controlled smoke preflight candidate detection.\n- Issue Quality Gate evaluation.\n- Operator-visible dry-run reporting.\n\n### Out of Scope\n\n- Live tracker mutation.\n- Real backend execution.\n- Review Agent execution.\n\n## Canonical References\n\n### Target Repository / Package\n\n- `Alive24/jade-symphony`\n\n### Relevant Knowledge Sources\n\n- `docs/dogfood-smoke.md`\n- `docs/dogfood-readiness.md`\n\n### Relevant Code Paths\n\n- `src/main.rs`\n- `examples/dogfood-smoke-workflow.md`\n- `examples/fixtures/dogfood-smoke-issues.json`\n\n## Current State\n\nThe live dogfood smoke command exists, but this fixture provides a safe local candidate.\n\n## Deliverable Shape\n\nA dry-run smoke preflight report with one controlled executable candidate.\n\n## Risks or Constraints\n\n- Fixture mode must remain non-write-ready.\n\n## Expected Outcome\n\nThe smoke preflight reports one controlled executable candidate and `write_ready=false`.\n\n## Verification\n\n### Completion Criteria\n\n- `cargo run -- dogfood-smoke examples/dogfood-smoke-workflow.md --dry-run` reports `controlled_candidates=1` and `executable_candidates=1`.\n\n### Functional Verification\n\n- `cargo test`\n- `cargo fmt --check`\n- `cargo clippy --all-targets --all-features -- -D warnings`\n\n### UAT\n\n- Not required.\n\n### Context Verification\n\n- Confirm fixture smoke remains separate from live dogfood smoke.",
+    "url": "https://github.com/Alive24/jade-symphony/issues/9001",
+    "state": "Todo",
+    "labels": ["dogfood-smoke", "fixture"],
+    "assignees": ["codex"],
+    "priority": 1,
+    "branch_name": null,
+    "linked_pull_requests": [],
+    "blocked_by": [],
+    "project_fields": {
+      "Status": "Todo"
+    },
+    "created_at": "2026-05-14T00:00:00Z",
+    "updated_at": "2026-05-14T00:00:00Z"
+  },
+  {
+    "tracker_kind": "github_project_v2",
+    "id": "GHI_dogfood_smoke_uncontrolled",
+    "item_id": "PVTI_dogfood_smoke_uncontrolled",
+    "identifier": "#9002",
+    "title": "Ordinary fixture issue outside controlled smoke",
+    "description": "## Issue Setup\n\n- UAT Required: No\n\n## Issue Goal\n\nRemain outside the controlled dogfood smoke candidate set.\n\n## Why Now\n\nThe fixture should prove that ordinary Todo issues do not count as controlled dogfood smoke candidates.\n\n## Issue Context\n\nThis issue is loaded by `examples/dogfood-smoke-workflow.md` but does not carry the `dogfood-smoke` label or title marker.\n\n## Non-Negotiable Guardrails\n\n- Do not count this issue as a controlled smoke candidate.\n\n## Scope\n\n### In Scope\n\n- Candidate filtering fixture coverage.\n\n### Out of Scope\n\n- Live tracker mutation.\n\n## Canonical References\n\n### Target Repository / Package\n\n- `Alive24/jade-symphony`\n\n### Relevant Knowledge Sources\n\n- `docs/dogfood-smoke.md`\n\n### Relevant Code Paths\n\n- `examples/fixtures/dogfood-smoke-issues.json`\n\n## Current State\n\nThe fixture needs a non-controlled issue for contrast.\n\n## Deliverable Shape\n\nAn ordinary Todo issue that is ignored by controlled smoke filtering.\n\n## Risks or Constraints\n\n- This issue must not accidentally include the smoke marker.\n\n## Expected Outcome\n\nThe dry-run smoke command still reports exactly one controlled candidate.\n\n## Verification\n\n### Completion Criteria\n\n- The fixture smoke command reports `controlled_candidates=1`.\n\n### Functional Verification\n\n- `cargo test`\n\n### UAT\n\n- Not required.\n\n### Context Verification\n\n- Confirm the title and labels do not include the controlled smoke marker.",
+    "url": "https://github.com/Alive24/jade-symphony/issues/9002",
+    "state": "Todo",
+    "labels": ["fixture"],
+    "assignees": ["codex"],
+    "priority": 2,
+    "branch_name": null,
+    "linked_pull_requests": [],
+    "blocked_by": [],
+    "project_fields": {
+      "Status": "Todo"
+    },
+    "created_at": "2026-05-14T00:05:00Z",
+    "updated_at": "2026-05-14T00:05:00Z"
+  }
+]


### PR DESCRIPTION
## Summary
- add a credential-free controlled dogfood-smoke fixture workflow
- add fixture issues with one controlled candidate and one ordinary Todo issue
- document the fixture smoke command separately from live Project #9 smoke

## Verification
- cargo run -- dogfood-smoke examples/dogfood-smoke-workflow.md --dry-run
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

Closes #145