### PR TITLE
Add inspect state filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Expected shape:
 cargo run -- validate examples/dry-run-workflow.md
 cargo run -- validate-workflow examples/dry-run-workflow.md
 cargo run -- inspect examples/dry-run-workflow.md
+cargo run -- inspect examples/github-project-workflow.md --state Merging --state Rework
 cargo run -- doctor examples/dry-run-workflow.md
 cargo run -- plan examples/dry-run-workflow.md
 cargo run -- plan-dispatch examples/dry-run-workflow.md

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     match command {
         Command::Plan { workflow_path } => plan(workflow_path),
         Command::Validate { workflow_path } => validate(workflow_path),
-        Command::Inspect { workflow_path } => inspect(workflow_path),
+        Command::Inspect {
+            workflow_path,
+            states,
+        } => inspect(workflow_path, states),
         Command::Doctor { workflow_path } => doctor(workflow_path),
         Command::Profiles { workflow_path } => list_profiles(workflow_path),
         Command::DogfoodSmoke {
@@ -962,14 +965,20 @@ fn validate(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn inspect(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+fn inspect(
+    workflow_path: PathBuf,
+    state_filters: Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let workflow = WorkflowDefinition::load(&workflow_path)?;
     let config = RuntimeConfig::from_workflow(&workflow, &workflow_path)?;
     config.validate()?;
 
     let adapter = adapter_from_config(&config);
-    let issues = adapter.list_dispatchable_issues()?;
+    let issues = filter_issues_by_state(adapter.list_dispatchable_issues()?, &state_filters);
 
+    if !state_filters.is_empty() {
+        println!("state_filter={}", state_filters.join(","));
+    }
     println!("issues={}", issues.len());
     for issue in issues {
         let gate = evaluate_issue_for_current_source(&config, &issue)?;
@@ -990,6 +999,29 @@ fn inspect(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn filter_issues_by_state(
+    issues: Vec<TrackerIssue>,
+    state_filters: &[String],
+) -> Vec<TrackerIssue> {
+    if state_filters.is_empty() {
+        return issues;
+    }
+
+    let normalized_filters = state_filters
+        .iter()
+        .map(|state| normalize_state(state))
+        .collect::<Vec<_>>();
+    issues
+        .into_iter()
+        .filter(|issue| {
+            let issue_state = issue.normalized_state();
+            normalized_filters
+                .iter()
+                .any(|filter| filter == &issue_state)
+        })
+        .collect()
 }
 
 fn doctor(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
@@ -2151,6 +2183,7 @@ enum Command {
     },
     Inspect {
         workflow_path: PathBuf,
+        states: Vec<String>,
     },
     Doctor {
         workflow_path: PathBuf,
@@ -2329,7 +2362,7 @@ enum CliCommand {
     Plan(WorkflowPathArgs),
     #[command(alias = "validate-workflow")]
     Validate(WorkflowPathArgs),
-    Inspect(WorkflowPathArgs),
+    Inspect(InspectArgs),
     #[command(alias = "audit-project")]
     Doctor(WorkflowPathArgs),
     Profiles(WorkflowPathArgs),
@@ -2381,6 +2414,18 @@ enum CliCommand {
 struct WorkflowPathArgs {
     #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
     workflow_path: PathBuf,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+    #[arg(long = "write")]
+    _write: bool,
+}
+
+#[derive(Debug, Args)]
+struct InspectArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
+    workflow_path: PathBuf,
+    #[arg(long = "state")]
+    states: Vec<String>,
     #[arg(long = "dry-run")]
     _dry_run: bool,
     #[arg(long = "write")]
@@ -2701,6 +2746,7 @@ impl TryFrom<Cli> for Command {
                     }),
                     CliCommand::Inspect(args) => Ok(Self::Inspect {
                         workflow_path: args.workflow_path,
+                        states: args.states,
                     }),
                     CliCommand::Doctor(args) => Ok(Self::Doctor {
                         workflow_path: args.workflow_path,
@@ -3185,6 +3231,50 @@ mod tests {
                 workflow_path: PathBuf::from("examples/dry-run-workflow.md")
             }
         );
+    }
+
+    #[test]
+    fn parses_inspect_state_filters() {
+        assert_eq!(
+            parse(&[
+                "inspect",
+                "examples/github-project-workflow.md",
+                "--state",
+                "Merging",
+                "--state",
+                "Rework"
+            ]),
+            Command::Inspect {
+                workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                states: vec!["Merging".into(), "Rework".into()]
+            }
+        );
+    }
+
+    #[test]
+    fn inspect_state_filter_matches_normalized_states() {
+        let issues = vec![
+            tracker_issue("Todo"),
+            tracker_issue("In Progress"),
+            tracker_issue("Agent Review"),
+        ];
+
+        let filtered = filter_issues_by_state(issues, &["in progress".into(), "todo".into()]);
+
+        assert_eq!(
+            filtered
+                .into_iter()
+                .map(|issue| issue.state)
+                .collect::<Vec<_>>(),
+            vec!["Todo", "In Progress"]
+        );
+    }
+
+    #[test]
+    fn inspect_state_filter_preserves_unfiltered_issue_list() {
+        let issues = vec![tracker_issue("Todo"), tracker_issue("Done")];
+
+        assert_eq!(filter_issues_by_state(issues.clone(), &[]), issues);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add repeated --state filters to the read-only inspect command
- filter tracker issues through normalized state matching while preserving default inspect behavior
- add parser and filtering tests plus a README focused queue-check example

## Verification
- cargo run -- inspect examples/dry-run-workflow.md --state Todo
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

Closes #155