### PR TITLE
Improve doctor repair UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,16 @@ For a compact source-linked view of what is landed, what is waiting in
   `GET /status.json` or `GET /status` for one request, then exits.
 - `doctor` / `audit-project` can read the configured tracker and report
   workflow invariant violations such as Agent Review without PR evidence, Human
-  Review without review pass evidence, dirty Merging PRs, stale-looking In
-  Progress work, and queued issues with attached PRs. `--json` emits the same
-  report as structured data, and `--strict` exits nonzero when blocker
-  violations are present. A guarded `doctor-repair-human-review` command can
-  repair the specific invalid Human Review-without-pass-evidence case by
-  writing workpad evidence and moving the issue back to `Agent Review`.
+  Review without review pass evidence, dirty Merging PRs, partial `Todo` claim
+  states, stale runtime-state records, In Progress issues with PR evidence, and
+  queued issues with attached PRs. `doctor` defaults to
+  `JADE_SYMPHONY_WORKFLOW`, then `workflows/jade-symphony.md`, then
+  `WORKFLOW.md`; `--json` emits the same report as structured data, and
+  `--strict` exits nonzero when blocker violations are present. `doctor
+  --interactive` prints issue-specific repair entrypoints, `doctor repair 194`
+  starts a non-destructive repair plan, and `doctor --auto-fix --write` only
+  applies clearly safe repairs. A guarded `doctor-repair-human-review` command
+  remains for compatibility.
 - JSONL event-log primitives exist and can record selected profile identity.
 - runtime state helpers can write, read, and clear a tracker-neutral
   `runtime/runtime-state.json` file under the configured logs root, including
@@ -236,6 +240,9 @@ cargo run -- inspect examples/dry-run-workflow.md
 cargo run -- cleanup-plan workflows/jade-symphony.md
 cargo run -- inspect workflows/jade-symphony.md --state Merging --state Rework
 cargo run -- doctor examples/dry-run-workflow.md
+cargo run -- doctor --interactive
+cargo run -- doctor repair 194
+cargo run -- doctor --auto-fix --dry-run
 cargo run -- doctor-repair-human-review examples/dry-run-workflow.md --dry-run
 cargo run -- doctor examples/dry-run-workflow.md --json
 cargo run -- doctor examples/dry-run-workflow.md --strict

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -5,7 +5,9 @@ It is organized by operator task and safety boundary rather than by parser
 order.
 
 All live tracker mutations require explicit `--write`. Fixture-backed workflows
-remain the preferred rehearsal path for local development.
+remain the preferred rehearsal path for local development. `doctor` can omit the
+workflow path when `JADE_SYMPHONY_WORKFLOW` is set, or when
+`workflows/jade-symphony.md` exists in the current repo checkout.
 
 The canonical `workflows/jade-symphony.md` file is a workflow index/config. It
 references lane-specific prompts in `workflows/prompts/` so Main, Review, and
@@ -24,9 +26,25 @@ workflows may still use an inline prompt body.
 | `validate-workflow` | Compatibility alias for `validate`. | `cargo run -- validate-workflow examples/dry-run-workflow.md` |
 | `inspect` | Read tracker issues and print gate/status information. | `cargo run -- inspect workflows/jade-symphony.md` |
 | `project-state` | Diagnose whether the canonical Project read path is trustworthy. | `cargo run -- project-state workflows/jade-symphony.md` |
-| `doctor` | Audit Project/workflow invariants. | `cargo run -- doctor workflows/jade-symphony.md` |
+| `doctor` | Audit Project/workflow/runtime invariants. | `cargo run -- doctor` |
 | `audit-project` | Compatibility alias for `doctor`. | `cargo run -- audit-project workflows/jade-symphony.md` |
 | `profiles` | List configured/discovered execution profiles. | `cargo run -- profiles examples/cockpit-profiles-workflow.md` |
+
+Doctor repair helpers:
+
+```bash
+cargo run -- doctor --interactive
+cargo run -- doctor --auto-fix --dry-run
+cargo run -- doctor --auto-fix --write
+cargo run -- doctor repair 194
+cargo run -- doctor repair 194 --move-need-human-input --write
+```
+
+`doctor repair ISSUE` is non-destructive by default. It prints safe,
+uncertain, and dangerous actions for the issue using tracker state, Project
+fields, runtime-state evidence, branch/PR hints, and doctor findings. The
+`--move-need-human-input --write` path writes workpad evidence before changing
+tracker state.
 
 ## Main Implementation Runtime
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -212,11 +212,16 @@ Project v2 issues:
      endpoint is still needed.
    - Clear integration-gap reporting when credentials are missing or unusable
      while avoiding false missing-token warnings when `gh api graphql` works.
