### PR TITLE
#226: Add tmux pane capture and session status classification

### DIFF
--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -95,6 +95,12 @@ only then pastes the rendered issue prompt. Set
 `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` to opt out; when disabled, or when readiness
 cannot be confirmed, the tick fails closed with attach/log evidence and does not
 hand off to `Agent Review`.
+Routine status output reads the durable session registry, probes bounded pane
+and log tails, and reports a conservative session classification such as
+`running`, `waiting_for_trust`, `waiting_for_approval`, `usage_limited`,
+`failed`, `completed`, `stale`, or `unknown`. The status surface includes only
+compact evidence snippets plus attach/log locations; attach manually when raw
+scrollback is needed.
 If an operator switches the workflow back to `agent.backend: dry-run`, the
 mutating tick exits before runtime-state writes, worktree creation, Project
 claims, or workpad mutation.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -16,6 +16,8 @@ use crate::session_registry::{
     AgentSessionRecord, SessionStatus,
 };
 
+const DEFAULT_TMUX_CAPTURE_LINES: usize = 200;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PreparedRun {
     pub backend: String,
@@ -717,7 +719,7 @@ fn wait_for_codex_tmux_readiness(
     let mut last_capture = String::new();
 
     for _ in 0..20 {
-        let capture = capture_tmux_pane(prepared, tmux, target)?;
+        let capture = capture_tmux_pane(prepared, tmux, target, DEFAULT_TMUX_CAPTURE_LINES)?;
         if codex_viewport_ready(&capture) {
             return Ok(());
         }
@@ -758,7 +760,7 @@ fn wait_for_codex_tmux_readiness(
     }
 
     for _ in 0..20 {
-        let capture = capture_tmux_pane(prepared, tmux, target)?;
+        let capture = capture_tmux_pane(prepared, tmux, target, DEFAULT_TMUX_CAPTURE_LINES)?;
         if codex_viewport_ready(&capture) {
             return Ok(());
         }
@@ -772,7 +774,13 @@ fn wait_for_codex_tmux_readiness(
     ))
 }
 
-fn capture_tmux_pane(prepared: &PreparedRun, tmux: &str, target: &str) -> Result<String, String> {
+fn capture_tmux_pane(
+    prepared: &PreparedRun,
+    tmux: &str,
+    target: &str,
+    max_lines: usize,
+) -> Result<String, String> {
+    let start = format!("-{}", max_lines.clamp(1, 500));
     tmux_command_output(
         Command::new(tmux).envs(prepared.env.iter()).args([
             "capture-pane",
@@ -780,7 +788,7 @@ fn capture_tmux_pane(prepared: &PreparedRun, tmux: &str, target: &str) -> Result
             "-t",
             target,
             "-S",
-            "-200",
+            &start,
         ]),
         "capture-pane",
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ use jade_symphony::merge_lane::{
     merge_lane_workpad, merge_pull_request, pull_request_status_from_linked, MergeLaneDecisionKind,
 };
 use jade_symphony::model::{
-    normalize_state, GateDecision, GateDecisionKind, LatestStatus, TrackerIssue,
+    normalize_state, GateDecision, GateDecisionKind, LatestStatus, SessionStatusSnapshot,
+    TrackerIssue,
 };
 use jade_symphony::observability_api::serve_once;
 use jade_symphony::orchestrator::Orchestrator;
@@ -75,6 +76,10 @@ use jade_symphony::runtime_state::{
     record_runtime_retry, runtime_state_path, save_runtime_state, RuntimeIssueState,
     RuntimeRetryState, RuntimeStallState, RuntimeState, RuntimeTransition,
 };
+use jade_symphony::session_registry::{
+    capture_tmux_pane_tail, classify_session_record, load_session_registry, read_log_tail,
+    session_registry_path, unix_timestamp_ms,
+};
 use jade_symphony::status_surface::{render_latest_status_bar, render_snapshot};
 use jade_symphony::tracker::{
     adapter_from_config, claim_decision, classify_project_state_error, ClaimDecision,
@@ -87,6 +92,8 @@ use jade_symphony::workspace::{
 };
 
 const DEFAULT_RUN_LOOP_BASE_BRANCH: &str = "main";
+const DEFAULT_SESSION_STATUS_LINES: usize = 80;
+const DEFAULT_SESSION_STALE_AFTER_MS: u64 = 15 * 60 * 1000;
 
 fn main() {
     if let Err(error) = run() {
@@ -305,6 +312,7 @@ fn build_plan_snapshot(
     let adapter = adapter_from_config(&config);
     let integration_gaps = adapter.integration_gaps();
     let issues = adapter.list_dispatchable_issues()?;
+    let session_statuses = session_status_snapshots(&config);
     let event_log_path = config
         .observability
         .logs_root
@@ -314,9 +322,54 @@ fn build_plan_snapshot(
     let orchestrator = Orchestrator::new(config);
     let mut plan = orchestrator.plan_dispatch(issues);
     plan.integration_gaps.extend(integration_gaps);
+    match session_statuses {
+        Ok(sessions) => plan.snapshot.sessions = sessions,
+        Err(error) => plan
+            .integration_gaps
+            .push(format!("tmux session status unavailable: {error}")),
+    }
     plan.snapshot.integration_gaps = plan.integration_gaps.clone();
     plan.snapshot.event_log_path = Some(event_log_path);
     Ok(plan.snapshot)
+}
+
+fn session_status_snapshots(
+    config: &RuntimeConfig,
+) -> Result<Vec<SessionStatusSnapshot>, Box<dyn std::error::Error>> {
+    let registry = load_session_registry(&session_registry_path(config))?;
+    let now_ms = unix_timestamp_ms();
+    let mut snapshots = Vec::new();
+
+    for record in registry.sessions.iter().rev().take(20).rev() {
+        let pane_tail = capture_tmux_pane_tail(
+            &config.tmux.command,
+            &record.pane_target,
+            DEFAULT_SESSION_STATUS_LINES,
+        )
+        .ok();
+        let log_tail = read_log_tail(&record.log_path, DEFAULT_SESSION_STATUS_LINES)?;
+        let probe = classify_session_record(
+            record,
+            pane_tail.as_deref(),
+            log_tail.as_deref(),
+            now_ms,
+            DEFAULT_SESSION_STALE_AFTER_MS,
+        );
+        snapshots.push(SessionStatusSnapshot {
+            session_id: record.session_name.clone(),
+            lane: record.lane.clone(),
+            status: probe.status.as_str().into(),
+            evidence_source: probe.source.as_str().into(),
+            evidence: probe.evidence,
+            issue_identifier: record.issue_identifier.clone(),
+            issue_title: record.issue_title.clone(),
+            attach_command: Some(record.attach_command.clone()),
+            log_path: Some(record.log_path.display().to_string()),
+            updated_at_ms: record.updated_at_ms,
+        });
+    }
+
+    Ok(snapshots)
 }
 
 fn render_plan_snapshot(

--- a/src/model.rs
+++ b/src/model.rs
@@ -117,6 +117,24 @@ pub struct RunningSnapshot {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionStatusSnapshot {
+    pub session_id: String,
+    pub lane: String,
+    pub status: String,
+    pub evidence_source: String,
+    pub evidence: String,
+    #[serde(default)]
+    pub issue_identifier: Option<String>,
+    #[serde(default)]
+    pub issue_title: Option<String>,
+    #[serde(default)]
+    pub attach_command: Option<String>,
+    #[serde(default)]
+    pub log_path: Option<String>,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RetrySnapshot {
     pub issue_id: String,
     pub identifier: String,
@@ -187,6 +205,8 @@ pub struct RuntimeSnapshot {
     pub retrying: Vec<RetrySnapshot>,
     pub codex_totals: TokenTotals,
     pub polling: PollingSnapshot,
+    #[serde(default)]
+    pub sessions: Vec<SessionStatusSnapshot>,
     #[serde(default)]
     pub skipped: Vec<SkippedIssue>,
     #[serde(default)]

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -97,6 +97,7 @@ impl Orchestrator {
                 next_poll_in_ms: Some(self.config.polling.interval_ms),
                 poll_interval_ms: self.config.polling.interval_ms,
             },
+            sessions: Vec::new(),
             skipped,
             integration_gaps: Vec::new(),
             latest_status: None,

--- a/src/session_registry.rs
+++ b/src/session_registry.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -43,7 +44,59 @@ pub struct AgentSessionRecord {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionStatus {
+    Starting,
     Running,
+    WaitingForTrust,
+    WaitingForApproval,
+    WaitingForHumanInput,
+    UsageLimited,
+    Failed,
+    Completed,
+    Stale,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionStatusProbe {
+    pub status: SessionStatus,
+    pub source: SessionStatusSource,
+    pub evidence: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionStatusSource {
+    Pane,
+    Log,
+    Registry,
+    None,
+}
+
+impl SessionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::WaitingForTrust => "waiting_for_trust",
+            Self::WaitingForApproval => "waiting_for_approval",
+            Self::WaitingForHumanInput => "waiting_for_human_input",
+            Self::UsageLimited => "usage_limited",
+            Self::Failed => "failed",
+            Self::Completed => "completed",
+            Self::Stale => "stale",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl SessionStatusSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Pane => "pane",
+            Self::Log => "log",
+            Self::Registry => "registry",
+            Self::None => "none",
+        }
+    }
 }
 
 #[derive(Debug, Error)]
@@ -130,6 +183,250 @@ pub fn unix_timestamp_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
         .unwrap_or_default()
+}
+
+pub fn capture_tmux_pane_tail(
+    tmux_command: &str,
+    target: &str,
+    max_lines: usize,
+) -> Result<String, String> {
+    let start = format!("-{}", max_lines.clamp(1, 500));
+    match Command::new(tmux_command)
+        .args(["capture-pane", "-p", "-t", target, "-S", &start])
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        }
+        Ok(output) => Err(format!(
+            "tmux capture-pane exited with status {}",
+            output.status.code().unwrap_or(-1)
+        )),
+        Err(error) => Err(format!("tmux capture-pane failed: {error}")),
+    }
+}
+
+pub fn read_log_tail(
+    path: &Path,
+    max_lines: usize,
+) -> Result<Option<String>, SessionRegistryError> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(Some(tail_lines(&content, max_lines))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub fn classify_session_record(
+    record: &AgentSessionRecord,
+    pane_tail: Option<&str>,
+    log_tail: Option<&str>,
+    now_ms: u64,
+    stale_after_ms: u64,
+) -> SessionStatusProbe {
+    if let Some(probe) =
+        pane_tail.and_then(|tail| classify_session_output(tail, SessionStatusSource::Pane))
+    {
+        return probe;
+    }
+
+    if let Some(probe) =
+        log_tail.and_then(|tail| classify_session_output(tail, SessionStatusSource::Log))
+    {
+        return probe;
+    }
+
+    if stale_after_ms > 0
+        && now_ms.saturating_sub(record.updated_at_ms) > stale_after_ms
+        && !matches!(
+            record.status,
+            SessionStatus::Completed | SessionStatus::Failed
+        )
+    {
+        return SessionStatusProbe {
+            status: SessionStatus::Stale,
+            source: SessionStatusSource::Registry,
+            evidence: format!(
+                "registry record has not updated for {}ms",
+                now_ms.saturating_sub(record.updated_at_ms)
+            ),
+        };
+    }
+
+    if let Some(tail) = pane_tail
+        .filter(|tail| !tail.trim().is_empty())
+        .or_else(|| log_tail.filter(|tail| !tail.trim().is_empty()))
+    {
+        return SessionStatusProbe {
+            status: SessionStatus::Unknown,
+            source: if pane_tail.is_some() {
+                SessionStatusSource::Pane
+            } else {
+                SessionStatusSource::Log
+            },
+            evidence: compact_session_evidence(tail),
+        };
+    }
+
+    SessionStatusProbe {
+        status: record.status.clone(),
+        source: SessionStatusSource::Registry,
+        evidence: format!("registry status {}", record.status.as_str()),
+    }
+}
+
+pub fn classify_session_output(
+    text: &str,
+    source: SessionStatusSource,
+) -> Option<SessionStatusProbe> {
+    let evidence = compact_session_evidence(text);
+    if evidence.is_empty() {
+        return Some(SessionStatusProbe {
+            status: SessionStatus::Starting,
+            source,
+            evidence: "no pane or log output yet".into(),
+        });
+    }
+
+    let normalized = normalized_session_text(text);
+    let status = if contains_any(
+        &normalized,
+        &[
+            "usage limit",
+            "rate limit",
+            "quota exceeded",
+            "too many requests",
+            "429",
+        ],
+    ) {
+        SessionStatus::UsageLimited
+    } else if contains_any(
+        &normalized,
+        &[
+            "do you trust the contents of this directory",
+            "do you trust the files in this directory",
+            "do you trust the files in this folder",
+        ],
+    ) || (normalized.contains("trust")
+        && normalized.contains("directory")
+        && normalized.contains("codex"))
+    {
+        SessionStatus::WaitingForTrust
+    } else if (normalized.contains("approval")
+        || normalized.contains("approve")
+        || normalized.contains("allow"))
+        && contains_any(
+            &normalized,
+            &[
+                "command",
+                "permission",
+                "escalation",
+                "sandbox",
+                "execute",
+                "action",
+            ],
+        )
+    {
+        SessionStatus::WaitingForApproval
+    } else if contains_any(
+        &normalized,
+        &[
+            "need human input",
+            "needs human input",
+            "waiting for human",
+            "requires human input",
+            "clarification needed",
+            "please provide",
+        ],
+    ) {
+        SessionStatus::WaitingForHumanInput
+    } else if contains_any(
+        &normalized,
+        &[
+            "completed successfully",
+            "task complete",
+            "status=complete",
+            "final answer",
+            "done; verification",
+        ],
+    ) {
+        SessionStatus::Completed
+    } else if contains_any(
+        &normalized,
+        &[
+            "exited with status",
+            "fatal:",
+            "panic",
+            "thread '",
+            "error:",
+            "operation not permitted",
+            "permission denied",
+        ],
+    ) {
+        SessionStatus::Failed
+    } else if contains_any(
+        &normalized,
+        &[
+            "starting",
+            "launching",
+            "loading",
+            "checking workspace",
+            "preparing",
+        ],
+    ) {
+        SessionStatus::Starting
+    } else if contains_any(
+        &normalized,
+        &[
+            "thinking",
+            "working",
+            "running",
+            "executing",
+            "applying patch",
+            "tokens",
+            "codex",
+        ],
+    ) || text.contains('›')
+        || text.contains('▌')
+    {
+        SessionStatus::Running
+    } else {
+        return None;
+    };
+
+    Some(SessionStatusProbe {
+        status,
+        source,
+        evidence,
+    })
+}
+
+pub fn tail_lines(text: &str, max_lines: usize) -> String {
+    let max_lines = max_lines.max(1);
+    let lines = text.lines().collect::<Vec<_>>();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].join("\n")
+}
+
+pub fn compact_session_evidence(text: &str) -> String {
+    let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    const MAX_LEN: usize = 180;
+    if compact.len() > MAX_LEN {
+        format!("{}...", &compact[..MAX_LEN])
+    } else {
+        compact
+    }
+}
+
+fn contains_any(text: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| text.contains(needle))
+}
+
+fn normalized_session_text(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
 }
 
 fn issue_number(identifier: &str) -> Option<String> {
@@ -242,5 +539,94 @@ mod tests {
 
         assert_eq!(loaded.sessions.len(), 1);
         assert_eq!(loaded.sessions[0].updated_at_ms, 20);
+    }
+
+    #[test]
+    fn classifies_required_session_statuses_from_fixture_output() {
+        let fixtures = [
+            ("Starting Codex...", SessionStatus::Starting),
+            (
+                "Codex is thinking about the next edit",
+                SessionStatus::Running,
+            ),
+            (
+                "Do you trust the contents of this directory?",
+                SessionStatus::WaitingForTrust,
+            ),
+            (
+                "Approval required: allow this command to execute?",
+                SessionStatus::WaitingForApproval,
+            ),
+            (
+                "Need human input before continuing",
+                SessionStatus::WaitingForHumanInput,
+            ),
+            (
+                "usage limit reached; try again later",
+                SessionStatus::UsageLimited,
+            ),
+            ("cargo clippy exited with status 101", SessionStatus::Failed),
+            (
+                "Task complete. Final answer ready.",
+                SessionStatus::Completed,
+            ),
+        ];
+
+        for (fixture, expected) in fixtures {
+            let probe = classify_session_output(fixture, SessionStatusSource::Pane).unwrap();
+            assert_eq!(probe.status, expected, "fixture={fixture}");
+            assert_eq!(probe.source, SessionStatusSource::Pane);
+        }
+    }
+
+    #[test]
+    fn classifies_stale_when_registry_record_is_old_and_output_is_unknown() {
+        let record = fixture_record();
+
+        let probe = classify_session_record(&record, Some("unrecognized"), None, 10_500, 5_000);
+
+        assert_eq!(probe.status, SessionStatus::Stale);
+        assert_eq!(probe.source, SessionStatusSource::Registry);
+    }
+
+    #[test]
+    fn classifies_unknown_when_bounded_output_is_inconclusive() {
+        let record = fixture_record();
+
+        let probe = classify_session_record(&record, Some("unrecognized"), None, 3_000, 5_000);
+
+        assert_eq!(probe.status, SessionStatus::Unknown);
+        assert_eq!(probe.source, SessionStatusSource::Pane);
+    }
+
+    fn fixture_record() -> AgentSessionRecord {
+        AgentSessionRecord {
+            issue_id: Some("I_226".into()),
+            issue_identifier: Some("#226".into()),
+            issue_title: Some("Classify status".into()),
+            lane: "main".into(),
+            actor_role: None,
+            actor_label: None,
+            git_author: None,
+            profile_id: None,
+            instance_name: None,
+            worktree: PathBuf::from("/tmp/worktree"),
+            branch: None,
+            backend: "tmux".into(),
+            session_name: "jade-main-226-attempt-1-classify".into(),
+            pane_target: "jade-main-226-attempt-1-classify".into(),
+            prompt_artifact_path: PathBuf::from("/tmp/prompt.md"),
+            log_path: PathBuf::from("/tmp/session.log"),
+            attach_command: "tmux attach-session -t jade-main-226-attempt-1-classify".into(),
+            attempt: 1,
+            status: SessionStatus::Running,
+            started_at_ms: 1_000,
+            updated_at_ms: 1_000,
+        }
+    }
+
+    #[test]
+    fn tails_bounded_log_lines() {
+        assert_eq!(tail_lines("one\ntwo\nthree\nfour", 2), "three\nfour");
     }
 }

--- a/src/status_surface.rs
+++ b/src/status_surface.rs
@@ -36,6 +36,7 @@ pub fn render_snapshot(snapshot: &RuntimeSnapshot) -> String {
     }
 
     render_running(snapshot, &mut lines);
+    render_sessions(snapshot, &mut lines);
     render_retrying(snapshot, &mut lines);
     render_skipped(snapshot, &mut lines);
     render_integration_gaps(snapshot, &mut lines);
@@ -89,6 +90,27 @@ fn render_running(snapshot: &RuntimeSnapshot, lines: &mut Vec<String>) {
             entry.profile_id.as_deref().unwrap_or("n/a"),
             entry.workspace_path.as_deref().unwrap_or("n/a"),
             entry.session_id.as_deref().unwrap_or("n/a"),
+        ));
+    }
+}
+
+fn render_sessions(snapshot: &RuntimeSnapshot, lines: &mut Vec<String>) {
+    if snapshot.sessions.is_empty() {
+        return;
+    }
+
+    lines.push("tmux sessions:".into());
+    for entry in &snapshot.sessions {
+        lines.push(format!(
+            "- {} lane={} issue={} status={} source={} evidence=\"{}\" attach={} log={}",
+            entry.session_id,
+            entry.lane,
+            entry.issue_identifier.as_deref().unwrap_or("n/a"),
+            entry.status,
+            entry.evidence_source,
+            entry.evidence,
+            entry.attach_command.as_deref().unwrap_or("n/a"),
+            entry.log_path.as_deref().unwrap_or("n/a"),
         ));
     }
 }
@@ -154,7 +176,7 @@ mod tests {
     use super::*;
     use crate::model::{
         GateDecision, GateDecisionKind, LatestStatus, PollingSnapshot, RetrySnapshot,
-        RunningSnapshot, RuntimeSnapshot, SkippedIssue, TokenTotals,
+        RunningSnapshot, RuntimeSnapshot, SessionStatusSnapshot, SkippedIssue, TokenTotals,
     };
 
     #[test]
@@ -196,6 +218,18 @@ mod tests {
                 next_poll_in_ms: Some(1000),
                 poll_interval_ms: 5000,
             },
+            sessions: vec![SessionStatusSnapshot {
+                session_id: "jade-main-1-attempt-1".into(),
+                lane: "main".into(),
+                status: "waiting_for_approval".into(),
+                evidence_source: "pane".into(),
+                evidence: "Approval required: allow this command?".into(),
+                issue_identifier: Some("#1".into()),
+                issue_title: Some("Wire runtime".into()),
+                attach_command: Some("tmux attach-session -t jade-main-1-attempt-1".into()),
+                log_path: Some("/tmp/jade-main-1.log".into()),
+                updated_at_ms: 10,
+            }],
             skipped: vec![SkippedIssue {
                 issue_id: "GHI_3".into(),
                 identifier: "#3".into(),
@@ -225,6 +259,8 @@ mod tests {
 
         assert!(rendered.contains("Latest: main | #1 | handoff | pr_created"));
         assert!(rendered.contains("running issues:"));
+        assert!(rendered.contains("tmux sessions:"));
+        assert!(rendered.contains("status=waiting_for_approval"));
         assert!(rendered.contains("profile=codex-alpha"));
         assert!(rendered.contains("retrying issues:"));
         assert!(rendered.contains("skipped issues:"));

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -25,8 +25,10 @@ cargo run -- agent-session list workflows/jade-symphony.md
 
 Main Agent execution uses the local `tmux` backend. A bounded write tick creates
 an attachable session, prints `tmux attach-session -t ...`, records the session
-log path, and leaves the issue active until real implementation evidence is
-available for the normal handoff path.
+log path, persists a session registry record, and leaves the issue active until
+real implementation evidence is available for the normal handoff path. Status
+commands classify registered tmux sessions from bounded pane/log evidence while
+keeping full scrollback out of routine output.
 The `agent-session` command is the manual tmux recovery path for all lanes:
 `main`, `review`, and `merge` each render their own lane prompt, claim the
 matching Project field, and leave workflow state unchanged until the lane's


### PR DESCRIPTION
Closes #226

## Summary
- Add bounded tmux pane and log-tail probing for registered sessions.
- Add conservative session status classification for starting, running, waiting_for_trust, waiting_for_approval, waiting_for_human_input, usage_limited, failed, completed, stale, and unknown.
- Surface compact tmux session status evidence in runtime/status snapshots and operator docs without dumping raw scrollback.

## Verification
- cargo fmt --check
- cargo test -- --test-threads=1
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- status workflows/jade-symphony.md --json