### PR TITLE
Make Issue Forge conversational and quality-gate driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,9 +312,19 @@ cargo run -- review-loop examples/review-fixture-workflow.md --max-iterations 1 
 cargo run -- review-freshness --issue '#123' --prior-head old --current-head new --prior-base old-base --current-base new-base --changed-file docs/dogfood-readiness.md --stale-reason merge-conflict --rework-class mechanical-conflict-resolution --patch-summary "Resolved merge conflict without semantic changes."
 ```
 
-`forge-interactive` is dry-run by default. If it is used to create a tracker
-issue, it requires both `--write` and `--confirm-create`; `--workflow` is also
-required for that write path, and `--add-to-project` remains explicit.
+`forge-interactive` is dry-run by default and can start as a conversational
+Issue Forge Agent with only the canonical workflow path:
+
+```bash
+cargo run -- forge-interactive --workflow workflows/jade-symphony.md
+```
+
+It reads natural-language intent from stdin when `--intent` or `--file` is not
+provided, infers a draft title, prints focused clarification questions for thin
+intent, and shows the final quality-gated issue draft before any tracker
+mutation. If it is used to create a tracker issue, it requires `--write`,
+`--confirm-create`, and `--assignee`; `--workflow` is also required for that
+write path, and `--add-to-project` remains explicit.
 
 `add-to-project` initializes the configured ProjectV2 `Status` field to the
 workflow's mapped `Todo` option so newly added issues are visible to the

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -88,7 +88,7 @@ cargo run -- gate-apply workflows/jade-symphony.md '#123' --write
 | `forge-draft` | Build a quality-template issue draft from title/goal. | Read-only. |
 | `forge-validate` | Validate an issue body against the quality gate. | Read-only. |
 | `forge-repair` | Repair thin Markdown into an executable issue shape. | Read-only. |
-| `forge-interactive` | CLI-first guided issue shaping. | Creation requires `--write --confirm-create`. |
+| `forge-interactive` | Conversation-first issue shaping from natural-language intent. | Starts with only `--workflow`; creation requires `--write --confirm-create --assignee`. |
 | `forge-reflect` | Reflect over local context and print candidate issues. | Read-only. |
 | `forge-create` | Create a quality-gated tracker issue. | Requires explicit `--write`; live GitHub creation requires `--assignee`; can add to Project with `--add-to-project`. |
 
@@ -96,6 +96,8 @@ Examples:
 
 ```bash
 cargo run -- forge-validate --title "Thin Forge issue" --file examples/fixtures/thin-issue.md
