### PR TITLE
#220: Add main tmux backend slice

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -51,7 +51,7 @@ tracker state.
 | Command | Purpose | Boundary |
 | --- | --- | --- |
 | `run-once` | Execute one selected issue through the configured backend. | Fixture-safe by default when the workflow has `tracker.fixture_path`. |
-| `run-loop` | Poll/select/claim/run/handoff in bounded or idle-loop modes. | Live write mode requires `--write` and a real main-agent backend; `agent.backend: dry-run` is rejected before tracker/runtime mutation. |
+| `run-loop` | Poll/select/claim/run/handoff in bounded or idle-loop modes. | Live write mode requires `--write` and a real main-agent backend; tmux sessions stay active instead of auto-handing off. |
 | `dogfood-smoke` | Supervised preflight for one controlled dogfood issue. | Dry-run inspection by default; live readiness does not bypass review or merge gates. |
 
 Examples:
@@ -77,10 +77,14 @@ active issue, but it uses the same lane claim check and stamps `Main Agent`
 before tracker mutation. `run-loop`, `review-loop`, and `merge-once` print
 compact `Latest:` status bars in addition to their detailed line logs.
 
-The canonical `workflows/jade-symphony.md` file may still be configured with
-`agent.backend: dry-run` for preview-only operator checks. In that state,
-`run-loop --write` exits non-zero before loading runtime state, creating
-worktrees, claiming Project fields, or writing workpads.
+The canonical `workflows/jade-symphony.md` file uses the local `tmux` main-agent
+backend. A launched tmux session records its session name, log path, workspace,
+branch, and attach command in runtime/workpad evidence, then keeps the issue in
+the active main lane. It does not move to `Agent Review` until later completion
+evidence satisfies the existing handoff rules. If an operator overrides the
+workflow back to `agent.backend: dry-run`, `run-loop --write` exits non-zero
+before loading runtime state, creating worktrees, claiming Project fields, or
+writing workpads.
 
 ## Tracker Writes
 

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -1,10 +1,10 @@
 # Dogfood Readiness
 
-Status: dry-run dogfood baseline with read-only GitHub Project v2 loading through
-the `gh` CLI and a `run-loop` skeleton that can idle-poll in unbounded write
-mode. The live GitHub Project workflow now carries a real Jade operating prompt,
-but Jade Symphony is not ready for unattended live GitHub Project v2 execution
-yet.
+Status: local tmux main-agent dogfood baseline with read-only GitHub Project v2
+loading through the `gh` CLI and a `run-loop` skeleton that can launch an
+attachable Main Agent session without treating session creation as completion.
+The live GitHub Project workflow now carries a real Jade operating prompt, but
+Jade Symphony is not ready for unattended live GitHub Project v2 execution yet.
 
 ## Current Capability Status
 
@@ -21,7 +21,7 @@ yet.
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, dependency preflight for `Todo` / `Rework`, runtime-state persistence, tracker-visible advisory ownership markers, resume preflight, retry backoff records, stall detection, live PR handoff plus tracker PR link recording in non-fixture GitHub mode, guarded `merge-once` and bounded `merge-loop` lanes for `Merging` issues, first-slice `--pool` selection guarded by `Main Agent` / `Merging Agent` Project fields, a controlled `dogfood-smoke` preflight report with blocking-vs-warning integration gap severity, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, unbounded merge idle polling, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, grouped read-only `clean plan` / `clean audit` cleanup and persistence classification, guarded terminal cleanup planning, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, dirty/no-op guards before branch push, optional configured verification commands before PR handoff, branch push, PR create-or-reuse, tracker PR link recording, run-loop handoff evidence, profile-scoped workspace keys, parsed-but-unused SSH worker host config, a namespaced artifact layout, and dry-run cleanup planning exist. Automatic runtime cleanup, write-mode artifact cleanup, and live SSH execution are not wired yet. |
 | Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
-| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. Prepared runs include selected profile/instance metadata and profile environment context. The Codex subprocess backend safely refuses `codex app-server` commands because that transport is not implemented yet. A first-slice Codex app-server event normalizer maps fixture JSON-RPC stream lines into Jade `AgentEvent` values, including completion, failure, cancellation, input-required, token usage, notification, and malformed events. Full Codex app-server transport and Claude Code protocol parity remain follow-ups. |
+| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. A first-slice local `tmux` backend can launch an attachable Main Agent session, paste the rendered prompt, record the session name, attach command, and log path, and leave the issue active instead of handing off to review. Prepared runs include selected profile/instance metadata and profile environment context. The Codex subprocess backend safely refuses `codex app-server` commands because that transport is not implemented yet. A first-slice Codex app-server event normalizer maps fixture JSON-RPC stream lines into Jade `AgentEvent` values, including completion, failure, cancellation, input-required, token usage, notification, and malformed events. Review/Merging tmux lane support, full Codex app-server transport, and Claude Code protocol parity remain follow-ups. |
 | Prompt rendering | Strict prompt rendering supports `issue.*`, `attempt`, and basic `{% if %}` / `{% else %}` blocks. The supported subset is documented in `docs/prompt-template-contract.md`; full Liquid compatibility remains a parity gap. |
 | Dynamic tools | A first-slice dynamic-tool registry can describe planned backend-specific tools such as Codex `linear_graphql` without coupling them to the orchestrator. Tool execution and Codex app-server dynamic-tool protocol wiring are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings, review-freshness evidence for Merging conflict repair, bounded `review-loop` worker selection/reconciliation with one issue per worker slot, Project `Review Agent` claim markers before backend launch, terminal failure/timeout claim cleanup for retry, durable JSON review job ledger records, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
