### PR TITLE
Fix issue #143 post-merge compile regression

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5899,6 +5899,7 @@ mod tests {
             "Create issue".into(),
             forge_contract(),
             true,
+            Vec::new(),
             true,
         )
         .unwrap_err()


### PR DESCRIPTION
Repair for #143 after PR #144 landed with one stale forge_create test call.\n\nVerification in isolated repair worktree:\n- cargo test\n- cargo fmt --check\n- cargo clippy --all-targets --all-features -- -D warnings