### PR TITLE
Make Gemini review command configurable via env

### DIFF
--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -100,6 +100,7 @@ specific blocker before running another write tick.
 For a bounded Review Agent pass, run:
 
 ```bash
+export JADE_GEMINI_COMMAND="$(command -v gemini)"
 cargo run -- review-loop examples/github-project-workflow.md --max-iterations 1 --write
 ```
 
@@ -109,6 +110,11 @@ Expected outcomes:
 - confirmed findings move the issue to `Rework`;
 - failed, inconclusive, timed-out, or unavailable review stays out of
   `Human Review` and records evidence.
+
+If the review workflow uses `review.gemini_command: $JADE_GEMINI_COMMAND`,
+set that environment variable to an absolute Gemini CLI path before starting
+the supervised review loop. This avoids worker sessions with a narrower `PATH`
+recording a backend-unavailable failure for an otherwise installed Gemini CLI.
 
 Do not use review commands to bypass human acceptance.
 

--- a/examples/github-project-workflow.md
+++ b/examples/github-project-workflow.md
@@ -49,8 +49,8 @@ codex:
 claude:
   command: claude
 review:
-  backend: fake
-  gemini_command: gemini
+  backend: gemini-cli
+  gemini_command: $JADE_GEMINI_COMMAND
   timeout_ms: 600000
 verification:
   timeout_ms: 600000

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,8 +314,10 @@ impl RuntimeConfig {
         let review = ReviewConfig {
             backend: get_string(root.get("review"), "backend")
                 .unwrap_or_else(|| "fake".to_string()),
-            gemini_command: get_string(root.get("review"), "gemini_command")
-                .unwrap_or_else(|| "gemini".to_string()),
+            gemini_command: resolve_command_token(
+                get_string(root.get("review"), "gemini_command"),
+                "gemini",
+            ),
             timeout_ms: get_u64(root.get("review"), "timeout_ms").unwrap_or(600_000),
             max_concurrent_workers: get_u64(root.get("review"), "max_concurrent_workers")
                 .unwrap_or(1)
@@ -712,6 +714,17 @@ fn resolve_secret(value: Option<String>, fallback_env: &str) -> Option<String> {
     }
 }
 
+fn resolve_command_token(value: Option<String>, default: &str) -> String {
+    match value {
+        Some(raw) if raw.starts_with('$') => env::var(raw.trim_start_matches('$'))
+            .ok()
+            .filter(|value| !value.is_empty())
+            .unwrap_or(raw),
+        Some(raw) if !raw.is_empty() => raw,
+        _ => default.to_string(),
+    }
+}
+
 fn resolve_path(raw: Option<&str>, workflow_dir: &Path, default: &Path) -> PathBuf {
     let value = raw
         .and_then(resolve_path_token)
@@ -876,6 +889,24 @@ mod tests {
                 .get("jade.actorRole")
                 .map(String::as_str),
             Some("review_agent")
+        );
+    }
+
+    #[test]
+    fn review_gemini_command_can_use_environment_token() {
+        std::env::set_var("JADE_TEST_GEMINI_COMMAND", "/opt/homebrew/bin/gemini-test");
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\nreview:\n  backend: gemini-cli\n  gemini_command: $JADE_TEST_GEMINI_COMMAND\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+        std::env::remove_var("JADE_TEST_GEMINI_COMMAND");
+
+        assert_eq!(
+            config.review.gemini_command,
+            "/opt/homebrew/bin/gemini-test"
         );
     }
 


### PR DESCRIPTION
## Summary

- resolve `review.gemini_command` environment tokens such as `$JADE_GEMINI_COMMAND`
- configure the live GitHub Project workflow to use the Gemini CLI review backend through that token
- document exporting the Gemini command path before supervised `review-loop`

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- validate examples/github-project-workflow.md`

Closes #176