@@ -436,9 +436,8 @@ GitHub Project v2 execution is hardened.
 ## Live Project Workflow
 
 `workflows/jade-symphony.md` is the canonical non-fixture workflow for manual
-live Project v2 reads and explicit tracker writes through `gh`. It still uses
-the `dry-run` backend by default, but the prompt body is the real Jade dogfood
-operating prompt rather than a placeholder. With that default backend,
-`run-loop --write` is rejected before runtime-state writes, worktree creation,
-Project claim fields, or workpad mutation. Configure a real main-agent backend
-before using write-mode execution.
+live Project v2 reads and explicit tracker writes through `gh`. It uses the
+local `tmux` backend for Main Agent execution, while the prompt body remains the
+real Jade dogfood operating prompt. `run-loop --write` records attachable tmux
+session metadata and keeps the issue active until real implementation evidence
+is available for the existing handoff path.

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -84,10 +84,12 @@ target/debug/jade-symphony dogfood-smoke workflows/jade-symphony.md --dry-run
 ```
 
 If the smoke preflight fails, the launcher exits before claiming tracker work.
-If `workflows/jade-symphony.md` still has `agent.backend: dry-run`, the
-mutating `run-loop` tick also exits before runtime-state writes, worktree
-creation, Project claims, or workpad mutation. Configure a real main-agent
-backend before using the supervised write tick.
+The canonical workflow now uses the local `tmux` main-agent backend. A write
+tick starts an attachable tmux session, records its attach command and log path,
+and leaves the issue active until real implementation/handoff evidence exists.
+If an operator switches the workflow back to `agent.backend: dry-run`, the
+mutating tick exits before runtime-state writes, worktree creation, Project
+claims, or workpad mutation.
 
 ## Review Backend Setup
 

--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -88,10 +88,11 @@ Use one bounded write tick:
 cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
-That write tick requires a real main-agent backend. When the workflow is still
-configured with `agent.backend: dry-run`, `run-loop --write` fails before
-runtime-state writes, workspace creation, Project claim fields, or workpad
-mutation; keep using the dry-run preview until a real backend is configured.
+That write tick requires a real main-agent backend. The canonical workflow uses
+`agent.backend: tmux`, so a successful first slice starts an attachable local
+session, prints the `tmux attach-session` command, records the session log path,
+and keeps the issue active. A running tmux session alone is not completion
+evidence and must not move the issue to `Agent Review`.
 
 The operator launcher wraps the same workflow with local preflight checks:
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -36,8 +36,14 @@ pub struct PreparedRun {
 pub struct AgentSummary {
     pub backend: String,
     pub success: bool,
+    #[serde(default)]
+    pub pending_session: bool,
     pub session_id: Option<String>,
     pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attach_command: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -129,11 +135,14 @@ impl AgentBackend for DryRunBackend {
         AgentSummary {
             backend: self.name().into(),
             success,
+            pending_session: false,
             session_id: events.iter().find_map(|event| match event {
                 AgentEvent::SessionStarted { session_id, .. } => Some(session_id.clone()),
                 _ => None,
             }),
             message: "dry-run complete".into(),
+            log_path: None,
+            attach_command: None,
         }
     }
 }
@@ -254,6 +263,91 @@ impl AgentBackend for ClaudeCodeBackend {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct TmuxBackend;
+
+impl AgentBackend for TmuxBackend {
+    fn name(&self) -> &'static str {
+        "tmux"
+    }
+
+    fn prepare(
+        &self,
+        workspace: PathBuf,
+        rendered_prompt: String,
+        config: &RuntimeConfig,
+    ) -> Result<PreparedRun, AgentError> {
+        let profile = selected_execution_profile(&config.profiles)
+            .map_err(|error| AgentError::Unavailable(error.to_string()))?;
+        let mut env = profile_environment(profile.as_ref(), self.name());
+        env.insert(
+            "JADE_SYMPHONY_TMUX_COMMAND".into(),
+            config.tmux.command.clone(),
+        );
+        env.insert(
+            "JADE_SYMPHONY_TMUX_SESSION_PREFIX".into(),
+            config.tmux.session_prefix.clone(),
+        );
+        Ok(PreparedRun {
+            backend: self.name().into(),
+            workspace,
+            prompt: rendered_prompt,
+            prompt_artifact_path: None,
+            command: Some(config.tmux.agent_command.clone()),
+            timeout_ms: 0,
+            approval_policy: None,
+            sandbox: None,
+            profile_id: profile.as_ref().map(|profile| profile.profile_id.clone()),
+            instance_name: profile
+                .as_ref()
+                .map(|profile| profile.instance_name.clone()),
+            env,
+            actor_role: Some(config.identity.actor_role.clone()),
+            actor_label: Some(config.identity.actor_label.clone()),
+            git_author: config.identity.git.author(),
+        })
+    }
+
+    fn run(&self, prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
+        run_tmux_backend(prepared)
+    }
+
+    fn stop(&self, _reason: &str) -> Result<(), AgentError> {
+        Ok(())
+    }
+
+    fn summarize(&self, events: &[AgentEvent]) -> AgentSummary {
+        let session_id = events.iter().find_map(|event| match event {
+            AgentEvent::SessionStarted { session_id, .. } => Some(session_id.clone()),
+            _ => None,
+        });
+        let failure = events.iter().find_map(|event| match event {
+            AgentEvent::Failed { error, .. } => Some(error.clone()),
+            _ => None,
+        });
+        let log_path = message_field(events, "log_path=").map(PathBuf::from);
+        let attach_command = session_id
+            .as_ref()
+            .map(|session| format!("tmux attach-session -t {session}"));
+        let message = failure.clone().unwrap_or_else(|| {
+            format!(
+                "tmux session running; attach with `{}`",
+                attach_command.as_deref().unwrap_or("tmux attach-session")
+            )
+        });
+
+        AgentSummary {
+            backend: self.name().into(),
+            success: false,
+            pending_session: failure.is_none() && session_id.is_some(),
+            session_id,
+            message,
+            log_path,
+            attach_command,
+        }
+    }
+}
+
 fn run_subprocess_backend(
     prepared: PreparedRun,
     session_id: &str,
@@ -371,6 +465,187 @@ fn run_subprocess_backend(
 
         thread::sleep(Duration::from_millis(10));
     }
+}
+
+fn run_tmux_backend(prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
+    let mut events = Vec::new();
+
+    if !prepared.workspace.is_dir() {
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend,
+            error: format!("workspace does not exist: {}", prepared.workspace.display()),
+        });
+        return Ok(events);
+    }
+
+    let Some(agent_command) = prepared.command.as_deref() else {
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend,
+            error: "missing tmux agent command".into(),
+        });
+        return Ok(events);
+    };
+
+    let prompt_artifact_path = persist_prompt_artifact(&prepared)?;
+    let session_id = tmux_session_name(&prepared);
+    let log_path = tmux_log_path(&prepared, &session_id);
+    if let Some(parent) = log_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let tmux = prepared
+        .env
+        .get("JADE_SYMPHONY_TMUX_COMMAND")
+        .cloned()
+        .or_else(|| std::env::var("JADE_SYMPHONY_TMUX_COMMAND").ok())
+        .unwrap_or_else(|| "tmux".into());
+    let target = session_id.as_str();
+    let shell_command = tmux_agent_shell_command(&prepared, agent_command, &prompt_artifact_path);
+    if let Err(error) = tmux_command_status(
+        Command::new(&tmux)
+            .envs(prepared.env.iter())
+            .args(["new-session", "-d", "-s", target, "-c"])
+            .arg(&prepared.workspace)
+            .arg(shell_command),
+        "new-session",
+    ) {
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend,
+            error,
+        });
+        return Ok(events);
+    }
+    for (action, mut command) in [
+        ("pipe-pane", {
+            let mut command = Command::new(&tmux);
+            command
+                .envs(prepared.env.iter())
+                .args(["pipe-pane", "-o", "-t", target])
+                .arg(format!("cat >> {}", shell_quote_path(&log_path)));
+            command
+        }),
+        ("load-buffer", {
+            let mut command = Command::new(&tmux);
+            command
+                .envs(prepared.env.iter())
+                .args(["load-buffer", "-b", target])
+                .arg(&prompt_artifact_path);
+            command
+        }),
+        ("paste-buffer", {
+            let mut command = Command::new(&tmux);
+            command
+                .envs(prepared.env.iter())
+                .args(["paste-buffer", "-b", target, "-t", target]);
+            command
+        }),
+        ("send-keys", {
+            let mut command = Command::new(&tmux);
+            command
+                .envs(prepared.env.iter())
+                .args(["send-keys", "-t", target, "Enter"]);
+            command
+        }),
+    ] {
+        if let Err(error) = tmux_command_status(&mut command, action) {
+            events.push(AgentEvent::Failed {
+                backend: prepared.backend,
+                error,
+            });
+            return Ok(events);
+        }
+    }
+
+    events.push(AgentEvent::SessionStarted {
+        backend: prepared.backend.clone(),
+        session_id: session_id.clone(),
+    });
+    events.push(AgentEvent::Message {
+        backend: prepared.backend,
+        session_id: Some(session_id.clone()),
+        text: format!(
+            "tmux_session_started session={} attach_command=\"tmux attach-session -t {}\" log_path={} prompt_artifact={}",
+            session_id,
+            session_id,
+            log_path.display(),
+            prompt_artifact_path.display()
+        ),
+    });
+    Ok(events)
+}
+
+fn tmux_command_status(command: &mut Command, action: &str) -> Result<(), String> {
+    match command.status() {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => Err(format!(
+            "tmux {action} exited with status {}",
+            status.code().unwrap_or(-1)
+        )),
+        Err(error) => Err(format!("tmux {action} failed: {error}")),
+    }
+}
+
+fn tmux_agent_shell_command(
+    prepared: &PreparedRun,
+    agent_command: &str,
+    prompt_artifact_path: &Path,
+) -> String {
+    format!(
+        "JADE_SYMPHONY_PROMPT_PATH={} JADE_SYMPHONY_ACTOR_ROLE={} JADE_SYMPHONY_ACTOR_LABEL={} JADE_SYMPHONY_GIT_AUTHOR={} sh -lc {}",
+        shell_quote_str(&prompt_artifact_path.display().to_string()),
+        shell_quote_str(prepared.actor_role.as_deref().unwrap_or_default()),
+        shell_quote_str(prepared.actor_label.as_deref().unwrap_or_default()),
+        shell_quote_str(prepared.git_author.as_deref().unwrap_or_default()),
+        shell_quote_str(agent_command)
+    )
+}
+
+fn tmux_session_name(prepared: &PreparedRun) -> String {
+    let prefix = prepared
+        .env
+        .get("JADE_SYMPHONY_TMUX_SESSION_PREFIX")
+        .map(String::as_str)
+        .unwrap_or("jade");
+    format!(
+        "{}-main-{}-{}",
+        safe_path_component(Some(prefix)),
+        safe_path_component(
+            prepared
+                .workspace
+                .file_name()
+                .and_then(|name| name.to_str())
+        ),
+        current_time_ms()
+    )
+}
+
+fn tmux_log_path(prepared: &PreparedRun, session_id: &str) -> PathBuf {
+    prepared
+        .prompt_artifact_path
+        .as_ref()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .unwrap_or_else(|| Path::new("/tmp"))
+        .join("tmux")
+        .join(format!("{}.log", safe_path_component(Some(session_id))))
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    shell_quote_str(&path.display().to_string())
+}
+
+fn shell_quote_str(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn message_field(events: &[AgentEvent], prefix: &str) -> Option<String> {
+    events.iter().find_map(|event| {
+        let AgentEvent::Message { text, .. } = event else {
+            return None;
+        };
+        text.split_whitespace()
+            .find_map(|part| part.strip_prefix(prefix).map(str::to_string))
+    })
 }
 
 pub fn persist_prompt_artifact(prepared: &PreparedRun) -> Result<PathBuf, AgentError> {
@@ -512,10 +787,13 @@ fn summarize_events(backend: &str, events: &[AgentEvent]) -> AgentSummary {
     AgentSummary {
         backend: backend.into(),
         success: failure.is_none() && completed.is_some(),
+        pending_session: false,
         session_id,
         message: failure
             .or(completed)
             .unwrap_or_else(|| "no terminal event".into()),
+        log_path: None,
+        attach_command: None,
     }
 }
 
@@ -564,6 +842,7 @@ pub fn backend_from_config(config: &RuntimeConfig) -> Box<dyn AgentBackend> {
     match config.backend.kind.as_str() {
         "codex" => Box::<CodexBackend>::default(),
         "claude-code" => Box::<ClaudeCodeBackend>::default(),
+        "tmux" => Box::<TmuxBackend>::default(),
         _ => Box::<DryRunBackend>::default(),
     }
 }
@@ -586,6 +865,152 @@ mod tests {
             .unwrap();
         let events = backend.run(prepared).unwrap();
         assert!(matches!(events[0], AgentEvent::SessionStarted { .. }));
+    }
+
+    #[test]
+    fn tmux_backend_prepare_uses_local_session_config() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\nagent:\n  backend: tmux\ntmux:\n  command: /usr/local/bin/tmux\n  agent_command: codex\n  session_prefix: jade-test\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md"))
+                .unwrap();
+        let backend = TmuxBackend;
+
+        let prepared = backend
+            .prepare(PathBuf::from("/tmp/ws"), "prompt".into(), &config)
+            .unwrap();
+
+        assert_eq!(prepared.backend, "tmux");
+        assert_eq!(prepared.command.as_deref(), Some("codex"));
+        assert_eq!(
+            prepared
+                .env
+                .get("JADE_SYMPHONY_TMUX_COMMAND")
+                .map(String::as_str),
+            Some("/usr/local/bin/tmux")
+        );
+        assert_eq!(
+            prepared
+                .env
+                .get("JADE_SYMPHONY_TMUX_SESSION_PREFIX")
+                .map(String::as_str),
+            Some("jade-test")
+        );
+    }
+
+    #[test]
+    fn tmux_summary_reports_pending_attachable_session() {
+        let events = vec![
+            AgentEvent::SessionStarted {
+                backend: "tmux".into(),
+                session_id: "jade-main-220".into(),
+            },
+            AgentEvent::Message {
+                backend: "tmux".into(),
+                session_id: Some("jade-main-220".into()),
+                text: "tmux_session_started session=jade-main-220 log_path=/tmp/jade.log".into(),
+            },
+        ];
+
+        let summary = TmuxBackend.summarize(&events);
+
+        assert!(!summary.success);
+        assert!(summary.pending_session);
+        assert_eq!(
+            summary.attach_command.as_deref(),
+            Some("tmux attach-session -t jade-main-220")
+        );
+        assert_eq!(summary.log_path, Some(PathBuf::from("/tmp/jade.log")));
+    }
+
+    #[test]
+    fn tmux_backend_launches_attachable_session_when_tmux_available() {
+        if Command::new("tmux")
+            .arg("-V")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_err()
+        {
+            eprintln!("skipping tmux smoke: tmux is unavailable");
+            return;
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nagent:\n  backend: tmux\ntmux:\n  command: tmux\n  agent_command: cat > jade-prompt.txt\n  session_prefix: jade-test\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md"))
+                .unwrap();
+        let backend = TmuxBackend;
+        let mut prepared = backend
+            .prepare(workspace.clone(), "echo tmux-smoke".into(), &config)
+            .unwrap();
+        prepared.prompt_artifact_path = Some(temp.path().join("logs/prompts/smoke.prompt.md"));
+        let tmux_tmp = temp.path().join("tmux-tmp");
+        fs::create_dir_all(&tmux_tmp).unwrap();
+        let probe_session = format!("jade-test-probe-{}", current_time_ms());
+        let probe = Command::new("tmux")
+            .env("TMUX_TMPDIR", &tmux_tmp)
+            .args(["new-session", "-d", "-s", &probe_session, "sleep 30"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let probe_available = probe.is_ok_and(|status| status.success())
+            && Command::new("tmux")
+                .env("TMUX_TMPDIR", &tmux_tmp)
+                .args(["has-session", "-t", &probe_session])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .is_ok_and(|status| status.success());
+        if !probe_available {
+            eprintln!("skipping tmux smoke: tmux cannot create sessions in this sandbox");
+            return;
+        }
+        Command::new("tmux")
+            .env("TMUX_TMPDIR", &tmux_tmp)
+            .args(["kill-session", "-t", &probe_session])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .ok();
+        prepared
+            .env
+            .insert("TMUX_TMPDIR".into(), tmux_tmp.display().to_string());
+
+        let events = backend.run(prepared).unwrap();
+        let summary = backend.summarize(&events);
+
+        assert!(summary.pending_session);
+        assert!(summary
+            .attach_command
+            .as_deref()
+            .unwrap()
+            .contains("tmux attach-session -t jade-test-main-workspace"));
+        assert!(summary
+            .log_path
+            .as_ref()
+            .unwrap()
+            .display()
+            .to_string()
+            .ends_with(".log"));
+        if let Some(session) = summary.session_id.as_deref() {
+            Command::new("tmux")
+                .env("TMUX_TMPDIR", tmux_tmp)
+                .args(["kill-session", "-t", session])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .ok();
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,7 @@ pub struct RuntimeConfig {
     pub backend: BackendConfig,
     pub codex: CodexConfig,
     pub claude: ClaudeConfig,
+    pub tmux: TmuxConfig,
     pub review: ReviewConfig,
     pub quality_gate: QualityGateConfig,
     pub verification: VerificationConfig,
@@ -132,6 +133,13 @@ pub struct CodexConfig {
 pub struct ClaudeConfig {
     pub command: String,
     pub turn_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TmuxConfig {
+    pub command: String,
+    pub agent_command: String,
+    pub session_prefix: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -311,6 +319,13 @@ impl RuntimeConfig {
                 .unwrap_or_else(|| "claude".to_string()),
             turn_timeout_ms: get_u64(root.get("claude"), "turn_timeout_ms").unwrap_or(3_600_000),
         };
+        let tmux = TmuxConfig {
+            command: resolve_command_token(get_string(root.get("tmux"), "command"), "tmux"),
+            agent_command: get_string(root.get("tmux"), "agent_command")
+                .unwrap_or_else(|| "codex".to_string()),
+            session_prefix: get_string(root.get("tmux"), "session_prefix")
+                .unwrap_or_else(|| "jade".to_string()),
+        };
         let review = ReviewConfig {
             backend: get_string(root.get("review"), "backend")
                 .unwrap_or_else(|| "fake".to_string()),
@@ -355,6 +370,7 @@ impl RuntimeConfig {
             backend,
             codex,
             claude,
+            tmux,
             review,
             quality_gate,
             verification,
@@ -374,8 +390,18 @@ impl RuntimeConfig {
         }
 
         match self.backend.kind.as_str() {
-            "dry-run" | "codex" | "claude-code" => {}
+            "dry-run" | "codex" | "claude-code" | "tmux" => {}
             other => return Err(ConfigError::UnsupportedBackend(other.to_string())),
+        }
+        if self.backend.kind == "tmux" && self.tmux.session_prefix.trim().is_empty() {
+            return Err(ConfigError::Invalid(
+                "tmux.session_prefix must not be empty".into(),
+            ));
+        }
+        if self.backend.kind == "tmux" && self.tmux.agent_command.trim().is_empty() {
+            return Err(ConfigError::Invalid(
+                "tmux.agent_command must not be empty".into(),
+            ));
         }
         match self.review.backend.as_str() {
             "fake" | "gemini-cli" => {}
@@ -866,6 +892,23 @@ mod tests {
             .agent
             .max_concurrent_agents_by_state
             .contains_key("bad"));
+    }
+
+    #[test]
+    fn parses_tmux_backend_config() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nagent:\n  backend: tmux\ntmux:\n  command: /opt/homebrew/bin/tmux\n  agent_command: codex\n  session_prefix: jade-local\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert_eq!(config.backend.kind, "tmux");
+        assert_eq!(config.tmux.command, "/opt/homebrew/bin/tmux");
+        assert_eq!(config.tmux.agent_command, "codex");
+        assert_eq!(config.tmux.session_prefix, "jade-local");
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2856,7 +2856,10 @@ struct IssueExecutionResult {
     profile_id: Option<String>,
     instance_name: Option<String>,
     success: bool,
+    pending_session: bool,
     session_id: Option<String>,
+    backend_log_path: Option<PathBuf>,
+    backend_attach_command: Option<String>,
     message: String,
     usage_limit_pause: Option<UsageLimitPause>,
     prompt_artifact_path: Option<PathBuf>,
@@ -2965,7 +2968,10 @@ fn execute_issue_once_with_workspace_key(
             .as_ref()
             .map(|profile| profile.instance_name.clone()),
         success: summary.success,
+        pending_session: summary.pending_session,
         session_id: summary.session_id,
+        backend_log_path: summary.log_path,
+        backend_attach_command: summary.attach_command,
         message: summary.message,
         usage_limit_pause,
         prompt_artifact_path: Some(prompt_artifact_path),
@@ -3507,6 +3513,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             &config,
             event,
         );
+        runtime_state.branch_name = Some(handoff.branch_name.clone());
         mark_runtime_state_updated(&mut runtime_state, current_time_ms());
         save_runtime_state(&config, &runtime_state)?;
         println!(
@@ -3670,6 +3677,53 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
                 reason: "main worker handoff evidence",
             },
         );
+
+        if result.pending_session {
+            append_runtime_supervision_event(
+                &config,
+                Some(&runtime_state),
+                "TmuxSessionRunning",
+                &format!(
+                    "issue={} session={} attach_command={} log_path={}",
+                    latest.identifier,
+                    result.session_id.as_deref().unwrap_or("n/a"),
+                    result.backend_attach_command.as_deref().unwrap_or("n/a"),
+                    result
+                        .backend_log_path
+                        .as_ref()
+                        .map(|path| path.display().to_string())
+                        .unwrap_or_else(|| "n/a".into())
+                ),
+            )?;
+            println!(
+                "run_loop_action=session_started issue={} backend={} session={} attach_command=\"{}\" log_path={}",
+                latest.identifier,
+                result.backend,
+                result.session_id.as_deref().unwrap_or("n/a"),
+                result
+                    .backend_attach_command
+                    .as_deref()
+                    .unwrap_or("n/a"),
+                result
+                    .backend_log_path
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|| "n/a".into())
+            );
+            print_latest_status(&LatestStatus {
+                lane: "main".into(),
+                category: "running".into(),
+                action: "session_started".into(),
+                issue_identifier: Some(latest.identifier.clone()),
+                issue_title: Some(latest.title.clone()),
+                actor_label: Some(config.identity.actor_label.clone()),
+                workspace: Some(result.workspace_path.display().to_string()),
+                branch: runtime_state.branch_name.clone(),
+                session_id: result.session_id.clone(),
+                next: result.backend_attach_command.clone(),
+            });
+            break;
+        }
 
         if result.success {
             if !transition_allowed_for_main_agent("agent_review") {
@@ -4392,7 +4446,7 @@ fn ensure_write_mode_main_agent_backend(
     Err(io::Error::new(
         io::ErrorKind::InvalidInput,
         format!(
-            "write-mode {command} is blocked because workflow={} configures agent.backend=dry-run; configure a real main-agent backend such as codex or claude-code before using --write",
+            "write-mode {command} is blocked because workflow={} configures agent.backend=dry-run; configure a real main-agent backend such as tmux, codex, or claude-code before using --write",
             workflow_path.display()
         ),
     )
@@ -4502,6 +4556,7 @@ fn run_loop_runtime_state_for_issue(
     );
     state.attempt_count = next_runtime_attempt_count(existing, &issue.identifier);
     state.branch_name = issue.branch_name.clone();
+    state.lane = Some("main".into());
     state.profile_id = profile.as_ref().map(|profile| profile.profile_id.clone());
     state.instance_name = profile
         .as_ref()
@@ -4532,12 +4587,16 @@ fn run_loop_runtime_state_with_result(
     state.workspace_path = Some(result.workspace_path.clone());
     state.backend = result.backend.clone();
     state.backend_session_id = result.session_id.clone();
+    state.backend_log_path = result.backend_log_path.clone();
+    state.backend_attach_command = result.backend_attach_command.clone();
     state.profile_id = result.profile_id.clone();
     state.instance_name = result.instance_name.clone();
     state.actor_role = Some(result.actor_role.clone());
     state.actor_label = Some(result.actor_label.clone());
     state.git_author = result.git_author.clone();
-    state.last_event = Some(if result.success {
+    state.last_event = Some(if result.pending_session {
+        "SessionRunning".into()
+    } else if result.success {
         "Completed".into()
     } else {
         "Failed".into()
@@ -4845,6 +4904,26 @@ fn run_loop_handoff_workpad(
         format!(
             "- Session: `{}`",
             result.session_id.as_deref().unwrap_or("n/a")
+        ),
+        format!(
+            "- Session status: `{}`",
+            if result.pending_session {
+                "running"
+            } else {
+                "terminal"
+            }
+        ),
+        format!(
+            "- Attach command: `{}`",
+            result.backend_attach_command.as_deref().unwrap_or("n/a")
+        ),
+        format!(
+            "- Session log: `{}`",
+            result
+                .backend_log_path
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "n/a".into())
         ),
         format!("- Message: {}", result.message),
         String::new(),
@@ -7905,7 +7984,10 @@ mod tests {
             profile_id: Some("codex-alpha".into()),
             instance_name: Some("Codex Alpha".into()),
             success: true,
+            pending_session: false,
             session_id: Some("session-29".into()),
+            backend_log_path: None,
+            backend_attach_command: None,
             message: "ok".into(),
             usage_limit_pause: None,
             prompt_artifact_path: None,
@@ -7946,6 +8028,54 @@ mod tests {
                 reason: "main agent completed".into(),
             })
         );
+    }
+
+    #[test]
+    fn run_loop_runtime_state_records_pending_tmux_session_metadata() {
+        let config = test_config();
+        let issue = tracker_issue("In Progress");
+        let state = run_loop_runtime_state_for_issue(None, &issue, &config, "Claimed");
+        let result = IssueExecutionResult {
+            workspace_path: PathBuf::from("/tmp/jade/issue-220"),
+            backend: "tmux".into(),
+            profile_id: None,
+            instance_name: None,
+            success: false,
+            pending_session: true,
+            session_id: Some("jade-main-220".into()),
+            backend_log_path: Some(PathBuf::from("/tmp/jade/logs/tmux/jade-main-220.log")),
+            backend_attach_command: Some("tmux attach-session -t jade-main-220".into()),
+            message: "tmux session running".into(),
+            usage_limit_pause: None,
+            prompt_artifact_path: None,
+            actor_role: "implementation_agent".into(),
+            actor_label: "Jade Symphony Agent".into(),
+            git_author: None,
+            git_identity: GitIdentityApplyResult {
+                status: jade_symphony::workspace::GitIdentityApplyStatus::NotGitRepository,
+                author: None,
+                applied_keys: Vec::new(),
+            },
+            live_handoff: None,
+            handoff_verification: None,
+        };
+
+        let state = run_loop_runtime_state_with_result(state, &result);
+        let workpad = run_loop_handoff_workpad(
+            &issue,
+            &result,
+            &run_loop_handoff_plan(&config, &issue).unwrap(),
+        );
+
+        assert_eq!(state.last_event.as_deref(), Some("SessionRunning"));
+        assert_eq!(state.backend_session_id.as_deref(), Some("jade-main-220"));
+        assert_eq!(
+            state.backend_attach_command.as_deref(),
+            Some("tmux attach-session -t jade-main-220")
+        );
+        assert!(workpad.contains("Session status: `running`"));
+        assert!(workpad.contains("Attach command: `tmux attach-session -t jade-main-220`"));
+        assert!(workpad.contains("Session log: `/tmp/jade/logs/tmux/jade-main-220.log`"));
     }
 
     #[test]
@@ -8002,7 +8132,10 @@ mod tests {
             profile_id: None,
             instance_name: None,
             success: true,
+            pending_session: false,
             session_id: Some("session-33".into()),
+            backend_log_path: None,
+            backend_attach_command: None,
             message: "ok".into(),
             usage_limit_pause: None,
             prompt_artifact_path: None,
@@ -8124,7 +8257,10 @@ mod tests {
             profile_id: None,
             instance_name: None,
             success: true,
+            pending_session: false,
             session_id: Some("session-33".into()),
+            backend_log_path: None,
+            backend_attach_command: None,
             message: "ok".into(),
             usage_limit_pause: None,
             prompt_artifact_path: None,
@@ -8176,7 +8312,10 @@ mod tests {
             profile_id: None,
             instance_name: None,
             success: false,
+            pending_session: false,
             session_id: Some("session-63".into()),
+            backend_log_path: None,
+            backend_attach_command: None,
             message: "Codex subprocess exited with status 1".into(),
             usage_limit_pause: Some(UsageLimitPause {
                 classifier: "usage_limit".into(),
@@ -8277,7 +8416,10 @@ mod tests {
             profile_id: None,
             instance_name: None,
             success: true,
+            pending_session: false,
             session_id: Some("session-57".into()),
+            backend_log_path: None,
+            backend_attach_command: None,
             message: "ok".into(),
             usage_limit_pause: None,
             prompt_artifact_path: None,
@@ -8324,7 +8466,10 @@ mod tests {
             profile_id: None,
             instance_name: None,
             success: true,
+            pending_session: false,
             session_id: Some("session-57".into()),
+            backend_log_path: None,
+            backend_attach_command: None,
             message: "ok".into(),
             usage_limit_pause: None,
             prompt_artifact_path: None,

--- a/src/runtime_state.rs
+++ b/src/runtime_state.rs
@@ -16,6 +16,12 @@ pub struct RuntimeState {
     pub backend: String,
     pub backend_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lane: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_log_path: Option<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backend_attach_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instance_name: Option<String>,
@@ -44,6 +50,9 @@ impl RuntimeState {
             branch_name: None,
             backend: backend.into(),
             backend_session_id: None,
+            lane: None,
+            backend_log_path: None,
+            backend_attach_command: None,
             profile_id: None,
             instance_name: None,
             actor_role: None,
@@ -219,6 +228,9 @@ mod tests {
             branch_name: Some("feature-issue-1".into()),
             backend: "dry-run".into(),
             backend_session_id: Some("session".into()),
+            lane: Some("main".into()),
+            backend_log_path: Some(PathBuf::from("/tmp/jade/logs/session.log")),
+            backend_attach_command: Some("tmux attach-session -t session".into()),
             profile_id: Some("codex-alpha".into()),
             instance_name: Some("Codex Alpha".into()),
             actor_role: Some("implementation_agent".into()),

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -21,6 +21,11 @@ cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- merge-once workflows/jade-symphony.md --write
 ```
 
