### PR TITLE
#227: Extend tmux runtime support to Review and Merging lanes

### DIFF
--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -131,6 +131,12 @@ export GEMINI_CLI_TRUST_WORKSPACE=true
 target/debug/jade-symphony review-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
+For supervised manual review terminals, use
+`review-session WORKFLOW '#issue' --write` on an `Agent Review` issue. It uses
+the shared `agent-session` lane path to claim the Review Agent field, start the
+lane-specific review prompt in tmux, and write attach/log evidence without
+moving the issue to `Human Review`.
+
 If Gemini cannot start, the review workpad should name the configured command,
 whether worker `PATH` could resolve it, the required operator action, and the
 retry command. Do not move an issue to `Human Review` unless the Review Agent
@@ -243,6 +249,10 @@ apply lane-specific claim checks. Main work uses the `Main Agent` Project field
 as a soft claim-lock hint while still processing one active runtime issue per
 loop tick. Merge work uses the `Merging Agent` Project field and can process
 multiple guarded merge slots in one bounded loop.
+For supervised merge terminals, use `merge-session WORKFLOW '#issue' --write`
+on a `Merging` issue. It uses the shared `agent-session` lane path to claim the
+`Merging Agent` field, start the merge prompt in tmux, and write attach/log
+evidence without merging the PR or closing the issue.
 
 Operator commands also print compact `Latest:` lines for the current lane,
 issue, category, action, actor, workspace/branch when known, and next expected

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,8 +215,18 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             target_state,
             write,
         } => review_manual_reject(workflow_path, issue_ref, evidence, target_state, write),
+        Command::ReviewSession {
+            workflow_path,
+            issue_ref,
+            write,
+        } => agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Review, write),
         Command::ReviewFreshness { input } => review_freshness(input),
         Command::ReviewLoop { options } => review_loop(options),
+        Command::MergeSession {
+            workflow_path,
+            issue_ref,
+            write,
+        } => agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Merge, write),
         Command::AgentSessionStart {
             workflow_path,
             issue_ref,
@@ -6073,11 +6083,21 @@ enum Command {
         target_state: String,
         write: bool,
     },
+    ReviewSession {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        write: bool,
+    },
     ReviewFreshness {
         input: ReviewFreshnessInput,
     },
     ReviewLoop {
         options: ReviewLoopOptions,
+    },
+    MergeSession {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        write: bool,
     },
     AgentSessionStart {
         workflow_path: PathBuf,
@@ -6311,6 +6331,8 @@ enum CliCommand {
     MergeOnce(MergeOnceArgs),
     #[command(name = "merge-loop")]
     MergeLoop(MergeLoopArgs),
+    #[command(name = "merge-session")]
+    MergeSession(LaneSessionAliasArgs),
     #[command(name = "set-state")]
     SetState(SetStateArgs),
     Workpad(WorkpadArgs),
@@ -6332,6 +6354,8 @@ enum CliCommand {
     ReviewPass(ReviewEvidenceArgs),
     #[command(name = "review-reject")]
     ReviewReject(ReviewRejectArgs),
+    #[command(name = "review-session")]
+    ReviewSession(LaneSessionAliasArgs),
     #[command(name = "review-freshness")]
     ReviewFreshness(ReviewFreshnessArgs),
     #[command(name = "review-loop")]
@@ -6604,6 +6628,17 @@ struct AgentSessionAttachArgs {
     session: String,
     #[arg(long)]
     exec: bool,
+}
+
+#[derive(Debug, Args)]
+struct LaneSessionAliasArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
 }
 
 #[derive(Debug, Args)]
@@ -7066,6 +7101,11 @@ impl TryFrom<Cli> for Command {
                             },
                         })
                     }
+                    CliCommand::MergeSession(args) => Ok(Self::MergeSession {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
+                        write: args.write,
+                    }),
                     CliCommand::SetState(args) => Ok(Self::SetState {
                         workflow_path: args.workflow_path,
                         issue_ref: args.issue_ref,
@@ -7128,6 +7168,11 @@ impl TryFrom<Cli> for Command {
                         issue_ref: args.issue_ref,
                         evidence: read_required_file(args.evidence_file)?,
                         target_state: args.target_state,
+                        write: args.write,
+                    }),
+                    CliCommand::ReviewSession(args) => Ok(Self::ReviewSession {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
                         write: args.write,
                     }),
                     CliCommand::ReviewFreshness(args) => Ok(Self::ReviewFreshness {
@@ -8070,6 +8115,32 @@ mod tests {
                 workflow_path: PathBuf::from("workflows/jade-symphony.md"),
                 session: "jade-review-220".into(),
                 exec: false,
+            }
+        );
+        assert_eq!(
+            parse(&[
+                "review-session",
+                "workflows/jade-symphony.md",
+                "#227",
+                "--write"
+            ]),
+            Command::ReviewSession {
+                workflow_path: PathBuf::from("workflows/jade-symphony.md"),
+                issue_ref: "#227".into(),
+                write: true,
+            }
+        );
+        assert_eq!(
+            parse(&[
+                "merge-session",
+                "workflows/jade-symphony.md",
+                "#227",
+                "--write"
+            ]),
+            Command::MergeSession {
+                workflow_path: PathBuf::from("workflows/jade-symphony.md"),
+                issue_ref: "#227".into(),
+                write: true,
             }
         );
     }

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -19,6 +19,8 @@ cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- forge-interactive --workflow workflows/jade-symphony.md
 cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- merge-once workflows/jade-symphony.md --write
+cargo run -- review-session workflows/jade-symphony.md '#123' --write
+cargo run -- merge-session workflows/jade-symphony.md '#123' --write
 cargo run -- agent-session start workflows/jade-symphony.md '#220' --lane review --write
 cargo run -- agent-session list workflows/jade-symphony.md
 ```
@@ -33,6 +35,9 @@ The `agent-session` command is the manual tmux recovery path for all lanes:
 `main`, `review`, and `merge` each render their own lane prompt, claim the
 matching Project field, and leave workflow state unchanged until the lane's
 normal evidence path is ready.
+`review-session` and `merge-session` are lane-specific shortcuts for the same
+session path. They write attach/log evidence without approving reviews, merging
+PRs, or closing issues.
 
 Lane prompt files:
 


### PR DESCRIPTION
Closes #227

Depends on #236.

## Summary
- Add explicit `review-session` and `merge-session` tmux entrypoints for supervised lane-specific terminals.
- Reuse the tmux backend, session registry, attach command, log path, prompt artifact, and status-classification substrate from #226.
- Preserve Review/Merging authority boundaries: sessions only record attach/log evidence and do not approve reviews, merge PRs, close issues, or move work to Human Review/Done.
- Document the supervised lane commands and add parser/help coverage.

## Verification
- cargo fmt --check
- cargo test -- --test-threads=1
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- review-session --help
- cargo run -- merge-session --help