### PR TITLE
#219: Reject write-mode dry-run backend

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -51,7 +51,7 @@ tracker state.
 | Command | Purpose | Boundary |
 | --- | --- | --- |
 | `run-once` | Execute one selected issue through the configured backend. | Fixture-safe by default when the workflow has `tracker.fixture_path`. |
-| `run-loop` | Poll/select/claim/run/handoff in bounded or idle-loop modes. | Live write mode requires `--write`; `--pool N` filters by `Main Agent`; main-agent completion stops at `Agent Review`. |
+| `run-loop` | Poll/select/claim/run/handoff in bounded or idle-loop modes. | Live write mode requires `--write` and a real main-agent backend; `agent.backend: dry-run` is rejected before tracker/runtime mutation. |
 | `dogfood-smoke` | Supervised preflight for one controlled dogfood issue. | Dry-run inspection by default; live readiness does not bypass review or merge gates. |
 
 Examples:
@@ -76,6 +76,11 @@ processes one main work item at a time because the runtime state tracks one
 active issue, but it uses the same lane claim check and stamps `Main Agent`
 before tracker mutation. `run-loop`, `review-loop`, and `merge-once` print
 compact `Latest:` status bars in addition to their detailed line logs.
+
+The canonical `workflows/jade-symphony.md` file may still be configured with
+`agent.backend: dry-run` for preview-only operator checks. In that state,
+`run-loop --write` exits non-zero before loading runtime state, creating
+worktrees, claiming Project fields, or writing workpads.
 
 ## Tracker Writes
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -438,7 +438,7 @@ GitHub Project v2 execution is hardened.
 `workflows/jade-symphony.md` is the canonical non-fixture workflow for manual
 live Project v2 reads and explicit tracker writes through `gh`. It still uses
 the `dry-run` backend by default, but the prompt body is the real Jade dogfood
-operating prompt rather than a placeholder. `run-loop --write` is available only
-as a bounded runtime skeleton and should not be treated as full autonomous agent
-execution until claim reconciliation, full runtime resume reconciliation,
-configured verification commands, and worker supervision are hardened.
+operating prompt rather than a placeholder. With that default backend,
+`run-loop --write` is rejected before runtime-state writes, worktree creation,
+Project claim fields, or workpad mutation. Configure a real main-agent backend
+before using write-mode execution.

--- a/docs/dogfood-smoke.md
+++ b/docs/dogfood-smoke.md
@@ -69,6 +69,9 @@ In `--write` mode, `dogfood-smoke` exits non-zero when those readiness
 conditions are not met. The command still prints `dogfood_smoke_blocked=true`
 and the blocker before exiting, so scripts can treat it as a gate without
 losing the operator-readable reason.
