### PR TITLE
Use issue relationships as dependency source of truth

### DIFF
--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -16,7 +16,7 @@ yet.
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
-| Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies the template `UAT Required` field, explicit dependency semantics, target repository, referenced local paths, and supported verification command shapes. Optional local command-backed LLM gate mode exists as disabled/advisory/required; richer semantic validation and hosted providers are still follow-ups. |
+| Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies the template `UAT Required` field, relationship-first dependency semantics, target repository, referenced local paths, and supported verification command shapes. Structured `blocked_by` tracker relationships are authoritative for dispatch blocking; missing Markdown dependency boilerplate no longer blocks otherwise independent work, while body-only blocker claims still require clarification or a structured relationship. Optional local command-backed LLM gate mode exists as disabled/advisory/required; richer semantic validation and hosted providers are still follow-ups. |
 | Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping with dependency sections, conservative reflective follow-up candidate generation that surfaces likely dependency/overlap signals, and explicit `forge-create` tracker issue creation from quality-gated Markdown with duplicate-title guarding. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path, `forge-create --add-to-project` can set GitHub Project v2 single-select fields such as `Capability` with repeatable `--project-field NAME=VALUE` flags, and live GitHub `forge-create` requires `--assignee` before adding executable Project items. Text/number/date field setup is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, dependency preflight for `Todo` / `Rework`, runtime-state persistence, tracker-visible advisory ownership markers, resume preflight, retry backoff records, stall detection, live PR handoff plus tracker PR link recording in non-fixture GitHub mode, guarded `merge-once` and bounded `merge-loop` lanes for `Merging` issues, first-slice `--pool` selection guarded by `Main Agent` / `Merging Agent` Project fields, a controlled `dogfood-smoke` preflight report with blocking-vs-warning integration gap severity, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, unbounded merge idle polling, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, guarded terminal cleanup planning, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, dirty/no-op guards before branch push, optional configured verification commands before PR handoff, branch push, PR create-or-reuse, tracker PR link recording, run-loop handoff evidence, profile-scoped workspace keys, parsed-but-unused SSH worker host config, a namespaced artifact layout, and dry-run cleanup planning exist. Automatic runtime cleanup, write-mode artifact cleanup, and live SSH execution are not wired yet. |
@@ -83,9 +83,9 @@ Project v2 issues:
      current `gh` login or selected profile login before claim.
    - `run-loop` reuses tracker claim helpers to claim only `Todo` / `Rework`,
      resume active `In Progress`, and stop/replan on externally changed states.
-   - Main-agent dispatch requires explicit dependency semantics in the issue
-     contract and skips `Todo` / `Rework` issues with unresolved tracker
-     blockers before claim.
+   - Main-agent dispatch treats structured tracker blockers as authoritative,
+     skips `Todo` / `Rework` issues with unresolved blockers before claim, and
+     no longer requires Markdown dependency boilerplate for independent work.
    - Revalidate issue state immediately before dispatch.
    - Keep GitHub-specific fields out of `orchestrator`.
 - Current explicit `gate-apply` can record quality-gate assumptions or
@@ -162,9 +162,10 @@ Project v2 issues:
      final transition intent. Resume preflight now blocks conflicting stale
      active state, honors retry backoff, and reports stalls; full multi-worker
      reconciliation remains pending.
-   - Dependency-free work must say so in the issue body; semantic dependency
-     placeholders stay in `Need to Clarify`, and tracker blockers must be
-     terminal before dispatch.
+   - Structured tracker blockers are the dependency source of truth. Missing
+     body dependency boilerplate does not block otherwise independent work, but
+     semantic dependency placeholders and body-only blocker claims stay in
+     `Need to Clarify`; tracker blockers must be terminal before dispatch.
    - Write-mode `run-loop` now writes a tracker-visible runtime ownership marker
      before backend execution and skips active `In Progress` work when the
      marker points at a different profile, workspace key, or branch. `run-loop`

--- a/examples/github-project-workflow.md
+++ b/examples/github-project-workflow.md
@@ -102,9 +102,9 @@ question, but do not edit files under
 2. Confirm the issue is still executable with the Issue Quality Gate. If the
    issue is not executable, leave a precise workpad note, move it to
    `Need to Clarify`, and stop this issue.
-   The gate must include explicit dependency semantics: either no blocking
-   dependencies, or named blockers/overlaps with the condition that makes the
-   issue claimable.
+   Structured tracker blockers are the dependency source of truth. Body text can
+   explain dependencies, but missing dependency boilerplate is not a blocker for
+   otherwise independent work.
 3. Work in exactly one isolated workspace and branch for this issue. Do not mix
    unrelated issue scopes in this branch or PR.
 4. Capture a short implementation plan in the workpad before significant edits.