+Main Agent execution uses the local `tmux` backend. A bounded write tick creates
+an attachable session, prints `tmux attach-session -t ...`, records the session
+log path, and leaves the issue active until real implementation evidence is
+available for the normal handoff path.
+
 Lane prompt files:
 
 - `workflows/prompts/main-agent.md`: implementation agent contract; stops at

--- a/workflows/jade-symphony.md
+++ b/workflows/jade-symphony.md
@@ -45,10 +45,14 @@ artifacts:
 workspace:
   root: $JADE_SYMPHONY_ARTIFACT_ROOT/Alive24/jade-symphony/default/worktrees
 agent:
-  backend: dry-run
+  backend: tmux
   max_concurrent_agents: 1
   max_turns: 3
   max_retry_backoff_ms: 300000
+tmux:
+  command: tmux
+  agent_command: codex
+  session_prefix: jade
 codex:
   command: codex app-server
 claude:


### PR DESCRIPTION
Refs #220

## Summary
- add a local tmux Main Agent backend that starts an attachable session, pastes the rendered prompt, and logs the session
- record pending-session metadata in runtime state and workpad evidence: lane, workspace, branch, session, log path, and attach command
- configure the canonical workflow to use `agent.backend: tmux` and document that session launch is not handoff/completion evidence

## Scope note
This is the first vertical slice only: Main Agent tmux backend. Review and Merging tmux lanes remain out of this PR.

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- validate workflows/jade-symphony.md
- cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
- cargo test tmux_backend_launches_attachable_session_when_tmux_available -- --nocapture (real local tmux smoke, elevated)
- env TMUX_TMPDIR=/private/tmp/jade-symphony-tmux-smoke/tmux cargo run -- run-loop /private/tmp/jade-symphony-tmux-smoke/WORKFLOW.md --max-iterations 1 --write (fixture-backed tmux Main Agent smoke; printed attach command and kept state at SessionRunning)