### PR TITLE
#157: Detect Merging items without reliable PR linkage

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -65,6 +65,24 @@ pub fn audit_project_issues(issues: &[TrackerIssue]) -> ProjectAuditReport {
                     "Return to Agent Review until Review Agent pass evidence is recorded.",
                 ));
             }
+            "merging" if reliable_pr_targets(issue).is_empty() => {
+                violations.push(violation(
+                    issue,
+                    AuditSeverity::Blocker,
+                    "merging_missing_pr_target",
+                    "Merging issue has no reliable PR target.",
+                    "Record exactly one PR link in the Project field, issue closing reference, or Jade workpad before attempting to land.",
+                ));
+            }
+            "merging" if reliable_pr_targets(issue).len() > 1 => {
+                violations.push(violation(
+                    issue,
+                    AuditSeverity::Blocker,
+                    "merging_ambiguous_pr_target",
+                    "Merging issue has multiple candidate PR targets.",
+                    "Choose the correct PR and remove or supersede stale PR evidence before attempting to land.",
+                ));
+            }
             "merging" if has_dirty_or_conflicted_pr(issue) => {
                 violations.push(violation(
                     issue,
@@ -208,6 +226,24 @@ fn has_pr_url(issue: &TrackerIssue) -> bool {
         .linked_pull_requests
         .iter()
         .any(|pr| pr.url.as_deref().is_some_and(|url| !url.trim().is_empty()))
+}
+
+fn reliable_pr_targets(issue: &TrackerIssue) -> Vec<String> {
+    let mut targets = Vec::new();
+    for pr in &issue.linked_pull_requests {
+        let target = pr
+            .url
+            .as_deref()
+            .filter(|url| !url.trim().is_empty())
+            .map(str::to_string)
+            .or_else(|| pr.number.map(|number| format!("#{number}")));
+        if let Some(target) = target {
+            if !targets.contains(&target) {
+                targets.push(target);
+            }
+        }
+    }
+    targets
 }
 
 fn has_open_pr(issue: &TrackerIssue) -> bool {
@@ -354,6 +390,10 @@ mod tests {
     #[test]
     fn reports_dirty_merging_pr() {
         let mut issue = issue("#60", "Merging");
+        issue.linked_pull_requests.push(linked_pr(
+            "https://github.com/Alive24/jade-symphony/pull/60",
+            "OPEN",
+        ));
         issue.project_fields.insert(
             "pr_merge_state".into(),
             serde_json::Value::String("DIRTY".into()),
@@ -362,6 +402,45 @@ mod tests {
         let report = audit_project_issues(&[issue]);
 
         assert_eq!(report.violations[0].code, "merging_pr_not_clean");
+    }
+
+    #[test]
+    fn reports_merging_missing_pr_target() {
+        let report = audit_project_issues(&[issue("#60", "Merging")]);
+
+        assert_eq!(report.blocker_count(), 1);
+        assert_eq!(report.violations[0].code, "merging_missing_pr_target");
+    }
+
+    #[test]
+    fn reports_merging_ambiguous_pr_target() {
+        let mut issue = issue("#60", "Merging");
+        issue.linked_pull_requests.push(linked_pr(
+            "https://github.com/Alive24/jade-symphony/pull/60",
+            "OPEN",
+        ));
+        issue.linked_pull_requests.push(linked_pr(
+            "https://github.com/Alive24/jade-symphony/pull/61",
+            "OPEN",
+        ));
+
+        let report = audit_project_issues(&[issue]);
+
+        assert_eq!(report.blocker_count(), 1);
+        assert_eq!(report.violations[0].code, "merging_ambiguous_pr_target");
+    }
+
+    #[test]
+    fn accepts_merging_with_one_pr_target() {
+        let mut issue = issue("#60", "Merging");
+        issue.linked_pull_requests.push(linked_pr(
+            "https://github.com/Alive24/jade-symphony/pull/60",
+            "OPEN",
+        ));
+
+        let report = audit_project_issues(&[issue]);
+
+        assert!(report.is_clean());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1233,7 +1233,7 @@ fn doctor(options: DoctorOptions) -> Result<(), Box<dyn std::error::Error>> {
     config.validate()?;
 
     let adapter = adapter_from_config(&config);
-    let issues = adapter.list_dispatchable_issues()?;
+    let issues = adapter.fetch_issues_by_states(&all_mapped_tracker_states(&config))?;
     let mut report = audit_project_issues(&issues);
     report.integration_gaps = adapter.integration_gaps();
 
@@ -1293,6 +1293,22 @@ fn doctor_repair_human_review(
     }
 
     Ok(())
+}
+
+fn all_mapped_tracker_states(config: &RuntimeConfig) -> Vec<String> {
+    let state_map = &config.tracker.state_map;
+    vec![
+        state_map.backlog.clone(),
+        state_map.todo.clone(),
+        state_map.need_to_clarify.clone(),
+        state_map.in_progress.clone(),
+        state_map.need_human_input.clone(),
+        state_map.agent_review.clone(),
+        state_map.human_review.clone(),
+        state_map.rework.clone(),
+        state_map.merging.clone(),
+        state_map.done.clone(),
+    ]
 }
 
 fn list_profiles(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
@@ -4231,6 +4247,16 @@ mod tests {
                 reason: "workspace_missing".into()
             }
         );
+    }
+
+    #[test]
+    fn all_mapped_tracker_states_includes_merging_for_doctor() {
+        let config = test_config();
+        let states = all_mapped_tracker_states(&config);
+
+        assert!(states.contains(&"Merging".to_string()));
+        assert!(states.contains(&"Rework".to_string()));
+        assert!(states.contains(&"Done".to_string()));
     }
 
     #[test]

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -226,6 +226,13 @@ impl GithubProjectV2Adapter {
     }
 
     fn load_issues(&self) -> Result<Vec<TrackerIssue>, TrackerError> {
+        Ok(apply_github_read_filters(
+            self.load_mapped_issues()?,
+            &self.config,
+        ))
+    }
+
+    fn load_mapped_issues(&self) -> Result<Vec<TrackerIssue>, TrackerError> {
         let issues =
             if !self.fixture_issues.is_empty() || self.config.tracker.fixture_path.is_some() {
                 self.fixture_issues.clone()
@@ -233,17 +240,26 @@ impl GithubProjectV2Adapter {
                 GithubProjectV2GhClient::new(&self.config).fetch_project_issues()?
             };
 
-        Ok(apply_github_read_filters(issues, &self.config))
+        Ok(apply_github_status_filters(issues, &self.config))
     }
 }
 
-fn apply_github_read_filters(
+fn apply_github_status_filters(
     issues: Vec<TrackerIssue>,
     config: &RuntimeConfig,
 ) -> Vec<TrackerIssue> {
     issues
         .into_iter()
         .filter(|issue| status_is_mapped(&issue.state, config))
+        .collect()
+}
+
+fn apply_github_read_filters(
+    issues: Vec<TrackerIssue>,
+    config: &RuntimeConfig,
+) -> Vec<TrackerIssue> {
+    apply_github_status_filters(issues, config)
+        .into_iter()
         .filter(|issue| issue_matches_assignee_filter(issue, &config.tracker.assignee_filter))
         .collect()
 }
@@ -302,14 +318,14 @@ impl TrackerAdapter for GithubProjectV2Adapter {
 
     fn get_issue(&self, issue_ref: &str) -> Result<Option<TrackerIssue>, TrackerError> {
         Ok(self
-            .load_issues()?
+            .load_mapped_issues()?
             .iter()
             .find(|issue| issue.id == issue_ref || issue.identifier == issue_ref)
             .cloned())
     }
 
     fn fetch_issues_by_states(&self, states: &[String]) -> Result<Vec<TrackerIssue>, TrackerError> {
-        MemoryTracker::new(self.load_issues()?).fetch_issues_by_states(states)
+        MemoryTracker::new(self.load_mapped_issues()?).fetch_issues_by_states(states)
     }
 
     fn set_state(&self, issue_ref: &str, normalized_state: &str) -> Result<(), TrackerError> {
@@ -2821,6 +2837,35 @@ Prompt
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].state, "Todo");
         assert_eq!(filtered[0].assignees, vec!["Codex"]);
+    }
+
+    #[test]
+    fn github_state_reads_can_bypass_main_assignee_filter_for_merge_lane() {
+        let config = github_config(
+            r#"---
+tracker:
+  kind: github_project_v2
+  owner: Alive24
+  repo: jade-symphony
+  project_owner: Alive24
+  project_number: 1
+  assignee_filter:
+    source: issue_assignees
+    allow_unassigned: false
+    assignees: []
+---
+Prompt
+"#,
+        );
+
+        let unassigned_merging = issue("Merging");
+        let dispatch_filtered =
+            apply_github_read_filters(vec![unassigned_merging.clone()], &config);
+        let state_filtered = apply_github_status_filters(vec![unassigned_merging], &config);
+
+        assert!(dispatch_filtered.is_empty());
+        assert_eq!(state_filtered.len(), 1);
+        assert_eq!(state_filtered[0].state, "Merging");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Split GitHub Project reads so main-agent dispatch keeps assignee filtering while exact/state-specific lane reads bypass it.
- Make project doctor audit all mapped states, including Merging/Rework/Done, and keep integration gap reporting.
- Add Merging PR target invariants for missing or ambiguous PR evidence.

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- doctor examples/github-project-workflow.md
- cargo run -- merge-once examples/github-project-workflow.md --dry-run

Closes #157