--- a/src/quality_gate.rs
+++ b/src/quality_gate.rs
@@ -37,7 +37,7 @@ pub fn evaluate_issue(issue: &TrackerIssue) -> GateDecision {
     if let Err(missing_uat) = validate_uat_required(description) {
         missing.push(missing_uat);
     }
-    if let Err(missing_dependency) = validate_dependency_semantics(description) {
+    if let Err(missing_dependency) = validate_dependency_semantics(issue, description) {
         missing.push(missing_dependency);
     }
 
@@ -387,7 +387,11 @@ fn validate_uat_required(markdown: &str) -> Result<(), String> {
     }
 }
 
-fn validate_dependency_semantics(markdown: &str) -> Result<(), String> {
+fn validate_dependency_semantics(issue: &TrackerIssue, markdown: &str) -> Result<(), String> {
+    if !issue.blocked_by.is_empty() {
+        return Ok(());
+    }
+
     let lines = section_lines(markdown, "Dependencies");
     let dependencies = lines
         .iter()
@@ -397,11 +401,15 @@ fn validate_dependency_semantics(markdown: &str) -> Result<(), String> {
         .collect::<Vec<_>>();
 
     if dependencies.is_empty() {
-        return Err("dependency semantics".into());
+        return Ok(());
     }
 
     let joined = dependencies.join(" ").to_ascii_lowercase();
-    if contains_any_dependency_marker(&joined) && !contains_ambiguous_dependency_marker(&joined) {
+    if contains_ambiguous_dependency_marker(&joined) {
+        Err("resolved dependency semantics".into())
+    } else if claims_blocking_dependency_without_relationship(&joined) {
+        Err("structured blocked-by relationship".into())
+    } else if contains_any_dependency_marker(&joined) {
         Ok(())
     } else {
         Err("resolved dependency semantics".into())
@@ -424,6 +432,17 @@ fn contains_any_dependency_marker(text: &str) -> bool {
         || text.contains("pull request")
         || text.contains("pr #")
         || text.contains('#')
+}
+
+fn claims_blocking_dependency_without_relationship(text: &str) -> bool {
+    (text.contains("blocked by")
+        || text.contains("depends on")
+        || text.contains("dependency:")
+        || text.contains("dependencies:")
+        || text.contains("requires #"))
+        && !text.contains("no blocking")
+        && !text.contains("no known blocking")
+        && !text.contains("none")
 }
 
 fn contains_ambiguous_dependency_marker(text: &str) -> bool {
@@ -801,7 +820,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_dependency_semantics_needs_clarification() {
+    fn missing_dependency_section_does_not_block_independent_issue() {
         let body = [
             "## Issue Setup",
             "- UAT Required: No",
@@ -827,10 +846,23 @@ mod tests {
 
         let decision = evaluate_issue(&issue(Some(body)));
 
+        assert!(decision.is_dispatchable(), "{decision:?}");
+    }
+
+    #[test]
+    fn body_only_blocker_claim_needs_structured_relationship() {
+        let mut body = aligned_body_with_uat("No");
+        body = body.replace(
+            "## Dependencies\n- No blocking dependencies.",
+            "## Dependencies\n\n- Blocked by #44 until it is Done.",
+        );
+
+        let decision = evaluate_issue(&issue(Some(body)));
+
         assert_eq!(decision.kind, GateDecisionKind::NeedToClarify);
         assert!(decision
             .missing
-            .contains(&"dependency semantics".to_string()));
+            .contains(&"structured blocked-by relationship".to_string()));
     }
 
     #[test]
@@ -851,7 +883,11 @@ mod tests {
 
     #[test]
     fn dependency_preflight_blocks_non_terminal_tracker_blocker() {
-        let mut issue = issue(Some(aligned_body_with_uat("No")));
+        let body = aligned_body_with_uat("No").replace(
+            "## Dependencies\n- No blocking dependencies.",
+            "## Dependencies\n",
+        );
+        let mut issue = issue(Some(body));
         issue.blocked_by.push(crate::model::BlockerRef {
             id: None,
             identifier: Some("#99".into()),
@@ -867,7 +903,11 @@ mod tests {
 
     #[test]
     fn dependency_preflight_allows_terminal_tracker_blocker() {
-        let mut issue = issue(Some(aligned_body_with_uat("No")));
+        let body = aligned_body_with_uat("No").replace(
+            "## Dependencies\n- No blocking dependencies.",
+            "## Dependencies\n",
+        );
+        let mut issue = issue(Some(body));
         issue.blocked_by.push(crate::model::BlockerRef {
             id: None,
             identifier: Some("#99".into()),


### PR DESCRIPTION
Closes #187.

Summary:
- Treat structured tracker blocked_by relationships as the authoritative dependency source for the issue quality gate.
- Allow independent issues without Markdown dependency boilerplate to dispatch.
- Keep body-only blocker claims in Need to Clarify until represented as a structured relationship.
- Update dogfood readiness docs and the GitHub Project workflow prompt to match the relationship-first contract.

Verification:
- cargo fmt --check
- git diff --check
- cargo test dependency -- --nocapture
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

UAT:
- Covered by dependency gate fixture tests for no-dependency boilerplate, body-only blocker claims, unresolved structured blockers, and terminal structured blockers.