+cargo run -- forge-interactive --workflow workflows/jade-symphony.md
+cargo run -- forge-interactive --workflow workflows/jade-symphony.md --intent "make run-loop explain retry backoff better"
 cargo run -- forge-reflect --context-file docs/dogfood-readiness.md --limit 1
 cargo run -- forge-create --workflow workflows/jade-symphony.md --title "Follow-up title" --file /tmp/issue.md --assignee Alive24 --add-to-project --write
 ```

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -235,9 +235,11 @@ Project v2 issues:
    - `forge-create` can create a tracker issue and optionally add it to the
      configured project through the normalized adapter with initial `Todo`
      status in GitHub ProjectV2 mode.
-   - `forge-interactive` can select a lightweight issue skill/template, ask a
-     focused clarification question for thin intent, and print a quality-gated
-     issue draft before any live tracker write.
+   - `forge-interactive` can start from only the canonical workflow path, read
+     natural-language intent from stdin or `--intent`, infer a title, select a
+     lightweight issue skill/template, ask a focused clarification question for
+     thin intent, and print a quality-gated issue draft before any live tracker
+     write.
    - `forge-reflect` can scan local context for conservative follow-up signals
      and print quality-gated draft candidates without creating live issues.
    - `forge-create --add-to-project` can set GitHub Project v2 single-select

--- a/src/issue_forge.rs
+++ b/src/issue_forge.rs
@@ -66,6 +66,8 @@ pub struct InteractiveForgeInput {
     pub intent: String,
     pub skill: Option<String>,
     pub context: Option<String>,
+    #[serde(default)]
+    pub assignees: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -255,6 +257,10 @@ pub fn select_issue_skill(intent: &str, explicit: Option<&str>) -> IssueForgeSki
     find_issue_skill(selected).expect("built-in issue forge skill exists")
 }
 
+pub fn conversational_title_from_intent(intent: &str) -> String {
+    title_from_intent(intent)
+}
+
 pub fn interactive_forge(input: InteractiveForgeInput) -> InteractiveForgeReport {
     let selected_skill = select_issue_skill(&input.intent, input.skill.as_deref());
     let issue_markdown = issue_markdown_from_interactive_input(&input, &selected_skill);
@@ -289,6 +295,7 @@ pub fn reflective_candidates_from_context(
                 intent,
                 skill: Some(skill.key.clone()),
                 context: Some(line.to_string()),
+                assignees: Vec::new(),
             };
             let report = interactive_forge(input);
             ReflectiveForgeCandidate {
@@ -460,6 +467,13 @@ fn issue_markdown_from_interactive_input(
 ) -> String {
     let mut draft = draft_from_template(&input.title, input.intent.trim());
     draft = draft.replace(
+        "- UAT Required: No",
+        &format!(
+            "- UAT Required: No\n- Assignee: {}",
+            format_interactive_assignee(input)
+        ),
+    );
+    draft = draft.replace(
         "## Why Now\n\nTBD",
         "## Why Now\n\nThis follow-up is needed to continue turning Jade Symphony from a dry-run skeleton into a usable orchestration binary.",
     );
@@ -558,6 +572,15 @@ fn issue_markdown_from_interactive_input(
         "### Context Verification\n\n- Confirm the issue still matches canonical sources and Project #9 state before dispatch.",
     );
     draft
+}
+
+fn format_interactive_assignee(input: &InteractiveForgeInput) -> String {
+    input
+        .assignees
+        .first()
+        .map(|assignee| assignee.trim().trim_start_matches('@').to_string())
+        .filter(|assignee| !assignee.is_empty())
+        .unwrap_or_else(|| "Alive24".into())
 }
 
 fn format_interactive_context(input: &InteractiveForgeInput, skill: &IssueForgeSkill) -> String {
@@ -896,14 +919,28 @@ mod tests {
             intent: "run-loop should inspect runtime state before claiming new work".into(),
             skill: Some("runtime".into()),
             context: None,
+            assignees: vec!["Alive24".into()],
         });
 
         assert_eq!(report.selected_skill.key, "runtime");
         assert!(report.validation.decision.is_dispatchable());
         assert!(report.issue_markdown.contains("## Issue Goal"));
+        assert!(report.issue_markdown.contains("- Assignee: Alive24"));
         assert!(report.issue_markdown.contains("## Dependencies"));
         assert!(report.issue_markdown.contains("src/runtime_state.rs"));
         assert!(report.question.is_none());
+    }
+
+    #[test]
+    fn conversational_title_is_inferred_from_operator_intent() {
+        let title = conversational_title_from_intent(
+            "make forge interactive accept natural language issue intent",
+        );
+
+        assert_eq!(
+            title,
+            "Issue candidate: make forge interactive accept natural language issue intent"
+        );
     }
 
     #[test]
@@ -913,6 +950,7 @@ mod tests {
             intent: "fix tracker".into(),
             skill: Some("tracker".into()),
             context: None,
+            assignees: Vec::new(),
         });
 
         assert!(report.validation.decision.is_dispatchable());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::io::{self, Read};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
@@ -26,9 +27,9 @@ use jade_symphony::handoff::{
     IssueHandoffPlan,
 };
 use jade_symphony::issue_forge::{
-    discover_candidates, draft_from_template, find_issue_skill, interactive_forge,
-    next_clarification_question, reflective_candidates_from_context, repair_markdown,
-    validate_markdown, InteractiveForgeInput,
+    conversational_title_from_intent, discover_candidates, draft_from_template, find_issue_skill,
+    interactive_forge, next_clarification_question, reflective_candidates_from_context,
+    repair_markdown, validate_markdown, InteractiveForgeInput,
 };
 use jade_symphony::merge_lane::{
     expected_merge_base_branch, fetch_pull_request_status_with_recheck, merge_lane_decision,
@@ -699,43 +700,89 @@ fn normalized_issue_title_key(title: &str) -> String {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ForgeInteractiveOptions {
     workflow_path: Option<PathBuf>,
-    title: String,
-    intent: String,
+    title: Option<String>,
+    intent: Option<String>,
+    file: Option<PathBuf>,
     skill: Option<String>,
     context: Option<String>,
+    assignees: Vec<String>,
     add_to_project: bool,
     write: bool,
     confirm_create: bool,
 }
 
 fn forge_interactive(options: ForgeInteractiveOptions) -> Result<(), Box<dyn std::error::Error>> {
+    let intent = resolve_interactive_intent(options.intent, options.file)?;
+    let title = options
+        .title
+        .unwrap_or_else(|| conversational_title_from_intent(&intent));
     let report = interactive_forge(InteractiveForgeInput {
-        title: options.title.clone(),
-        intent: options.intent,
+        title: title.clone(),
+        intent,
         skill: options.skill,
         context: options.context,
+        assignees: options.assignees.clone(),
     });
+    println!("forge_interactive_session=conversation");
+    println!("transcript_summary=operator_intent_captured");
     print_interactive_forge_report(&report);
 
     if options.write {
         if !options.confirm_create {
             return Err("forge-interactive --write requires --confirm-create".into());
         }
+        if !report.validation.decision.is_dispatchable() {
+            return Err(
+                "forge-interactive refuses to create because the Issue Quality Gate failed".into(),
+            );
+        }
+        if report.question.is_some() {
+            return Err(
+                "forge-interactive refuses to create while clarification questions remain".into(),
+            );
+        }
+        if options.assignees.is_empty() {
+            return Err("forge-interactive --write requires --assignee".into());
+        }
         let workflow_path = options
             .workflow_path
             .ok_or("forge-interactive --write requires --workflow")?;
         forge_create(
             workflow_path,
-            options.title,
+            title,
             report.issue_markdown,
             options.add_to_project,
             Vec::new(),
-            Vec::new(),
+            options.assignees,
             true,
         )?;
     }
 
     Ok(())
+}
+
+fn resolve_interactive_intent(
+    inline: Option<String>,
+    file: Option<PathBuf>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match (inline, file) {
+        (Some(value), None) if !value.trim().is_empty() => Ok(value),
+        (None, Some(path)) => Ok(std::fs::read_to_string(&path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?),
+        (None, None) => {
+            eprintln!("Describe the work you want Issue Forge to shape, then press Ctrl-D:");
+            let mut input = String::new();
+            io::stdin().read_to_string(&mut input)?;
+            if input.trim().is_empty() {
+                return Err(
+                    "forge-interactive requires operator intent from stdin, --intent, or --file"
+                        .into(),
+                );
+            }
+            Ok(input)
+        }
+        _ => Err(usage().into()),
+    }
 }
 
 fn forge_reflect(
@@ -4779,7 +4826,7 @@ struct ForgeInteractiveArgs {
     #[arg(long)]
     workflow: Option<PathBuf>,
     #[arg(long)]
-    title: String,
+    title: Option<String>,
     #[arg(long)]
     intent: Option<String>,
     #[arg(long)]
@@ -4788,6 +4835,8 @@ struct ForgeInteractiveArgs {
     skill: Option<String>,
     #[arg(long = "context-file")]
     context_file: Option<PathBuf>,
+    #[arg(long = "assignee")]
+    assignees: Vec<String>,
     #[arg(long = "add-to-project")]
     add_to_project: bool,
     #[arg(long)]
@@ -5020,9 +5069,11 @@ impl TryFrom<Cli> for Command {
                         options: ForgeInteractiveOptions {
                             workflow_path: args.workflow,
                             title: args.title,
-                            intent: read_source_arg(args.intent, args.file)?,
+                            intent: args.intent,
+                            file: args.file,
                             skill: validate_optional_forge_skill(args.skill)?,
                             context: read_optional_file(args.context_file)?,
+                            assignees: args.assignees,
                             add_to_project: args.add_to_project,
                             write: args.write,
                             confirm_create: args.confirm_create,
@@ -7134,6 +7185,8 @@ mod tests {
             "run-loop should inspect runtime state before claiming new work".into(),
             "--skill".into(),
             "runtime".into(),
+            "--assignee".into(),
+            "Alive24".into(),
             "--add-to-project".into(),
             "--write".into(),
             "--confirm-create".into(),
@@ -7148,12 +7201,35 @@ mod tests {
             options.workflow_path,
             Some(PathBuf::from("examples/github-project-workflow.md"))
         );
-        assert_eq!(options.title, "Add resume preflight");
-        assert!(options.intent.contains("runtime state"));
+        assert_eq!(options.title.as_deref(), Some("Add resume preflight"));
+        assert!(options.intent.as_deref().unwrap().contains("runtime state"));
         assert_eq!(options.skill.as_deref(), Some("runtime"));
+        assert_eq!(options.assignees, vec!["Alive24".to_string()]);
         assert!(options.add_to_project);
         assert!(options.write);
         assert!(options.confirm_create);
+    }
+
+    #[test]
+    fn parses_forge_interactive_without_title_for_conversational_path() {
+        let command = Command::parse(vec![
+            "forge-interactive".into(),
+            "--workflow".into(),
+            "workflows/jade-symphony.md".into(),
+        ])
+        .unwrap();
+
+        let Command::ForgeInteractive { options } = command else {
+            panic!("expected forge-interactive command");
+        };
+
+        assert_eq!(
+            options.workflow_path,
+            Some(PathBuf::from("workflows/jade-symphony.md"))
+        );
+        assert!(options.title.is_none());
+        assert!(options.intent.is_none());
+        assert!(options.assignees.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #194

## Summary

- Make `forge-interactive` start without `--title` and accept natural-language intent from stdin, `--intent`, or `--file`.
- Infer a conversational draft title, preserve the existing Issue Quality Gate boundary, and refuse live creation when the gate fails or clarification questions remain.
- Require explicit `--write --confirm-create --assignee` before live issue creation, while keeping lower-level forge commands intact.
- Update README and CLI docs for the new conversation-first workflow.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## UAT

- `printf '%s\n' 'make forge interactive accept natural language issue intent and ask focused clarification questions before creating issues' | cargo run -- forge-interactive --workflow workflows/jade-symphony.md`
- `cargo run -- forge-interactive --workflow workflows/jade-symphony.md --intent 'make forge interactive accept natural language issue intent and ask focused clarification questions before creating issues'`
- `cargo run -- forge-interactive --workflow workflows/jade-symphony.md --intent 'fix tracker' --assignee Alive24 --write --confirm-create` failed before creation because clarification questions remained.
- `cargo run -- forge-interactive --workflow workflows/jade-symphony.md --intent 'make forge interactive accept natural language issue intent and ask focused clarification questions before creating issues' --write --confirm-create` failed before creation because `--assignee` was missing.

No live issue was created by UAT.