-   - `doctor` / `audit-project` is available as a read-only project invariant
-     audit with human-readable output, JSON output, and explicit strict failure
-     signaling for blocker violations. Explicit-write repair currently covers
-     only invalid `Human Review` issues that lack independent Review Agent pass
-     evidence; broader repair mode remains a follow-up.
+   - `doctor` / `audit-project` is available as a project/workflow/runtime
+     invariant audit with human-readable output, JSON output, explicit strict
+     failure signaling for blocker violations, repo/default workflow discovery,
+     stale runtime-state detection, partial `Todo` claim detection, and
+     `In Progress` PR-evidence detection. `doctor --interactive` and
+     `doctor repair ISSUE` provide non-destructive repair guidance, while
+     explicit-write repair can move uncertain work to `Need Human Input` after
+     writing workpad evidence. `doctor --auto-fix --write` is limited to clearly
+     safe repairs such as invalid `Human Review` issues without independent
+     Review Agent pass evidence.
 
 9. Integration profile.
    - Credential-gated GitHub Project v2 smoke test.

--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -48,7 +48,8 @@ Use the live workflow as the source of tracker state:
 
 ```bash
 cargo run -- inspect workflows/jade-symphony.md
-cargo run -- doctor workflows/jade-symphony.md
+cargo run -- doctor
+cargo run -- doctor --interactive
 ```
 
 Review the output before mutating anything. In particular, check for:
@@ -177,9 +178,12 @@ When something goes wrong:
 
 - use `cargo run -- inspect workflows/jade-symphony.md` to refresh
   tracker state;
-- use `cargo run -- doctor workflows/jade-symphony.md` to find project
+- use `cargo run -- doctor` to find project, claim, and runtime-state
   invariant violations;
-- inspect runtime state under the configured logs root;
+- use `cargo run -- doctor repair ISSUE` to inspect safe, uncertain, and
+  dangerous repair choices before mutating tracker state;
+- inspect runtime state under the configured logs root when the repair output
+  says resume or reset needs operator confirmation;
 - continue existing issue branches/PRs for rework rather than creating duplicate
   branches;
 - keep one issue, one branch, one PR.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::model::{normalize_state, LinkedPullRequest, TrackerIssue};
+use crate::runtime_state::{detect_runtime_stall, RuntimeState};
 
 pub const HUMAN_REVIEW_MISSING_REVIEW_EVIDENCE: &str = "human_review_missing_review_evidence";
 
