### PR TITLE
Fix forge-create duplicate title test compatibility

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5899,6 +5899,7 @@ mod tests {
             "Create issue".into(),
             forge_contract(),
             true,
+            Vec::new(),
             true,
         )
         .unwrap_err()


### PR DESCRIPTION
## Summary
- Fixes the post-merge #143 test compile failure by passing the current empty project_fields argument to forge_create in the duplicate-title regression test.

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

Rework for #143.