### PR TITLE
Add examples workflow catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Run the bundled dry-run example:
 cargo run -- examples/dry-run-workflow.md
 ```
 
+The workflow catalog in `examples/README.md` groups fixture workflows, live
+workflow templates, backend fixtures, review fixtures, and their safe commands.
+
 Expected shape:
 
 - ready fixture issues appear under `running issues`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,66 @@
+# Jade Symphony Example Workflows
+
+This directory contains local workflows and fixtures for rehearsing Jade
+Symphony behavior. Most examples are fixture-backed and credential-free. The
+live GitHub workflow is explicit about tracker writes and should be used only
+with the documented `--write` commands.
+
+## Fixture Dispatch
+
+| Workflow | Purpose | Safe commands |
+| --- | --- | --- |
+| `dry-run-workflow.md` | Main credential-free dispatch and run-loop fixture backed by `fixtures/dry-run-issues.json`. | `cargo run -- plan examples/dry-run-workflow.md`; `cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run` |
+| `source-alignment-workflow.md` | Source-alignment gate fixture with one valid and one broken issue. | `cargo run -- plan examples/source-alignment-workflow.md`; `cargo run -- gate examples/source-alignment-workflow.md '#1'` |
+| `usage-limit-workflow.md` | Fixture backend path that exercises usage-limit pause handling. | `cargo run -- run-loop examples/usage-limit-workflow.md --max-iterations 1 --write` |
+| `git-identity-workflow.md` | Workspace-local git identity application fixture. | `cargo run -- run-once examples/git-identity-workflow.md` |
+
+Fixture workflows may use `--write` when the tracker is fixture-backed or
+memory-backed. They do not mutate live GitHub Project v2 state.
+
+## Tracker Adapters
+
+| Workflow | Purpose | Notes |
+| --- | --- | --- |
+| `linear-fixture-workflow.md` | Linear adapter fixture backed by `fixtures/linear-issues.json`. | Credential-free; does not prove live Linear readiness. |
+| `github-project-workflow.md` | Live GitHub Project v2 template for Project #9. | Non-fixture; read/write operations use `gh` or token auth and require explicit `--write` for mutation. |
+
+## Agent Backend Fixtures
+
+| Workflow | Purpose | Notes |
+| --- | --- | --- |
+| `codex-subprocess-workflow.md` | Conservative Codex subprocess backend fixture. | Runs the configured command in the prepared workspace. |
+| `claude-subprocess-workflow.md` | Conservative Claude Code subprocess backend fixture. | Separate backend path from Codex; not full protocol parity. |
+| `cockpit-profiles-workflow.md` | Execution profile discovery from a cockpit-tools-style fixture. | Reads `fixtures/cockpit-tools-codex-instances.json`; no secrets are used. |
+
+## Review And Quality Gate Fixtures
+
+| Workflow | Purpose | Notes |
+| --- | --- | --- |
+| `review-fixture-workflow.md` | Review-loop fixture backed by `fixtures/review-issues.json`. | Uses configured review flow without live reviewer credentials. |
+| `review-fake-workflow.md` | Fake review backend smoke path over dry-run issues. | Useful for role-bound transition checks. |
+| `llm-gate-workflow.md` | Optional command-backed LLM quality gate fixtures. | Uses shell fixtures in `fixtures/llm-gate-*.sh`; no hosted provider is called. |
+
+## Fixture Data
+
+| Fixture | Used by |
+| --- | --- |
+| `fixtures/dry-run-issues.json` | `dry-run-workflow.md`, `codex-subprocess-workflow.md`, `claude-subprocess-workflow.md`, `review-fake-workflow.md`, `cockpit-profiles-workflow.md` |
+| `fixtures/source-alignment-issues.json` | `source-alignment-workflow.md` |
+| `fixtures/usage-limit-issues.json` | `usage-limit-workflow.md` |
+| `fixtures/git-identity-issues.json` | `git-identity-workflow.md` |
+| `fixtures/linear-issues.json` | `linear-fixture-workflow.md` |
+| `fixtures/review-issues.json` | `review-fixture-workflow.md` |
+| `fixtures/llm-gate-issues.json` | `llm-gate-workflow.md` |
+| `fixtures/cockpit-tools-codex-instances.json` | `cockpit-profiles-workflow.md` |
+
+Issue Forge examples:
+
+- `fixtures/thin-issue.md`
+- `fixtures/repaired-issue.md`
+
+## Live Boundary
+
+Use `github-project-workflow.md` for live Project #9 reads and explicit writes.
+Do not treat fixture success as live readiness. Before any live write, inspect
+the Project state, confirm the issue contract, and use the workflow-specific
+commands documented in the root README and dogfood docs.


### PR DESCRIPTION
## Summary
- add examples/README.md cataloging current workflow files by purpose and safety boundary
- link the catalog from the root README
- keep fixture workflows separated from the live GitHub Project template

## Verification
- file-reference sanity check for examples files
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

Closes #149