@@ -42,7 +43,21 @@ impl ProjectAuditReport {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ProjectDoctorContext {
+    pub runtime_state: Option<RuntimeState>,
+    pub now_ms: u64,
+    pub stale_after_ms: u64,
+}
+
 pub fn audit_project_issues(issues: &[TrackerIssue]) -> ProjectAuditReport {
+    audit_project_issues_with_context(issues, None)
+}
+
+pub fn audit_project_issues_with_context(
+    issues: &[TrackerIssue],
+    context: Option<&ProjectDoctorContext>,
+) -> ProjectAuditReport {
     let mut violations = Vec::new();
     for issue in issues {
         let state = issue.normalized_state();
@@ -92,10 +107,7 @@ pub fn audit_project_issues(issues: &[TrackerIssue]) -> ProjectAuditReport {
                     "Move to Rework with review freshness evidence before attempting to land.",
                 ));
             }
-            "in progress"
-                if !issue.project_fields.contains_key("runtime_owner")
-                    && !issue.project_fields.contains_key("runtime_state") =>
-            {
+            "in progress" if !has_runtime_owner_metadata(issue) => {
                 violations.push(violation(
                     issue,
                     AuditSeverity::Warning,
@@ -127,6 +139,30 @@ pub fn audit_project_issues(issues: &[TrackerIssue]) -> ProjectAuditReport {
             }
             _ => {}
         }
+
+        if state == "todo" && claimed_main_agent(issue).is_some() {
+            violations.push(violation(
+                issue,
+                AuditSeverity::Warning,
+                "todo_main_agent_claimed",
+                "Todo issue already has a Main Agent claim marker.",
+                "Treat it as partially claimed or interrupted work; inspect with `doctor repair <issue>` before dispatching another worker.",
+            ));
+        }
+
+        if state == "in progress" && has_pr_url(issue) {
+            violations.push(violation(
+                issue,
+                AuditSeverity::Warning,
+                "in_progress_has_pr_evidence",
+                "In Progress issue already has PR evidence.",
+                "Inspect whether the work should be handed off to Agent Review or moved to Need Human Input with a workpad diagnostic.",
+            ));
+        }
+
+        if let Some(context) = context {
+            audit_runtime_consistency(issue, &state, context, &mut violations);
+        }
     }
 
     ProjectAuditReport {
@@ -134,6 +170,54 @@ pub fn audit_project_issues(issues: &[TrackerIssue]) -> ProjectAuditReport {
         violations,
         integration_gaps: Vec::new(),
     }
+}
+
+pub fn render_doctor_repair_workpad(
+    issue: &TrackerIssue,
+    report: &ProjectAuditReport,
+    action: &str,
+) -> String {
+    let related = related_violations(report, &issue.identifier);
+    let mut lines = vec![
+        "## Jade Symphony Workpad".to_string(),
+        String::new(),
+        "### Project Doctor Repair".to_string(),
+        format!("- Issue: {} {}", issue.identifier, issue.title),
+        format!("- Current state: `{}`", issue.state),
+        format!("- Requested action: `{action}`"),
+    ];
+
+    if let Some(main_agent) = claimed_main_agent(issue) {
+        lines.push(format!("- Main Agent: `{main_agent}`"));
+    }
+    if let Some(branch) = issue.branch_name.as_deref() {
+        lines.push(format!("- Tracker branch: `{branch}`"));
+    }
+    if has_pr_url(issue) {
+        let targets = reliable_pr_targets(issue).join(", ");
+        lines.push(format!("- PR evidence: `{targets}`"));
+    }
+
+    lines.extend([String::new(), "### Doctor Findings".to_string()]);
+    if related.is_empty() {
+        lines.push("- No issue-specific doctor violations were found.".to_string());
+    } else {
+        for violation in related {
+            lines.push(format!(
+                "- `{}` ({:?}): {}",
+                violation.code, violation.severity, violation.message
+            ));
+        }
+    }
+
+    lines.extend([
+        String::new(),
+        "### State Boundary".to_string(),
+        "- Doctor repair records evidence before any tracker mutation.".to_string(),
+        "- This repair does not delete worktrees, discard local work, or bypass review/merge lane authority.".to_string(),
+    ]);
+
+    lines.join("\n")
 }
 
 pub fn render_project_audit_report(report: &ProjectAuditReport) -> String {
@@ -279,6 +363,86 @@ fn has_dirty_or_conflicted_pr(issue: &TrackerIssue) -> bool {
         .unwrap_or(false)
 }
 
+fn audit_runtime_consistency(
+    issue: &TrackerIssue,
+    normalized_issue_state: &str,
+    context: &ProjectDoctorContext,
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    let Some(runtime_state) = context.runtime_state.as_ref() else {
+        return;
+    };
+    let Some(active_issue) = runtime_state.active_issue.as_ref() else {
+        return;
+    };
+
+    let runtime_matches_issue = issue_refs_match(&active_issue.identifier, &issue.identifier);
+
+    if runtime_matches_issue && normalized_issue_state != "in progress" {
+        violations.push(violation(
+            issue,
+            AuditSeverity::Warning,
+            "runtime_state_tracker_mismatch",
+            "Runtime state still points at this issue, but the tracker state is not In Progress.",
+            "Inspect the runtime state and tracker evidence before clearing or resuming the active issue.",
+        ));
+    }
+
+    if runtime_matches_issue && normalized_issue_state == "in progress" {
+        if let Some(stall) =
+            detect_runtime_stall(runtime_state, context.now_ms, context.stale_after_ms)
+        {
+            violations.push(violation(
+                issue,
+                AuditSeverity::Warning,
+                "runtime_state_stale",
+                &format!("Runtime state is stale: {}.", stall.reason),
+                "Use `doctor repair <issue>` to choose resume, no-op, or escalation before another worker claims it.",
+            ));
+        }
+    }
+
+    if !runtime_matches_issue && normalized_issue_state == "in progress" {
+        violations.push(violation(
+            issue,
+            AuditSeverity::Warning,
+            "runtime_active_issue_disagrees",
+            "Issue is In Progress but runtime state points at a different active issue.",
+            "Inspect both issues before dispatching or resetting ownership metadata.",
+        ));
+    }
+
+    if runtime_matches_issue
+        && matches!(normalized_issue_state, "todo" | "need to clarify")
+        && runtime_state.workspace_path.is_some()
+    {
+        violations.push(violation(
+            issue,
+            AuditSeverity::Warning,
+            "runtime_worktree_tracker_mismatch",
+            "Runtime state has a workspace for this queued issue.",
+            "Inspect the worktree and either resume the active work or move the issue to Need Human Input with evidence.",
+        ));
+    }
+
+    if runtime_matches_issue {
+        if let (Some(runtime_branch), Some(tracker_branch)) = (
+            runtime_state.branch_name.as_deref(),
+            issue.branch_name.as_deref(),
+        ) {
+            if runtime_branch != tracker_branch {
+                violations.push(violation(
+                    issue,
+                    AuditSeverity::Warning,
+                    "runtime_branch_mismatch",
+                    "Runtime state branch and tracker branch disagree.",
+                    "Inspect the runtime workspace, tracker branch, and PR evidence before repairing state.",
+                ));
+            }
+        }
+    }
+}
+
 fn bool_project_field(issue: &TrackerIssue, key: &str) -> bool {
     issue
         .project_fields
@@ -293,6 +457,44 @@ fn string_project_field(issue: &TrackerIssue, key: &str) -> Option<String> {
         .get(key)
         .and_then(serde_json::Value::as_str)
         .map(str::to_string)
+}
+
+fn string_project_field_any(issue: &TrackerIssue, keys: &[&str]) -> Option<String> {
+    keys.iter().find_map(|key| string_project_field(issue, key))
+}
+
+fn claimed_main_agent(issue: &TrackerIssue) -> Option<String> {
+    string_project_field_any(issue, &["Main Agent", "main_agent"])
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn has_runtime_owner_metadata(issue: &TrackerIssue) -> bool {
+    issue.project_fields.contains_key("runtime_owner")
+        || issue.project_fields.contains_key("runtime_state")
+        || claimed_main_agent(issue).is_some()
+        || string_project_field_any(issue, &["Merging Agent", "merging_agent"])
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+}
+
+fn issue_refs_match(left: &str, right: &str) -> bool {
+    normalize_issue_ref(left) == normalize_issue_ref(right)
+}
+
+fn normalize_issue_ref(value: &str) -> String {
+    value.trim().trim_start_matches('#').to_string()
+}
+
+fn related_violations<'a>(
+    report: &'a ProjectAuditReport,
+    issue_ref: &str,
+) -> Vec<&'a ProjectAuditViolation> {
+    report
+        .violations
+        .iter()
+        .filter(|violation| issue_refs_match(&violation.issue_ref, issue_ref))
+        .collect()
 }
 
 fn pr_state(pr: &LinkedPullRequest) -> Option<String> {
@@ -333,6 +535,22 @@ mod tests {
             url: Some(url.into()),
             state: Some(state.into()),
             ..Default::default()
+        }
+    }
+
+    fn runtime_context(identifier: &str, updated_at_ms: u64) -> ProjectDoctorContext {
+        let mut runtime_state = RuntimeState::active(
+            crate::runtime_state::RuntimeIssueState {
+                id: format!("ISSUE_{identifier}"),
+                identifier: identifier.into(),
+            },
+            "dry-run",
+        );
+        runtime_state.updated_at_ms = Some(updated_at_ms);
+        ProjectDoctorContext {
+            runtime_state: Some(runtime_state),
+            now_ms: 20_000,
+            stale_after_ms: 10_000,
         }
     }
 
@@ -467,5 +685,73 @@ mod tests {
         assert_eq!(parsed.violations[0].code, "agent_review_missing_pr_handoff");
         assert_eq!(parsed.integration_gaps, vec!["missing scope"]);
         assert!(!rendered.contains("\nintegration_gap="));
+    }
+
+    #[test]
+    fn reports_todo_with_main_agent_claim() {
+        let mut issue = issue("#202", "Todo");
+        issue.project_fields.insert(
+            "Main Agent".into(),
+            serde_json::Value::String("codex-alpha".into()),
+        );
+
+        let report = audit_project_issues(&[issue]);
+
+        assert_eq!(report.violations[0].code, "todo_main_agent_claimed");
+    }
+
+    #[test]
+    fn reports_stale_runtime_state_for_in_progress_issue() {
+        let issue = issue("#202", "In Progress");
+        let context = runtime_context("#202", 1_000);
+
+        let report = audit_project_issues_with_context(&[issue], Some(&context));
+
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.code == "runtime_state_stale"));
+    }
+
+    #[test]
+    fn reports_runtime_state_tracker_mismatch() {
+        let issue = issue("#202", "Agent Review");
+        let context = runtime_context("#202", 19_000);
+
+        let report = audit_project_issues_with_context(&[issue], Some(&context));
+
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.code == "runtime_state_tracker_mismatch"));
+    }
+
+    #[test]
+    fn reports_in_progress_with_pr_evidence() {
+        let mut issue = issue("#202", "In Progress");
+        issue.linked_pull_requests.push(linked_pr(
+            "https://github.com/Alive24/jade-symphony/pull/202",
+            "OPEN",
+        ));
+
+        let report = audit_project_issues(&[issue]);
+
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.code == "in_progress_has_pr_evidence"));
+    }
+
+    #[test]
+    fn reports_unsafe_runtime_active_issue_disagreement() {
+        let issue = issue("#203", "In Progress");
+        let context = runtime_context("#202", 19_000);
+
+        let report = audit_project_issues_with_context(&[issue], Some(&context));
+
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.code == "runtime_active_issue_disagrees"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,9 @@ use jade_symphony::agent::{
 use jade_symphony::artifacts::{artifact_layout, cleanup_plan, ArtifactClass, CleanupPlan};
 use jade_symphony::config::RuntimeConfig;
 use jade_symphony::doctor::{
-    audit_project_issues, human_review_repair_candidates, render_human_review_repair_workpad,
-    render_project_audit_report, render_project_audit_report_json,
+    audit_project_issues, audit_project_issues_with_context, human_review_repair_candidates,
+    render_doctor_repair_workpad, render_human_review_repair_workpad, render_project_audit_report,
+    render_project_audit_report_json, ProjectAuditReport, ProjectDoctorContext,
 };
 use jade_symphony::event_log::{
     EventLog, EventRecord, TrackerMutationAuditInput, TrackerMutationAuditRecord,
@@ -1918,7 +1919,7 @@ fn render_state_summary(issues: &[TrackerIssue]) -> String {
 }
 
 fn doctor(options: DoctorOptions) -> Result<(), Box<dyn std::error::Error>> {
-    let workflow_path = options.workflow_path;
+    let workflow_path = resolve_doctor_workflow_path(options.workflow_path.clone());
     if options.json && options.display == DisplayMode::Tui {
         return Err("doctor --json cannot be combined with --display tui".into());
     }
@@ -1928,15 +1929,43 @@ fn doctor(options: DoctorOptions) -> Result<(), Box<dyn std::error::Error>> {
 
     let adapter = adapter_from_config(&config);
     let issues = adapter.fetch_issues_by_states(&all_mapped_tracker_states(&config))?;
-    let mut report = audit_project_issues(&issues);
-    report.integration_gaps = adapter.integration_gaps();
+    let mut integration_gaps = adapter.integration_gaps();
+    let runtime_state = match load_runtime_state(&config) {
+        Ok(state) => state,
+        Err(error) => {
+            integration_gaps.push(format!("runtime_state_load_error: {error}"));
+            None
+        }
+    };
+    let context = ProjectDoctorContext {
+        runtime_state,
+        now_ms: current_time_ms(),
+        stale_after_ms: options.stale_after_ms,
+    };
+    let mut report = audit_project_issues_with_context(&issues, Some(&context));
+    report.integration_gaps = integration_gaps;
 
-    if options.json {
-        println!("{}", render_project_audit_report_json(&report)?);
-    } else if options.display == DisplayMode::Tui {
-        println!("{}", render_doctor_panel(&report));
-    } else {
-        println!("{}", render_project_audit_report(&report));
+    match &options.action {
+        Some(DoctorAction::Repair(repair)) => {
+            doctor_repair_issue(&config, adapter.as_ref(), &issues, &report, repair)?;
+            return Ok(());
+        }
+        None if options.json => {
+            println!("{}", render_project_audit_report_json(&report)?);
+        }
+        None => {
+            if options.display == DisplayMode::Tui {
+                println!("{}", render_doctor_panel(&report));
+            } else {
+                println!("{}", render_project_audit_report(&report));
+            }
+            if options.interactive {
+                print_doctor_interactive_plan(&report);
+            }
+            if options.auto_fix {
+                apply_doctor_auto_fix(&config, adapter.as_ref(), &report, options.write)?;
+            }
+        }
     }
 
     if options.strict && report.blocker_count() > 0 {
@@ -1948,6 +1977,174 @@ fn doctor(options: DoctorOptions) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+fn resolve_doctor_workflow_path(explicit: Option<PathBuf>) -> PathBuf {
+    if let Some(path) = explicit {
+        return path;
+    }
+    if let Some(path) = std::env::var_os("JADE_SYMPHONY_WORKFLOW")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+    {
+        return path;
+    }
+    let repo_default = PathBuf::from("workflows/jade-symphony.md");
+    if repo_default.exists() {
+        repo_default
+    } else {
+        PathBuf::from("WORKFLOW.md")
+    }
+}
+
+fn print_doctor_interactive_plan(report: &ProjectAuditReport) {
+    println!(
+        "doctor_interactive findings={} blockers={}",
+        report.violations.len(),
+        report.blocker_count()
+    );
+    if report.violations.is_empty() {
+        println!("doctor_interactive action=no_op reason=no_fixable_findings");
+        return;
+    }
+    for violation in &report.violations {
+        println!(
+            "doctor_interactive action=inspect issue={} code={} command=\"doctor repair {}\"",
+            violation.issue_ref,
+            violation.code,
+            violation.issue_ref.trim_start_matches('#')
+        );
+    }
+}
+
+fn apply_doctor_auto_fix(
+    config: &RuntimeConfig,
+    adapter: &dyn TrackerAdapter,
+    report: &ProjectAuditReport,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let candidates = human_review_repair_candidates(report);
+    println!(
+        "doctor_auto_fix safe_candidates={} write={write}",
+        candidates.len()
+    );
+    for violation in candidates {
+        println!(
+            "doctor_auto_fix action=move issue={} from={:?} to=agent_review",
+            violation.issue_ref, violation.state
+        );
+        if write {
+            let workpad = render_human_review_repair_workpad(violation);
+            adapter.upsert_workpad(&violation.issue_ref, &workpad)?;
+            append_tracker_mutation_audit(
+                config,
+                TrackerMutationAudit {
+                    command: "doctor --auto-fix",
+                    mutation_type: "workpad_write",
+                    issue_ref: Some(&violation.issue_ref),
+                    target: None,
+                    from_state: Some(violation.state.clone()),
+                    to_state: Some("agent_review".into()),
+                    reason: "doctor auto-fix evidence",
+                },
+            );
+            adapter.set_state(&violation.issue_ref, "agent_review")?;
+            append_tracker_mutation_audit(
+                config,
+                TrackerMutationAudit {
+                    command: "doctor --auto-fix",
+                    mutation_type: "state_change",
+                    issue_ref: Some(&violation.issue_ref),
+                    target: None,
+                    from_state: Some(violation.state.clone()),
+                    to_state: Some("agent_review".into()),
+                    reason: "safe doctor auto-fix for invalid Human Review boundary",
+                },
+            );
+        } else {
+            println!(
+                "doctor_auto_fix_dry_run action=workpad issue={} evidence=human_review_missing_review_evidence",
+                violation.issue_ref
+            );
+            println!(
+                "doctor_auto_fix_dry_run action=set_state issue={} target_state=agent_review",
+                violation.issue_ref
+            );
+        }
+    }
+    Ok(())
+}
+
+fn doctor_repair_issue(
+    config: &RuntimeConfig,
+    adapter: &dyn TrackerAdapter,
+    issues: &[TrackerIssue],
+    report: &ProjectAuditReport,
+    repair: &DoctorRepairIssueOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let issue = issues
+        .iter()
+        .find(|issue| issue_ref_matches(&issue.identifier, &repair.issue_ref))
+        .ok_or_else(|| format!("doctor repair could not find issue {}", repair.issue_ref))?;
+    println!(
+        "doctor_repair issue={} state={:?} write={} move_need_human_input={}",
+        issue.identifier, issue.state, repair.write, repair.move_need_human_input
+    );
+    println!(
+        "safe=no_op command=\"doctor repair {}\"",
+        issue.identifier.trim_start_matches('#')
+    );
+    println!("uncertain=resume command=\"run-loop <workflow> --write\" reason=requires operator confirmation and live workspace inspection");
+    println!("uncertain=reset reason=requires confirming no useful work would be discarded");
+    println!("uncertain=move_need_human_input command=\"doctor repair {} --move-need-human-input --write\" reason=records evidence before tracker mutation", issue.identifier.trim_start_matches('#'));
+    println!("dangerous=delete_worktree reason=out_of_scope_for_doctor_repair");
+
+    if repair.move_need_human_input {
+        let workpad = render_doctor_repair_workpad(issue, report, "move_need_human_input");
+        if repair.write {
+            adapter.upsert_workpad(&issue.identifier, &workpad)?;
+            append_tracker_mutation_audit(
+                config,
+                TrackerMutationAudit {
+                    command: "doctor repair",
+                    mutation_type: "workpad_write",
+                    issue_ref: Some(&issue.identifier),
+                    target: None,
+                    from_state: Some(issue.state.clone()),
+                    to_state: Some("need_human_input".into()),
+                    reason: "doctor repair evidence before human-input escalation",
+                },
+            );
+            adapter.set_state(&issue.identifier, "need_human_input")?;
+            append_tracker_mutation_audit(
+                config,
+                TrackerMutationAudit {
+                    command: "doctor repair",
+                    mutation_type: "state_change",
+                    issue_ref: Some(&issue.identifier),
+                    target: None,
+                    from_state: Some(issue.state.clone()),
+                    to_state: Some("need_human_input".into()),
+                    reason: "doctor repair escalated uncertain runtime state",
+                },
+            );
+        } else {
+            println!(
+                "doctor_repair_dry_run action=workpad issue={} evidence=doctor_repair",
+                issue.identifier
+            );
+            println!(
+                "doctor_repair_dry_run action=set_state issue={} target_state=need_human_input",
+                issue.identifier
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn issue_ref_matches(left: &str, right: &str) -> bool {
+    left.trim().trim_start_matches('#') == right.trim().trim_start_matches('#')
 }
 
 fn doctor_repair_human_review(
@@ -4422,10 +4619,27 @@ struct ReviewLoopOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DoctorOptions {
-    workflow_path: PathBuf,
+    workflow_path: Option<PathBuf>,
     json: bool,
     strict: bool,
     display: DisplayMode,
+    interactive: bool,
+    auto_fix: bool,
+    write: bool,
+    stale_after_ms: u64,
+    action: Option<DoctorAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DoctorAction {
+    Repair(DoctorRepairIssueOptions),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DoctorRepairIssueOptions {
+    issue_ref: String,
+    write: bool,
+    move_need_human_input: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -4630,18 +4844,42 @@ struct DoctorRepairArgs {
 
 #[derive(Debug, Args)]
 struct DoctorArgs {
-    #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
-    workflow_path: PathBuf,
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: Option<PathBuf>,
     #[arg(long)]
     json: bool,
     #[arg(long)]
     strict: bool,
     #[arg(long, value_enum, default_value_t = CliDisplayMode::Plain)]
     display: CliDisplayMode,
+    #[arg(long)]
+    interactive: bool,
+    #[arg(long = "auto-fix")]
+    auto_fix: bool,
+    #[arg(long = "stale-after-ms", default_value_t = 10_800_000)]
+    stale_after_ms: u64,
     #[arg(long = "dry-run")]
     _dry_run: bool,
     #[arg(long = "write")]
-    _write: bool,
+    write: bool,
+    #[command(subcommand)]
+    action: Option<DoctorSubcommandArgs>,
+}
+
+#[derive(Debug, Subcommand)]
+enum DoctorSubcommandArgs {
+    Repair(DoctorRepairIssueArgs),
+}
+
+#[derive(Debug, Args)]
+struct DoctorRepairIssueArgs {
+    issue_ref: String,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "move-need-human-input")]
+    move_need_human_input: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
 }
 
 #[derive(Debug, Args)]
@@ -5060,6 +5298,19 @@ impl TryFrom<Cli> for Command {
                             json: args.json,
                             strict: args.strict,
                             display: args.display.into(),
+                            interactive: args.interactive,
+                            auto_fix: args.auto_fix,
+                            write: args.write,
+                            stale_after_ms: args.stale_after_ms,
+                            action: args.action.map(|action| match action {
+                                DoctorSubcommandArgs::Repair(repair) => {
+                                    DoctorAction::Repair(DoctorRepairIssueOptions {
+                                        issue_ref: repair.issue_ref,
+                                        write: repair.write,
+                                        move_need_human_input: repair.move_need_human_input,
+                                    })
+                                }
+                            }),
                         },
                     }),
                     CliCommand::DoctorRepairHumanReview(args) => {
@@ -5748,10 +5999,15 @@ mod tests {
             parse(&["audit-project", "examples/dry-run-workflow.md"]),
             Command::Doctor {
                 options: DoctorOptions {
-                    workflow_path: PathBuf::from("examples/dry-run-workflow.md"),
+                    workflow_path: Some(PathBuf::from("examples/dry-run-workflow.md")),
                     json: false,
                     strict: false,
                     display: DisplayMode::Plain,
+                    interactive: false,
+                    auto_fix: false,
+                    write: false,
+                    stale_after_ms: 10_800_000,
+                    action: None,
                 }
             }
         );
@@ -5934,10 +6190,71 @@ mod tests {
             ]),
             Command::Doctor {
                 options: DoctorOptions {
-                    workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                    workflow_path: Some(PathBuf::from("examples/github-project-workflow.md")),
                     json: true,
                     strict: true,
                     display: DisplayMode::Plain,
+                    interactive: false,
+                    auto_fix: false,
+                    write: false,
+                    stale_after_ms: 10_800_000,
+                    action: None,
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn parses_short_doctor_commands() {
+        assert_eq!(
+            parse(&["doctor", "--interactive"]),
+            Command::Doctor {
+                options: DoctorOptions {
+                    workflow_path: None,
+                    json: false,
+                    strict: false,
+                    display: DisplayMode::Plain,
+                    interactive: true,
+                    auto_fix: false,
+                    write: false,
+                    stale_after_ms: 10_800_000,
+                    action: None,
+                }
+            }
+        );
+        assert_eq!(
+            parse(&["doctor", "--auto-fix", "--dry-run"]),
+            Command::Doctor {
+                options: DoctorOptions {
+                    workflow_path: None,
+                    json: false,
+                    strict: false,
+                    display: DisplayMode::Plain,
+                    interactive: false,
+                    auto_fix: true,
+                    write: false,
+                    stale_after_ms: 10_800_000,
+                    action: None,
+                }
+            }
+        );
+        assert_eq!(
+            parse(&["doctor", "repair", "194"]),
+            Command::Doctor {
+                options: DoctorOptions {
+                    workflow_path: None,
+                    json: false,
+                    strict: false,
+                    display: DisplayMode::Plain,
+                    interactive: false,
+                    auto_fix: false,
+                    write: false,
+                    stale_after_ms: 10_800_000,
+                    action: Some(DoctorAction::Repair(DoctorRepairIssueOptions {
+                        issue_ref: "194".into(),
+                        write: false,
+                        move_need_human_input: false,
+                    })),
                 }
             }
         );


### PR DESCRIPTION
## Summary
- add default workflow discovery for doctor via JADE_SYMPHONY_WORKFLOW, workflows/jade-symphony.md, then WORKFLOW.md
- add grouped doctor repair UX: doctor --interactive, doctor --auto-fix, and doctor repair ISSUE
- extend doctor diagnostics for partial Todo claims, stale runtime state, runtime/tracker mismatch, In Progress PR evidence, and runtime branch/worktree disagreement
- document the new operator commands and safety boundaries

Closes #202

## Verification
- cargo fmt --check
- git diff --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- doctor workflows/jade-symphony.md
- cargo run -- doctor --interactive
- cargo run -- doctor repair 194
- cargo run -- doctor examples/dry-run-workflow.md --auto-fix --dry-run

## UAT notes
- live doctor reported runtime/tracker warnings for #198, #202, and #204 without blockers
- live doctor --interactive used the default repo workflow path and printed per-issue repair entrypoints
- live doctor repair 194 printed safe/no-op, uncertain resume/reset/escalation, and dangerous delete-worktree boundaries without mutating tracker state