### PR TITLE
Separate operational workflows from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ For a compact source-linked view of what is landed, what is waiting in
 - basic strict prompt rendering supports known `issue.*` fields, `attempt`, and
   simple `{% if %}` / `{% else %}` blocks. The supported subset is documented
   in `docs/prompt-template-contract.md`.
-- `examples/github-project-workflow.md` now contains an inline Jade execution
-  prompt with the operating loop, workpad discipline, review boundary, stop
-  conditions, and one issue / one branch / one PR handoff rules.
+- `workflows/jade-symphony.md` is the canonical self-dogfood workflow and
+  contains an inline Jade execution prompt with the operating loop, workpad
+  discipline, review boundary, stop conditions, and one issue / one branch /
+  one PR handoff rules.
 - `scripts/jade-dogfood` provides a bounded operator launcher for the GitHub
   Project workflow with explicit dry-run/write modes and preflight checks for
   the built binary, git, `gh`, auth, workflow validation, and controlled
@@ -211,8 +212,9 @@ Run the bundled dry-run example:
 cargo run -- examples/dry-run-workflow.md
 ```
 
-The workflow catalog in `examples/README.md` groups fixture workflows, live
-workflow templates, backend fixtures, review fixtures, and their safe commands.
+The normal Jade Symphony dogfood workflow is `workflows/jade-symphony.md`. The
+workflow catalog in `examples/README.md` groups fixture workflows, compatibility
+templates, backend fixtures, review fixtures, and their safe commands.
 
 Expected shape:
 
@@ -231,8 +233,8 @@ boundaries, and role-specific lanes.
 cargo run -- validate examples/dry-run-workflow.md
 cargo run -- validate-workflow examples/dry-run-workflow.md
 cargo run -- inspect examples/dry-run-workflow.md
-cargo run -- cleanup-plan examples/github-project-workflow.md
-cargo run -- inspect examples/github-project-workflow.md --state Merging --state Rework
+cargo run -- cleanup-plan workflows/jade-symphony.md
+cargo run -- inspect workflows/jade-symphony.md --state Merging --state Rework
 cargo run -- doctor examples/dry-run-workflow.md
 cargo run -- doctor-repair-human-review examples/dry-run-workflow.md --dry-run
 cargo run -- doctor examples/dry-run-workflow.md --json
@@ -247,7 +249,7 @@ cargo run -- run-once examples/git-identity-workflow.md
 cargo run -- run-once examples/codex-subprocess-workflow.md
 cargo run -- run-once examples/claude-subprocess-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
-cargo run -- review-loop examples/github-project-workflow.md --max-iterations 1 --dry-run
+cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
 cargo run -- profiles examples/cockpit-profiles-workflow.md
 cargo run -- plan examples/linear-fixture-workflow.md
 cargo run -- gate examples/dry-run-workflow.md '#3'
@@ -259,7 +261,7 @@ cargo run -- forge-validate --title "Repaired Forge issue" --file examples/fixtu
 cargo run -- forge-draft --title "Implement read-only Project v2 adapter" --goal "Load Project v2 issues into TrackerIssue records."
 cargo run -- forge-interactive --title "Add resume preflight" --intent "run-loop should inspect runtime state before claiming new work" --skill runtime
 cargo run -- forge-reflect --context-file docs/dogfood-readiness.md --limit 1
-cargo run -- forge-create --workflow path/to/WORKFLOW.md --title "Follow-up title" --file path/to/issue.md --assignee Alive24 --add-to-project --project-field Capability=CLI --write
+cargo run -- forge-create --workflow workflows/jade-symphony.md --title "Follow-up title" --file path/to/issue.md --assignee Alive24 --add-to-project --project-field Capability=CLI --write
 ```
 
 `run-once` defaults to dry-run examples, but the Codex and Claude subprocess
@@ -441,13 +443,13 @@ cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
 scripts/jade-dogfood --dry-run
 cargo run -- dogfood-smoke examples/dogfood-smoke-workflow.md --dry-run
-cargo run -- dogfood-smoke examples/github-project-workflow.md --dry-run
+cargo run -- dogfood-smoke workflows/jade-symphony.md --dry-run
 cargo run -- merge-once examples/merge-fixture-workflow.md --dry-run
 scripts/jade-dogfood --write --confirm-write --max-iterations 1
 cargo run -- run-loop examples/usage-limit-workflow.md --max-iterations 1 --write
