### PR TITLE
Add inspect state summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ fixtures show controlled real-backend paths without invoking live hosted
 services. They write `JADE_SYMPHONY_PROMPT.md` into the prepared workspace and
 append JSONL events for the selected workflow.
 
+`inspect` prints the total issue count, a state summary, per-issue gate status,
+and configured integration gaps. It is the quickest read-only check for whether
+the Project still has `Merging`, `Rework`, `Todo`, or `In Progress` work.
+
 `profiles` lists execution profiles discovered from workflow config. For
 cockpit-tools, Jade currently reads the Codex instance store shape inspected in
 `https://github.com/jlcodes99/cockpit-tools`: a local `codex_instances.json` with camelCase

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -971,6 +972,7 @@ fn inspect(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     let issues = adapter.list_dispatchable_issues()?;
 
     println!("issues={}", issues.len());
+    println!("{}", render_state_summary(&issues));
     for issue in issues {
         let gate = evaluate_issue_for_current_source(&config, &issue)?;
         println!(
@@ -990,6 +992,27 @@ fn inspect(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn render_state_summary(issues: &[TrackerIssue]) -> String {
+    let mut counts = BTreeMap::new();
+    for issue in issues {
+        let state = issue.state.trim();
+        let state = if state.is_empty() { "(unknown)" } else { state };
+        *counts.entry(state.to_string()).or_insert(0usize) += 1;
+    }
+
+    let summary = if counts.is_empty() {
+        "(none)".to_string()
+    } else {
+        counts
+            .into_iter()
+            .map(|(state, count)| format!("{state}:{count}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    format!("state_summary={summary}")
 }
 
 fn doctor(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
@@ -3185,6 +3208,26 @@ mod tests {
                 workflow_path: PathBuf::from("examples/dry-run-workflow.md")
             }
         );
+    }
+
+    #[test]
+    fn render_state_summary_counts_states_in_stable_order() {
+        let issues = vec![
+            tracker_issue("Rework"),
+            tracker_issue("Agent Review"),
+            tracker_issue("Rework"),
+            tracker_issue(""),
+        ];
+
+        assert_eq!(
+            render_state_summary(&issues),
+            "state_summary=(unknown):1, Agent Review:1, Rework:2"
+        );
+    }
+
+    #[test]
+    fn render_state_summary_handles_empty_issue_list() {
+        assert_eq!(render_state_summary(&[]), "state_summary=(none)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- print a deterministic state summary from inspect output before the per-issue listing
- add focused renderer tests for stable ordering and empty issue lists
- document inspect as the quick read-only queue-state check in README

## Verification
- cargo run -- inspect examples/dry-run-workflow.md
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

Closes #153