+If the workflow still uses `agent.backend: dry-run`, `dogfood-smoke --write`
+fails before tracker reads and before it can recommend a mutating `run-loop`
+command.
 
 ## Skip Conditions
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -84,6 +84,10 @@ target/debug/jade-symphony dogfood-smoke workflows/jade-symphony.md --dry-run
 ```
 
 If the smoke preflight fails, the launcher exits before claiming tracker work.
+If `workflows/jade-symphony.md` still has `agent.backend: dry-run`, the
+mutating `run-loop` tick also exits before runtime-state writes, worktree
+creation, Project claims, or workpad mutation. Configure a real main-agent
+backend before using the supervised write tick.
 
 ## Review Backend Setup
 

--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -88,6 +88,11 @@ Use one bounded write tick:
 cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
+That write tick requires a real main-agent backend. When the workflow is still
+configured with `agent.backend: dry-run`, `run-loop --write` fails before
+runtime-state writes, workspace creation, Project claim fields, or workpad
+mutation; keep using the dry-run preview until a real backend is configured.
+
 The operator launcher wraps the same workflow with local preflight checks:
 
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -2318,6 +2318,9 @@ fn dogfood_smoke(workflow_path: PathBuf, write: bool) -> Result<(), Box<dyn std:
     let workflow = WorkflowDefinition::load(&workflow_path)?;
     let config = RuntimeConfig::from_workflow(&workflow, &workflow_path)?;
     config.validate()?;
+    if write {
+        ensure_write_mode_main_agent_backend(&workflow_path, &config, "dogfood-smoke")?;
+    }
 
     let adapter = adapter_from_config(&config);
     let integration_gaps = adapter.integration_gaps();
@@ -3033,6 +3036,9 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         let workflow = WorkflowDefinition::load(&options.workflow_path)?;
         let config = RuntimeConfig::from_workflow(&workflow, &options.workflow_path)?;
         config.validate()?;
+        if options.write {
+            ensure_write_mode_main_agent_backend(&options.workflow_path, &config, "run-loop")?;
+        }
         let adapter = adapter_from_config(&config);
         if options.write {
             let runtime_state = load_runtime_state(&config)?;
@@ -4372,6 +4378,25 @@ fn sanitize_archive_segment(value: &str) -> String {
         })
         .collect::<String>();
     sanitized.trim_matches('-').to_string()
+}
+
+fn ensure_write_mode_main_agent_backend(
+    workflow_path: &Path,
+    config: &RuntimeConfig,
+    command: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if config.backend.kind != "dry-run" {
+        return Ok(());
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!(
+            "write-mode {command} is blocked because workflow={} configures agent.backend=dry-run; configure a real main-agent backend such as codex or claude-code before using --write",
+            workflow_path.display()
+        ),
+    )
+    .into())
 }
 
 fn no_dispatch_action(
@@ -7058,6 +7083,26 @@ mod tests {
     }
 
     #[test]
+    fn dogfood_smoke_write_rejects_dry_run_backend_before_tracker_reads() {
+        let temp = tempfile::tempdir().unwrap();
+        let workflow_path = temp.path().join("WORKFLOW.md");
+        let missing_fixture = temp.path().join("missing-issues.json");
+        std::fs::write(
+            &workflow_path,
+            format!(
+                "---\ntracker:\n  kind: memory\n  fixture_path: {}\nagent:\n  backend: dry-run\n---\nPrompt",
+                missing_fixture.display()
+            ),
+        )
+        .unwrap();
+
+        let error = dogfood_smoke(workflow_path, true).unwrap_err().to_string();
+
+        assert!(error.contains("write-mode dogfood-smoke is blocked"));
+        assert!(error.contains("agent.backend=dry-run"));
+    }
+
+    #[test]
     fn clap_parser_treats_help_flags_as_successful_help() {
         assert!(help_text(&["--help"]).contains("Usage: jade-symphony"));
         assert!(help_text(&["-h"]).contains("Usage: jade-symphony"));
@@ -8672,6 +8717,70 @@ mod tests {
                 reason: "no_dispatchable_issue"
             }
         );
+    }
+
+    #[test]
+    fn run_loop_write_mode_rejects_dry_run_backend_before_runtime_writes() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("workspaces");
+        let logs_root = temp.path().join("logs");
+        let workflow_path = temp.path().join("WORKFLOW.md");
+        std::fs::write(
+            &workflow_path,
+            format!(
+                "---\ntracker:\n  kind: memory\nworkspace:\n  root: {}\nobservability:\n  logs_root: {}\nagent:\n  backend: dry-run\n---\nPrompt",
+                workspace_root.display(),
+                logs_root.display()
+            ),
+        )
+        .unwrap();
+
+        let error = run_loop(RunLoopOptions {
+            workflow_path: workflow_path.clone(),
+            max_iterations: Some(1),
+            once: false,
+            pool: None,
+            write: true,
+            display: DisplayMode::Plain,
+        })
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("write-mode run-loop is blocked"));
+        assert!(error.contains("agent.backend=dry-run"));
+        assert!(error.contains(workflow_path.to_string_lossy().as_ref()));
+        assert!(
+            !workspace_root.exists(),
+            "guard must fire before workspace creation"
+        );
+        assert!(!logs_root.exists(), "guard must fire before runtime writes");
+    }
+
+    #[test]
+    fn run_loop_dry_run_preview_allows_dry_run_backend() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace_root = temp.path().join("workspaces");
+        let logs_root = temp.path().join("logs");
+        let workflow_path = temp.path().join("WORKFLOW.md");
+        std::fs::write(
+            &workflow_path,
+            format!(
+                "---\ntracker:\n  kind: memory\nworkspace:\n  root: {}\nobservability:\n  logs_root: {}\nagent:\n  backend: dry-run\n---\nPrompt",
+                workspace_root.display(),
+                logs_root.display()
+            ),
+        )
+        .unwrap();
+
+        run_loop(RunLoopOptions {
+            workflow_path,
+            max_iterations: Some(1),
+            once: false,
+            pool: None,
+            write: false,
+            display: DisplayMode::Plain,
+        })
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes #219

## Summary
- reject run-loop and dogfood-smoke write mode when agent.backend is dry-run, before adapter/runtime/worktree paths
- keep ordinary dry-run previews working
- document the write-mode backend boundary in operator and dogfood docs

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
- cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write (expected blocked)
- cargo run -- dogfood-smoke workflows/jade-symphony.md --write (expected blocked)