-cargo run -- merge-once examples/github-project-workflow.md --dry-run
-cargo run -- merge-loop examples/github-project-workflow.md --max-iterations 3 --dry-run
-cargo run -- cleanup-workspaces examples/github-project-workflow.md --dry-run
+cargo run -- merge-once workflows/jade-symphony.md --dry-run
+cargo run -- merge-loop workflows/jade-symphony.md --max-iterations 3 --dry-run
+cargo run -- cleanup-workspaces workflows/jade-symphony.md --dry-run
 cargo run -- gate examples/llm-gate-workflow.md '#1'
 ```
 
@@ -468,14 +470,26 @@ The dry-run workflow uses:
 - `examples/fixtures/llm-gate-clarify.sh`
 - `examples/fixtures/llm-gate-malformed.sh`
 
-For a real GitHub Project v2 read/write workflow template, copy and edit:
+For normal Jade Symphony Project #9 dogfood, use:
 
-- `examples/github-project-workflow.md`
+- `workflows/jade-symphony.md`
 
-Update `owner`, `repo`, `project_owner`, `project_number`, and `state_map` before
-using it with a live project. The prompt body is the current Jade dogfood
-operator prompt; keep it aligned with `docs/bootstrap/JADE_WORKFLOW.md` when
-the workflow contract changes.
+The intended operator spelling is one loop plus one forge:
+
+```bash
+jade-symphony loop workflows/jade-symphony.md --write
+jade-symphony forge workflows/jade-symphony.md --interactive
+```
+
+Until those aliases land, use the explicit command names:
+
+```bash
+cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write
+cargo run -- forge-interactive --workflow workflows/jade-symphony.md
+```
+
+The legacy `examples/github-project-*.md` files are compatibility/reference
+templates, not the normal operator workflow.
 
 ## Bootstrap Sources
 

--- a/docs/artifact-storage-policy.md
+++ b/docs/artifact-storage-policy.md
@@ -67,7 +67,7 @@ operator removal when all of these are true:
 The command never deletes files:
 
 ```bash
-cargo run -- cleanup-plan examples/github-project-workflow.md
+cargo run -- cleanup-plan workflows/jade-symphony.md
 ```
 
 Use the report to decide what to remove manually or in a future explicit

--- a/docs/bootstrap-parity-audit.md
+++ b/docs/bootstrap-parity-audit.md
@@ -43,7 +43,7 @@ must not be edited by Jade Symphony implementation work.
 | Workflow loading | Landed | `src/workflow.rs`, `README.md`, `docs/dogfood-readiness.md` | Runtime reload with last-known-good config remains deferred. |
 | Typed config | Partial | `src/config.rs`, `examples/*.md` | Config is enough for current CLI paths, but richer live worker settings are still evolving. |
 | Normalized tracker model | Landed | `src/model.rs`, `src/tracker.rs` | Blocker relationship sources need continued adapter hardening. |
-| GitHub Project v2 adapter | Partial | `src/tracker.rs`, `examples/github-project-workflow.md` | Live writes exist behind `--write`; full reconciliation and richer Project field mutation are not fully landed on main. |
+| GitHub Project v2 adapter | Partial | `src/tracker.rs`, `workflows/jade-symphony.md` | Live writes exist behind `--write`; full reconciliation and richer Project field mutation are not fully landed on main. |
 | Linear adapter | Partial | `src/tracker.rs`, `examples/linear-fixture-workflow.md` | Live schema smoke coverage is still required before routine use. |
 | Issue Quality Gate | Landed | `src/quality_gate.rs`, `docs/bootstrap/ISSUE_QUALITY_GATE_TEMPLATE.md` | Semantic/LLM-assisted checks remain optional and conservative. |
 | Issue Forge | Partial | `src/issue_forge.rs`, README command docs | Tracker creation exists; richer field setup and conversational UI remain follow-ups. |
@@ -126,8 +126,8 @@ set `Human Review`, and only after review evidence is recorded.
 Keep this document aligned by running:
 
 ```bash
-cargo run -- inspect examples/github-project-workflow.md
-cargo run -- doctor examples/github-project-workflow.md
+cargo run -- inspect workflows/jade-symphony.md
+cargo run -- doctor workflows/jade-symphony.md
 cargo test
 cargo fmt --check
 cargo clippy --all-targets --all-features -- -D warnings

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -17,10 +17,10 @@ remain the preferred rehearsal path for local development.
 | `status` | Operator status alias for planning output. | `cargo run -- status examples/dry-run-workflow.md` |
 | `validate` | Validate workflow loading/configuration. | `cargo run -- validate examples/dry-run-workflow.md` |
 | `validate-workflow` | Compatibility alias for `validate`. | `cargo run -- validate-workflow examples/dry-run-workflow.md` |
-| `inspect` | Read tracker issues and print gate/status information. | `cargo run -- inspect examples/github-project-workflow.md` |
-| `project-state` | Diagnose whether the canonical Project read path is trustworthy. | `cargo run -- project-state examples/github-project-workflow.md` |
-| `doctor` | Audit Project/workflow invariants. | `cargo run -- doctor examples/github-project-workflow.md` |
-| `audit-project` | Compatibility alias for `doctor`. | `cargo run -- audit-project examples/github-project-workflow.md` |
+| `inspect` | Read tracker issues and print gate/status information. | `cargo run -- inspect workflows/jade-symphony.md` |
+| `project-state` | Diagnose whether the canonical Project read path is trustworthy. | `cargo run -- project-state workflows/jade-symphony.md` |
+| `doctor` | Audit Project/workflow invariants. | `cargo run -- doctor workflows/jade-symphony.md` |
+| `audit-project` | Compatibility alias for `doctor`. | `cargo run -- audit-project workflows/jade-symphony.md` |
 | `profiles` | List configured/discovered execution profiles. | `cargo run -- profiles examples/cockpit-profiles-workflow.md` |
 
 ## Main Implementation Runtime
@@ -36,8 +36,8 @@ Examples:
 ```bash
 cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
-cargo run -- run-loop examples/github-project-workflow.md --max-iterations 1 --pool 2 --dry-run
-cargo run -- dogfood-smoke examples/github-project-workflow.md --dry-run
+cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --pool 2 --dry-run
+cargo run -- dogfood-smoke workflows/jade-symphony.md --dry-run
 ```
 
 `run-loop --pool N` is a supervised planning and claim-locking slice. Dry-run
@@ -61,8 +61,8 @@ These commands can mutate live tracker state and require `--write`.
 Examples:
 
 ```bash
-cargo run -- set-state examples/github-project-workflow.md '#123' need_to_clarify --write
-cargo run -- workpad examples/github-project-workflow.md '#123' /tmp/workpad.md --write
+cargo run -- set-state workflows/jade-symphony.md '#123' need_to_clarify --write
+cargo run -- workpad workflows/jade-symphony.md '#123' /tmp/workpad.md --write
 ```
 
 ## Issue Quality Gate
@@ -76,7 +76,7 @@ Examples:
 
 ```bash
 cargo run -- gate examples/dry-run-workflow.md '#3'
-cargo run -- gate-apply examples/github-project-workflow.md '#123' --write
+cargo run -- gate-apply workflows/jade-symphony.md '#123' --write
 ```
 
 ## Issue Forge
@@ -97,7 +97,7 @@ Examples:
 ```bash
 cargo run -- forge-validate --title "Thin Forge issue" --file examples/fixtures/thin-issue.md
 cargo run -- forge-reflect --context-file docs/dogfood-readiness.md --limit 1
-cargo run -- forge-create --workflow examples/github-project-workflow.md --title "Follow-up title" --file /tmp/issue.md --assignee Alive24 --add-to-project --write
+cargo run -- forge-create --workflow workflows/jade-symphony.md --title "Follow-up title" --file /tmp/issue.md --assignee Alive24 --add-to-project --write
 ```
 
 ## Review Agent Lane
@@ -117,7 +117,7 @@ Example:
 
 ```bash
 cargo run -- review-loop examples/review-fixture-workflow.md --max-iterations 1 --dry-run
-cargo run -- review-loop examples/github-project-gemini-review-workflow.md --max-iterations 1 --write
+cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
 ## Merge Lane
@@ -130,7 +130,7 @@ cargo run -- review-loop examples/github-project-gemini-review-workflow.md --max
 Examples:
 
 ```bash
-cargo run -- merge-once examples/github-project-workflow.md --dry-run
+cargo run -- merge-once workflows/jade-symphony.md --dry-run
 ```
 
 `merge-once` is separate from main implementation and review work. It should
@@ -138,7 +138,7 @@ only consume issues already in `Merging`.
 
 ## Live Dogfood Boundary
 
-Use `examples/github-project-workflow.md` for Project #9 live reads and explicit
+Use `workflows/jade-symphony.md` for Project #9 live reads and explicit
 writes. Before running live write commands, confirm:
 
 - the issue contract passes the Issue Quality Gate;

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -11,7 +11,7 @@ yet.
 | Capability | Current Status |
 | --- | --- |
 | Workflow loader | Implemented for explicit workflow path and optional YAML front matter. A first-slice `WorkflowStore` can explicitly reload a workflow while preserving the last known good definition after load/parse failures. Long-running runtime reload wiring is not implemented. |
-| Dogfood workflow prompt | `examples/github-project-workflow.md` includes the Jade operating loop, issue quality gate expectation, workpad discipline, role boundaries, stop conditions, and one issue / one branch / one PR handoff rules. Tests guard against reverting to a placeholder-thin prompt. |
+| Dogfood workflow prompt | `workflows/jade-symphony.md` is the canonical normal operator workflow and includes the Jade operating loop, issue quality gate expectation, workpad discipline, role boundaries, stop conditions, and one issue / one branch / one PR handoff rules. Tests guard against reverting to a placeholder-thin prompt. |
 | Typed config | Implemented for the current skeleton, including GitHub Project v2-shaped settings, operator/agent identity metadata, first-slice execution profiles, and optional SSH worker host settings for future remote scheduling. |
 | Normalized issue model | Implemented as `TrackerIssue`, including ProjectV2 item ID, labels, assignees, blockers, linked PRs, and project fields. |
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
@@ -35,11 +35,11 @@ The operator launcher runbook is in `docs/operator-dogfood.md`; it keeps write
 mode explicit through `scripts/jade-dogfood --write --confirm-write` and runs
 the controlled dogfood smoke preflight before a mutating tick.
 
-Live dogfood workflow definitions live in `examples/github-project-workflow.md`
-and `examples/github-project-gemini-review-workflow.md`. Temp Markdown files can
-still be useful for drafts, but reusable workflow config and operator prompts
-should be promoted into `examples/` or `docs/` before they become the canonical
-run path.
+The live dogfood workflow definition lives in `workflows/jade-symphony.md`.
+Temp Markdown files can still be useful for drafts, but reusable workflow config
+and operator prompts should be promoted into `workflows/`, `examples/`, or
+`docs/` before they become the canonical run path. Normal operator workflow
+config belongs in `workflows/`; `examples/` is fixture/reference material.
 
 The controlled live smoke runbook is in `docs/dogfood-smoke.md`. It keeps the
 first dogfood acceptance path supervised and bounded to one controlled issue;
@@ -443,13 +443,12 @@ These commands should remain credential-free and deterministic. They are the
 local smoke tests for dispatch planning and bounded loop behavior until live
 GitHub Project v2 execution is hardened.
 
-## Live Project Template
+## Live Project Workflow
 
-`examples/github-project-workflow.md` is a non-fixture workflow template for
-manual live Project v2 reads and explicit tracker writes through `gh`. It still
-uses the `dry-run` backend by default, but the prompt body is now the real Jade
-dogfood operating prompt rather than a placeholder. `run-loop --write` is
-available only as a bounded runtime skeleton and should not be treated as full
-autonomous agent execution until claim reconciliation, full runtime resume
-reconciliation, configured verification commands, and worker supervision are
-hardened.
+`workflows/jade-symphony.md` is the canonical non-fixture workflow for manual
+live Project v2 reads and explicit tracker writes through `gh`. It still uses
+the `dry-run` backend by default, but the prompt body is the real Jade dogfood
+operating prompt rather than a placeholder. `run-loop --write` is available only
+as a bounded runtime skeleton and should not be treated as full autonomous agent
+execution until claim reconciliation, full runtime resume reconciliation,
+configured verification commands, and worker supervision are hardened.

--- a/docs/dogfood-smoke.md
+++ b/docs/dogfood-smoke.md
@@ -32,7 +32,7 @@ v2 readiness.
 Live Project preflight:
 
 ```bash
-cargo run -- dogfood-smoke examples/github-project-workflow.md --dry-run
+cargo run -- dogfood-smoke workflows/jade-symphony.md --dry-run
 ```
 
 The report includes:
@@ -50,7 +50,7 @@ When the preflight reports one executable controlled candidate, no blocking
 integration gaps, and a non-fixture tracker mode, run one bounded live tick:
 
 ```bash
-cargo run -- run-loop examples/github-project-workflow.md --max-iterations 1 --write
+cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
 Expected result:

--- a/docs/live-github-smoke-tests.md
+++ b/docs/live-github-smoke-tests.md
@@ -8,7 +8,7 @@ workflow. They are read-only / dry-run only in this slice, and ordinary
 
 - `gh` is installed.
 - `gh auth status` succeeds for the `Alive24/jade-symphony` repository.
-- The workflow at `examples/github-project-workflow.md` points at the intended
+- The workflow at `workflows/jade-symphony.md` points at the intended
   GitHub Project v2 tracker.
 
 No tokens or secrets are printed by the tests.
@@ -21,8 +21,8 @@ JADE_LIVE_GITHUB_SMOKE=1 cargo test --test live_github_smoke
 
 The smoke runs:
 
-- `jade-symphony inspect examples/github-project-workflow.md`
-- `jade-symphony dogfood-smoke examples/github-project-workflow.md --dry-run`
+- `jade-symphony inspect workflows/jade-symphony.md`
+- `jade-symphony dogfood-smoke workflows/jade-symphony.md --dry-run`
 
 ## Expected Behavior
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -28,16 +28,16 @@ The launcher checks:
 - the workflow validates.
 - in write mode, the controlled dogfood smoke preflight passes.
 
-The canonical supervised implementation workflow is
-`examples/github-project-workflow.md`. It defaults durable worktrees, logs, and
-runtime artifacts under `~/.jade-symphony/artifacts`; set
+The canonical supervised operator workflow is `workflows/jade-symphony.md`. It
+defaults durable worktrees, logs, and runtime artifacts under
+`~/.jade-symphony/artifacts`; set
 `JADE_SYMPHONY_ARTIFACT_ROOT` before running commands to move the whole local
 artifact tree.
 
 After preflight, dry-run mode executes:
 
 ```bash
-target/debug/jade-symphony run-loop examples/github-project-workflow.md --max-iterations 1 --dry-run
+target/debug/jade-symphony run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
 ```
 
 ## Supervised Write Tick
@@ -51,7 +51,7 @@ explicit confirmation flag is present. Before that mutating tick, the launcher
 runs:
 
 ```bash
-target/debug/jade-symphony dogfood-smoke examples/github-project-workflow.md --dry-run
+target/debug/jade-symphony dogfood-smoke workflows/jade-symphony.md --dry-run
 ```
 
 If the smoke preflight fails, the launcher exits before claiming tracker work.
@@ -78,7 +78,7 @@ review:
 ```
 
 ```bash
-target/debug/jade-symphony review-loop examples/github-project-gemini-review-workflow.md --max-iterations 1 --write
+target/debug/jade-symphony review-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
 If Gemini cannot start, the review workpad should name the configured command,
@@ -86,17 +86,17 @@ whether worker `PATH` could resolve it, the required operator action, and the
 retry command. Do not move an issue to `Human Review` unless the Review Agent
 actually records passing review evidence.
 
-Use `examples/github-project-gemini-review-workflow.md` for supervised review
-workers. Do not keep the active review workflow only under `/tmp` or
-`/private/tmp`; the CLI prints `workflow_warning=temporary_path` for those
-workflow files so operators can promote reusable config into the repo.
+Use `workflows/jade-symphony.md` for supervised review workers. Do not keep the
+active review workflow only under `/tmp` or `/private/tmp`; the CLI prints
+`workflow_warning=temporary_path` for those workflow files so operators can
+promote reusable config into the repo.
 
 ## Inspect And Resume
 
 ```bash
-target/debug/jade-symphony inspect examples/github-project-workflow.md
-target/debug/jade-symphony project-state examples/github-project-workflow.md
-target/debug/jade-symphony run-loop examples/github-project-workflow.md --max-iterations 1 --write
+target/debug/jade-symphony inspect workflows/jade-symphony.md
+target/debug/jade-symphony project-state workflows/jade-symphony.md
+target/debug/jade-symphony run-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
 Use `project-state` before claiming work when multiple operators are active. A
@@ -115,12 +115,12 @@ one environment variable before launching dogfood commands:
 export JADE_SYMPHONY_ARTIFACT_ROOT="$HOME/.jade-symphony/artifacts"
 ```
 
-The live implementation and Gemini review workflows derive their worktree and
-log paths from that root. Existing temp Markdown files should be classified
-before cleanup: workflow config belongs in `examples/`, reusable operator
-prompts belong in `docs/`, issue and PR drafts belong in tracker/workpad or log
-artifacts, and disposable scratch can be removed only through a separate
-cleanup decision.
+The live operator workflow derives implementation and review worktree/log paths
+from that root. Existing temp Markdown files should be classified before
+cleanup: normal operator workflow config belongs in `workflows/`, fixtures and
+reference examples belong in `examples/`, reusable operator prompts belong in
+`docs/`, issue and PR drafts belong in tracker/workpad or log artifacts, and
+disposable scratch can be removed only through a separate cleanup decision.
 
 For supervised parallel operators, pass `--pool N` to preview eligible slots and
 apply lane-specific claim checks. Main work uses the `Main Agent` Project field
@@ -129,8 +129,8 @@ loop tick. Merge work uses the `Merging Agent` Project field and can process
 multiple guarded merge slots in one bounded loop.
 
 ```bash
-target/debug/jade-symphony run-loop examples/github-project-workflow.md --max-iterations 1 --pool 2 --dry-run
-target/debug/jade-symphony merge-loop examples/github-project-workflow.md --max-iterations 1 --pool 2 --dry-run
+target/debug/jade-symphony run-loop workflows/jade-symphony.md --max-iterations 1 --pool 2 --dry-run
+target/debug/jade-symphony merge-loop workflows/jade-symphony.md --max-iterations 1 --pool 2 --dry-run
 ```
 
 ## Cleanup Planning
@@ -138,7 +138,7 @@ target/debug/jade-symphony merge-loop examples/github-project-workflow.md --max-
 Cleanup planning is read-only:
 
 ```bash
-target/debug/jade-symphony cleanup-plan examples/github-project-workflow.md
+target/debug/jade-symphony cleanup-plan workflows/jade-symphony.md
 ```
 
 It reports terminal worktrees that appear removable only when tracker state is

--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -30,26 +30,25 @@ cargo clippy --all-targets --all-features -- -D warnings
 Stop before live dogfood if the worktree is dirty, GitHub auth is unavailable,
 or verification is failing for an unexplained reason.
 
-The repo-owned live workflows are:
+The repo-owned live workflow is:
 
-- `examples/github-project-workflow.md` for implementation, merge, smoke,
-  inspect, and project-state commands.
-- `examples/github-project-gemini-review-workflow.md` for supervised Gemini
-  Review Agent commands.
+- `workflows/jade-symphony.md` for implementation, review, merge, smoke,
+  inspect, project-state, and Issue Forge commands.
 
-Both workflows default durable artifacts to `~/.jade-symphony/artifacts` when
+It defaults durable artifacts to `~/.jade-symphony/artifacts` when
 `JADE_SYMPHONY_ARTIFACT_ROOT` is unset. Set that variable to migrate worktrees,
 logs, runtime state, review prompts, and review ledgers to another local root.
 If a command points at `/tmp/*.md` or `/private/tmp/*.md`, promote the reusable
-workflow or prompt into `examples/` or `docs/` before treating it as canonical.
+workflow or prompt into `workflows/`, `examples/`, or `docs/` before treating it
+as canonical. Normal dogfood workflow config belongs in `workflows/`.
 
 ## Inspect The Project
 
 Use the live workflow as the source of tracker state:
 
 ```bash
-cargo run -- inspect examples/github-project-workflow.md
-cargo run -- doctor examples/github-project-workflow.md
+cargo run -- inspect workflows/jade-symphony.md
+cargo run -- doctor workflows/jade-symphony.md
 ```
 
 Review the output before mutating anything. In particular, check for:
@@ -66,7 +65,7 @@ Review the output before mutating anything. In particular, check for:
 Before the first write tick, run the controlled smoke preflight:
 
 ```bash
-cargo run -- dogfood-smoke examples/github-project-workflow.md --dry-run
+cargo run -- dogfood-smoke workflows/jade-symphony.md --dry-run
 ```
 
 Proceed only when there is exactly one executable controlled smoke candidate,
@@ -78,13 +77,13 @@ gaps.
 Preview the same bounded implementation tick without tracker mutation:
 
 ```bash
-cargo run -- run-loop examples/github-project-workflow.md --max-iterations 1 --dry-run
+cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
 ```
 
 Use one bounded write tick:
 
 ```bash
-cargo run -- run-loop examples/github-project-workflow.md --max-iterations 1 --write
+cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
 The operator launcher wraps the same workflow with local preflight checks:
@@ -114,7 +113,7 @@ For a bounded Review Agent pass, run:
 
 ```bash
 export JADE_GEMINI_COMMAND="$(command -v gemini)"
-cargo run -- review-loop examples/github-project-gemini-review-workflow.md --max-iterations 1 --write
+cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
 Expected outcomes:
@@ -139,8 +138,8 @@ After a human accepts work and moves the issue to `Merging`, use the guarded
 merge lane:
 
 ```bash
-cargo run -- merge-once examples/github-project-workflow.md --dry-run
-cargo run -- merge-once examples/github-project-workflow.md --write
+cargo run -- merge-once workflows/jade-symphony.md --dry-run
+cargo run -- merge-once workflows/jade-symphony.md --write
 ```
 
 The merge lane should:
@@ -167,17 +166,17 @@ cargo clippy --all-targets --all-features -- -D warnings
 Then refresh the tracker and project invariants:
 
 ```bash
-cargo run -- inspect examples/github-project-workflow.md
-cargo run -- doctor examples/github-project-workflow.md
+cargo run -- inspect workflows/jade-symphony.md
+cargo run -- doctor workflows/jade-symphony.md
 ```
 
 ## Recovery
 
 When something goes wrong:
 
-- use `cargo run -- inspect examples/github-project-workflow.md` to refresh
+- use `cargo run -- inspect workflows/jade-symphony.md` to refresh
   tracker state;
-- use `cargo run -- doctor examples/github-project-workflow.md` to find project
+- use `cargo run -- doctor workflows/jade-symphony.md` to find project
   invariant violations;
 - inspect runtime state under the configured logs root;
 - continue existing issue branches/PRs for rework rather than creating duplicate

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,9 +1,13 @@
 # Jade Symphony Example Workflows
 
-This directory contains local workflows and fixtures for rehearsing Jade
-Symphony behavior. Most examples are fixture-backed and credential-free. The
-live GitHub workflow is explicit about tracker writes and should be used only
-with the documented `--write` commands.
+This directory contains fixture, demo, and compatibility workflows for
+rehearsing Jade Symphony behavior. Most examples are fixture-backed and
+credential-free.
+
+The normal repo dogfood workflow is not in this directory. Use
+`workflows/jade-symphony.md` for live Project #9 operator runs. The live GitHub
+Project examples remain as compatibility/reference material for debugging older
+commands and testing specific lanes.
 
 ## Fixture Dispatch
 
@@ -22,8 +26,8 @@ memory-backed. They do not mutate live GitHub Project v2 state.
 | Workflow | Purpose | Notes |
 | --- | --- | --- |
 | `linear-fixture-workflow.md` | Linear adapter fixture backed by `fixtures/linear-issues.json`. | Credential-free; does not prove live Linear readiness. |
-| `github-project-workflow.md` | Live GitHub Project v2 template for Project #9. | Non-fixture; read/write operations use `gh` or token auth and require explicit `--write` for mutation. |
-| `github-project-gemini-review-workflow.md` | Live GitHub Project v2 Review Agent template for Project #9. | Uses `$JADE_GEMINI_COMMAND` and durable review artifacts under `$JADE_SYMPHONY_ARTIFACT_ROOT`. |
+| `github-project-workflow.md` | Legacy live GitHub Project v2 template for Project #9. | Compatibility/reference workflow; prefer `workflows/jade-symphony.md` for normal operator runs. |
+| `github-project-gemini-review-workflow.md` | Legacy live GitHub Project v2 Review Agent template for Project #9. | Compatibility/reference workflow; `workflows/jade-symphony.md` carries the normal review config. |
 
 ## Agent Backend Fixtures
 
@@ -61,15 +65,15 @@ Issue Forge examples:
 
 ## Live Boundary
 
-Use `github-project-workflow.md` for live Project #9 implementation reads and
-explicit writes. Use `github-project-gemini-review-workflow.md` for supervised
-Review Agent passes. Both live workflows default to
-`~/.jade-symphony/artifacts` when `JADE_SYMPHONY_ARTIFACT_ROOT` is unset, and
-support setting that environment variable to move durable worktrees, logs, and
-review artifacts together.
+Use `../workflows/jade-symphony.md` for normal live Project #9 implementation,
+review, merge, smoke, inspect, and Issue Forge commands. The legacy live
+examples default to `~/.jade-symphony/artifacts` when
+`JADE_SYMPHONY_ARTIFACT_ROOT` is unset, and support setting that environment
+variable to move durable worktrees, logs, and review artifacts together.
 
 Do not treat fixture success as live readiness. Before any live write, inspect
 the Project state, confirm the issue contract, and use the workflow-specific
 commands documented in the root README and dogfood docs. If an operator has a
 workflow file under `/tmp` or `/private/tmp`, promote the reusable config or
-prompt into `examples/` or `docs/` before relying on it for dogfood.
+prompt into `workflows/`, `examples/`, or `docs/` before relying on it for
+dogfood. Normal operator workflow config belongs in `workflows/`.

--- a/scripts/jade-dogfood
+++ b/scripts/jade-dogfood
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-WORKFLOW="examples/github-project-workflow.md"
+WORKFLOW="workflows/jade-symphony.md"
 MAX_ITERATIONS="1"
 MODE="dry-run"
 CONFIRM_WRITE="false"
@@ -16,7 +16,7 @@ Options:
   --dry-run            Preview the dogfood command without tracker mutation.
   --write              Run one bounded live write-mode tick after preflight.
   --confirm-write      Required with --write.
-  --workflow PATH      Workflow markdown path. Default: examples/github-project-workflow.md
+  --workflow PATH      Workflow markdown path. Default: workflows/jade-symphony.md
   --max-iterations N   Bounded run-loop iterations. Default: 1
   --help               Show this help.
 EOF

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -225,8 +225,7 @@ mod tests {
     }
 
     fn github_project_workflow() -> WorkflowDefinition {
-        let path =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/github-project-workflow.md");
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("workflows/jade-symphony.md");
         WorkflowDefinition::load(path).unwrap()
     }
 

--- a/tests/live_github_smoke.rs
+++ b/tests/live_github_smoke.rs
@@ -1,7 +1,7 @@
 use std::process::{Command, Output};
 
 const LIVE_SMOKE_ENV: &str = "JADE_LIVE_GITHUB_SMOKE";
-const WORKFLOW: &str = "examples/github-project-workflow.md";
+const WORKFLOW: &str = "workflows/jade-symphony.md";
 
 fn live_smoke_enabled() -> bool {
     matches!(

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,24 @@
+# Jade Symphony Workflows
+
+`workflows/jade-symphony.md` is the canonical normal operator workflow for Jade
+Symphony self-dogfood.
+
+Use it for live Project #9 operations:
+
+```bash
+jade-symphony loop workflows/jade-symphony.md --write
+jade-symphony forge workflows/jade-symphony.md --interactive
+```
+
+The current CLI command names are still the explicit debug/runtime names:
+
+```bash
+cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write
+cargo run -- forge-interactive --workflow workflows/jade-symphony.md
+cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --write
+cargo run -- merge-once workflows/jade-symphony.md --write
+```
+
+`examples/` is for fixture workflows, demos, and compatibility references. Do
+not add a second normal dogfood workflow for a specific lane; lane selection
+belongs in the command controller and this workflow config.

--- a/workflows/jade-symphony.md
+++ b/workflows/jade-symphony.md
@@ -1,0 +1,189 @@
+---
+tracker:
+  kind: github_project_v2
+  owner: Alive24
+  repo: jade-symphony
+  project_owner: Alive24
+  project_number: 9
+  status_field: Status
+  state_map:
+    backlog: Backlog
+    todo: Todo
+    need_to_clarify: Need to Clarify
+    in_progress: In Progress
+    need_human_input: Need Human Input
+    agent_review: Agent Review
+    human_review: Human Review
+    rework: Rework
+    merging: Merging
+    done: Done
+  active_states:
+    - Todo
+    - Rework
+  terminal_states:
+    - Done
+    - Closed
+    - Cancelled
+    - Canceled
+    - Duplicate
+  assignee_filter:
+    source: issue_assignees
+    allow_unassigned: false
+    assignees: []
+  workpad:
+    source: issue_comment
+    marker: "<!-- jade-symphony-workpad -->"
+polling:
+  interval_ms: 5000
+artifacts:
+  root: $JADE_SYMPHONY_ARTIFACT_ROOT
+  namespace: Alive24/jade-symphony
+workspace:
+  root: $JADE_SYMPHONY_ARTIFACT_ROOT/Alive24/jade-symphony/default/worktrees
+agent:
+  backend: dry-run
+  max_concurrent_agents: 1
+  max_turns: 3
+  max_retry_backoff_ms: 300000
+codex:
+  command: codex app-server
+claude:
+  command: claude
+review:
+  backend: gemini-cli
+  gemini_command: $JADE_GEMINI_COMMAND
+  timeout_ms: 600000
+  max_concurrent_workers: 2
+verification:
+  timeout_ms: 600000
+  commands: []
+observability:
+  logs_root: $JADE_SYMPHONY_ARTIFACT_ROOT/Alive24/jade-symphony/default/logs
+---
+
+You are working on Jade Symphony issue {{ issue.identifier }}.
+
+Title: {{ issue.title }}
+State: {{ issue.state }}
+{% if issue.url %}
+URL: {{ issue.url }}
+{% endif %}
+
+{% if attempt %}
+This is attempt {{ attempt }}. Resume from the existing issue workspace and
+preserve prior evidence unless it is stale or incorrect.
+{% endif %}
+
+## Mission
+
+You are the main implementation agent for Jade Symphony. Use GitHub Project v2
+project #9 as the tracker state machine and implement the current issue exactly
+as contracted. Jade Symphony is orchestration infrastructure, not downstream
+product business logic.
+
+This is the canonical operator workflow for Jade Symphony self-dogfood. Use this
+single workflow for implementation ticks, review ticks, merge ticks, smoke
+checks, inspect/project-state commands, and Issue Forge operations. Lane-specific
+behavior belongs in the command controller and workflow config, not in separate
+normal operator workflow files.
+
+Read these canonical sources before changing code:
+
+- `docs/bootstrap/JADE_WORKFLOW.md`
+- `docs/bootstrap/JADE_SYMPHONY_SPEC.md`
+- `docs/bootstrap/TRACKER_GITHUB_PROJECT_V2.md`
+- `docs/bootstrap/ISSUE_QUALITY_GATE_TEMPLATE.md`
+- the current issue body and its Jade Symphony workpad
+
+Also consult the official reference tree when a protocol capability is in
+question, but do not edit files under
+`docs/bootstrap/references/openai-symphony`.
+
+## Current Issue Contract
+
+{{ issue.description }}
+
+## Operating Loop
+
+1. Refresh tracker state, linked PR state, local git state, and any existing
+   issue workpad before implementation.
+2. Confirm the issue is still executable with the Issue Quality Gate. If the
+   issue is not executable, leave a precise workpad note, move it to
+   `Need to Clarify`, and stop this issue. The gate must include explicit
+   dependency semantics: either no blocking dependencies, or named
+   blockers/overlaps with the condition that makes the issue claimable.
+3. Work in exactly one isolated workspace and branch for this issue. Do not mix
+   unrelated issue scopes in this branch or PR.
+4. Capture a short implementation plan in the workpad before significant edits.
+5. Implement only the accepted issue scope. Keep tracker, backend,
+   observability, Issue Forge, quality gate, and review boundaries normalized
+   and traceable to the bootstrap docs.
+6. Run the verification required by the issue. Repair failures that are within
+   scope, then rerun the relevant checks.
+7. Update the workpad with context, decisions or assumptions, changed surfaces,
+   verification evidence, and handoff notes.
+8. Open or update exactly one PR for this issue with concise validation
+   evidence.
+9. Move locally complete main-agent work to `Agent Review` only.
+10. Return to tracker selection only after this issue has a PR/workpad handoff
+    or a documented blocked state.
+
+## State And Role Boundaries
+
+- `Todo` and `Rework` are claimable only after the quality gate passes and all
+  tracker-level blockers are terminal.
+- `In Progress` means the main implementation agent is actively working or
+  safely resuming the issue.
+- `Need to Clarify` is for an issue contract that cannot be executed.
+- `Need Human Input` is for missing decisions, credentials, destructive
+  approval, unavailable external services with no safe fallback, or locally
+  undiagnosable verification failure.
+- `Agent Review` is the main-agent completion target.
+- The main implementation agent must never set `Human Review`.
+- Do not set `Human Review`.
+- The independent Review Agent may set `Human Review` only after async review
+  passes and evidence is recorded.
+- Confirmed review findings go to `Rework`.
+- Failed, timed out, inconclusive, or unavailable review must not set
+  `Human Review`.
+- `Merging` is a separate land flow for PRs already approved by the review and
+  human gates. Do not merge from the implementation role.
+
+## Workpad Discipline
+
+Use the configured workpad marker and keep durable evidence in the issue
+workpad. Record:
+
+- environment and workspace path.
+- issue status and linked PR status at start.
+- quality gate result and assumptions.
+- plan and changed files.
+- verification commands and results.
+- PR URL and handoff summary.
+- any blocker and the exact next human or agent action needed.
+
+## Git And PR Discipline
+
+- Base the issue branch on the current `origin/main` unless the issue says
+  otherwise.
+- Use a branch name that includes the issue number.
+- Keep one issue per branch and one branch per PR.
+- Do not rewrite or revert unrelated user changes.
+- If the branch or worktree appears to belong to another issue, stop and move
+  to `Need Human Input` with evidence.
+- PR handoff must explain scope, validation, and the state boundary that main
+  work stops at `Agent Review`.
+
+## Stop Conditions
+
+Stop this issue and record evidence when:
+
+- no executable Todo, Rework, or resumable In Progress work remains.
+- the issue belongs in `Need to Clarify`.
+- the issue needs a human decision, credential, secret, destructive approval,
+  or external service with no safe fallback.
+- verification fails and cannot be locally diagnosed or repaired within scope.
+- continuing would require unrelated work, downstream product logic, or changing
+  files explicitly outside the issue contract.
+- the environment blocks required tracker/PR mutation and continuing would hide
+  the real state of the Project.


### PR DESCRIPTION
Closes #191.

Summary:
- Add workflows/jade-symphony.md as the single canonical normal operator workflow for implementation, review, merge, smoke, inspect, and Issue Forge operations.
- Add workflows/README.md documenting the intended one-loop/one-forge operator model and current explicit CLI equivalents.
- Move scripts/jade-dogfood and live smoke tests to the canonical workflow path.
- Update README, dogfood docs, CLI reference, and examples README so examples are fixture/reference material and legacy live workflows are compatibility references.

Verification:
- cargo fmt --check
- git diff --check
- cargo run -- validate workflows/jade-symphony.md
- cargo run -- validate examples/github-project-workflow.md
- cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

UAT:
- Operator-facing docs now answer the normal workflow file as exactly workflows/jade-symphony.md.
- examples/README.md identifies examples as fixture/reference material.

Note:
- The pre-existing source-alignment gate reported missing path workflows/ before this issue started; that path is the deliverable created here.