### PR TITLE
Add CLI authority surfaces for manual review

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -9,6 +9,13 @@ remain the preferred rehearsal path for local development. `doctor` can omit the
 workflow path when `JADE_SYMPHONY_WORKFLOW` is set, or when
 `workflows/jade-symphony.md` exists in the current repo checkout.
 
+For normal dogfood, Jade Symphony CLI is the authority for GitHub Project v2
+workflow reads and mutations. Direct `gh issue view` / `gh pr view` is still
+acceptable for raw issue or PR content, but Project status, Project fields,
+relationships, claim locks, workpads, and state transitions should go through
+the commands in this reference. Manual Project UI or raw Project GraphQL changes
+are break-glass recovery actions, not the standard path.
+
 The canonical `workflows/jade-symphony.md` file is a workflow index/config. It
 references lane-specific prompts in `workflows/prompts/` so Main, Review, and
 Merge commands initialize with their own authority contracts. Older fixture
@@ -26,6 +33,7 @@ workflows may still use an inline prompt body.
 | `validate-workflow` | Compatibility alias for `validate`. | `cargo run -- validate-workflow examples/dry-run-workflow.md` |
 | `inspect` | Read tracker issues and print gate/status information. | `cargo run -- inspect workflows/jade-symphony.md` |
 | `project-state` | Diagnose whether the canonical Project read path is trustworthy. | `cargo run -- project-state workflows/jade-symphony.md` |
+| `project-issue` | Read one issue's normalized Project state, fields, blockers, and linked PRs through Jade Symphony. | `cargo run -- project-issue workflows/jade-symphony.md '#235' --json` |
 | `doctor` | Audit Project/workflow/runtime invariants. | `cargo run -- doctor` |
 | `audit-project` | Compatibility alias for `doctor`. | `cargo run -- audit-project workflows/jade-symphony.md` |
 | `profiles` | List configured/discovered execution profiles. | `cargo run -- profiles examples/cockpit-profiles-workflow.md` |
@@ -188,6 +196,10 @@ changes.
 | `review-fake` | Fixture/fake review transition helper. | Local testing path. |
 | `review-once` | Run one configured review backend for one issue. | Only Review Agent may advance passed reviews to `Human Review`. |
 | `review-loop` | Bounded review worker selection/reconciliation. | Prevents duplicate review workers where evidence exists. |
+| `review-claim` | Claim one `Agent Review` item's `Review Agent` field for manual/operator review. | Requires `--write`; refuses non-`Agent Review` issues. |
+| `review-clear-claim` | Clear one issue's `Review Agent` claim through the tracker adapter. | Requires `--write`; use after terminal manual review routing. |
+| `review-pass` | Record manual independent review pass evidence and move to `Human Review`. | Requires `--write` and a durable evidence file; writes the doctor-recognized pass marker first. |
+| `review-reject` | Record failed/inconclusive manual review evidence and route to `Agent Review`, `Rework`, or `Need Human Input`. | Refuses `Human Review`. |
 | `review-freshness` | Record/inspect review freshness evidence. | Used around merging/rework conflict repair. |
 | `agent-session start` | Start an attachable local tmux session for a selected lane. | Manual recovery path; it claims only the chosen lane and does not advance workflow state. |
 | `agent-session list` | List active Jade tmux sessions by configured prefix. | Read-only operator summary. |
@@ -200,6 +212,9 @@ cargo run -- review-loop examples/review-fixture-workflow.md --max-iterations 1 
 cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- agent-session start workflows/jade-symphony.md '#220' --lane review --write
 cargo run -- agent-session list workflows/jade-symphony.md
+cargo run -- review-claim workflows/jade-symphony.md '#226' --worker "Manual Gemini Review" --write
+cargo run -- review-pass workflows/jade-symphony.md '#226' --evidence-file /tmp/review-evidence.md --write
+cargo run -- review-reject workflows/jade-symphony.md '#226' --evidence-file /tmp/review-evidence.md --target-state rework --write
 ```
 
 ## Merge Lane

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -61,6 +61,10 @@ Project v2 issues:
    - Use `project-state` as the canonical dogfood diagnostic before claim or
      merge work; failed reads print a classified blocker instead of looking like
      an empty queue.
+   - Use `project-issue` for per-issue Project status, fields, claim locks,
+     blockers, and linked PRs. Direct `gh issue view` / `gh pr view` is still
+     allowed for raw issue and PR context, but not for normal Project state
+     reads.
    - Retry transient network and rate-limit failures, and fail partial Project
      payloads loudly when required item fields are missing.
    - Filter to real GitHub Issues, not draft items or PR items.
@@ -72,8 +76,9 @@ Project v2 issues:
 
 2. Harden GitHub tracker writes.
    - Current explicit commands can set ProjectV2 status by option ID,
-     create/update one marker workpad comment, create follow-up issues, and add
-     issues to the configured project.
+     create/update one marker workpad comment, create follow-up issues, add
+     issues to the configured project, claim/clear Review Agent fields, and
+     route manual review pass/reject outcomes.
    - Mutating commands require `--write`.
    - Same-state status updates are treated as no-ops before mutation.
    - PR linking currently uses an issue comment/autolink strategy instead of a
@@ -104,6 +109,10 @@ Project v2 issues:
      `Agent Review` but cannot set `Human Review`.
    - Independent Review Agent commands can set `Human Review` only after a
      passed review with evidence.
+   - Manual/operator review uses `review-claim`, `review-clear-claim`,
+     `review-pass`, and `review-reject` instead of raw Project field edits.
+     `review-pass` writes the doctor-recognized review pass marker before
+     `Human Review`; `review-reject` refuses `Human Review`.
    - Bounded `review-loop` can discover eligible `Agent Review` issues, skip
      existing review-worker markers, select up to the configured concurrent
      worker limit, and apply the same independent Review Agent transition rules

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -158,6 +158,7 @@ promote reusable config into the repo.
 ```bash
 target/debug/jade-symphony inspect workflows/jade-symphony.md
 target/debug/jade-symphony project-state workflows/jade-symphony.md
+target/debug/jade-symphony project-issue workflows/jade-symphony.md '#235' --json
 target/debug/jade-symphony project-state workflows/jade-symphony.md --display tui
 target/debug/jade-symphony doctor workflows/jade-symphony.md --display tui
 target/debug/jade-symphony run-loop workflows/jade-symphony.md --max-iterations 1 --write
@@ -169,6 +170,13 @@ and a state summary. A failed read prints `project_state_access=blocked`,
 `trusted=false`, and a `failure_kind` such as `auth`, `network`, `rate_limit`,
 `schema`, `partial_response`, or `payload`; treat that as a blocker, not as an
 empty queue.
+
+Use `project-issue` for per-issue Project status, Project fields, blocker
+relationships, claim locks, and linked PRs. Raw `gh issue view` and `gh pr view`
+remain acceptable for ordinary issue/PR body text, comments, and diff context,
+but normal dogfood should not read or mutate Project fields, status, claim locks,
+or relationships through raw Project GraphQL or the Project UI. Those are
+break-glass recovery paths.
 
 If `run-loop` finds runtime-state for an issue that has already moved out of
 active main-agent work, it reconciles tracker state first. Clean or absent
@@ -182,6 +190,18 @@ is durable. Project fields named `review_pass_evidence_recorded` or
 current GitHub Project #9 schema, the canonical source is the review workpad text
 written into the issue comment stream. A `Review Agent` claim by itself is not
 pass evidence.
+
+For a manual Gemini/operator review, claim and route through the CLI:
+
+```bash
+target/debug/jade-symphony review-claim workflows/jade-symphony.md '#226' --worker "Manual Gemini Review" --write
+target/debug/jade-symphony review-pass workflows/jade-symphony.md '#226' --evidence-file /tmp/review-evidence.md --write
+target/debug/jade-symphony review-reject workflows/jade-symphony.md '#226' --evidence-file /tmp/review-evidence.md --target-state rework --write
+```
+
+`review-pass` writes the review pass marker before moving to `Human Review`.
+`review-reject` refuses `Human Review` and may route only to `Agent Review`,
+`Rework`, or `Need Human Input`.
 
 ## Artifact Root Migration
 

--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -131,10 +131,21 @@ export GEMINI_CLI_TRUST_WORKSPACE=true
 cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
+For a manual/operator-supplied review, use the same CLI authority boundary
+instead of editing the Project board directly:
+
+```bash
+cargo run -- review-claim workflows/jade-symphony.md '#226' --worker "Manual Gemini Review" --write
+cargo run -- review-pass workflows/jade-symphony.md '#226' --evidence-file /tmp/review-evidence.md --write
+cargo run -- review-reject workflows/jade-symphony.md '#226' --evidence-file /tmp/review-evidence.md --target-state rework --write
+```
+
 Expected outcomes:
 
 - each write-mode Review Agent records a `Review Agent` Project field claim
   before launching the backend;
+- manual review claims use `review-claim`, and terminal manual review routing
+  clears the `Review Agent` claim through the tracker adapter;
 - passed independent review may move the issue to `Human Review`;
 - confirmed findings move the issue to `Rework`;
 - completed but inconclusive automatic review moves to `Rework` with a missing

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,11 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             states,
         } => inspect(workflow_path, states),
         Command::ProjectState { options } => project_state(options),
+        Command::ProjectIssue {
+            workflow_path,
+            issue_ref,
+            json,
+        } => project_issue(workflow_path, issue_ref, json),
         Command::Doctor { options } => doctor(options),
         Command::DoctorRepairHumanReview {
             workflow_path,
@@ -179,6 +184,30 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             issue_ref,
             write,
         } => review_once(workflow_path, issue_ref, write),
+        Command::ReviewClaim {
+            workflow_path,
+            issue_ref,
+            worker,
+            write,
+        } => review_claim(workflow_path, issue_ref, worker, write),
+        Command::ReviewClearClaim {
+            workflow_path,
+            issue_ref,
+            write,
+        } => review_clear_claim(workflow_path, issue_ref, write),
+        Command::ReviewPass {
+            workflow_path,
+            issue_ref,
+            evidence,
+            write,
+        } => review_manual_pass(workflow_path, issue_ref, evidence, write),
+        Command::ReviewReject {
+            workflow_path,
+            issue_ref,
+            evidence,
+            target_state,
+            write,
+        } => review_manual_reject(workflow_path, issue_ref, evidence, target_state, write),
         Command::ReviewFreshness { input } => review_freshness(input),
         Command::ReviewLoop { options } => review_loop(options),
         Command::AgentSessionStart {
@@ -995,6 +1024,308 @@ fn review_once(
         job.backend, decision.outcome, decision.target_state
     );
     println!("{}", decision.message);
+    Ok(())
+}
+
+fn review_claim(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    worker: String,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let issue = adapter
+        .get_issue(&issue_ref)?
+        .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
+    if issue.normalized_state() != "agent review" {
+        return Err(format!(
+            "review claim requires Agent Review state; {} is currently {}",
+            issue.identifier, issue.state
+        )
+        .into());
+    }
+    if !write {
+        println!(
+            "review_claim_dry_run action=claim_field issue_ref={} field=\"Review Agent\" value={worker}",
+            issue.identifier
+        );
+        return Ok(());
+    }
+    adapter.set_project_field(
+        &issue.identifier,
+        &ProjectFieldAssignment {
+            name: "Review Agent".into(),
+            value: worker.clone(),
+        },
+    )?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "review-claim",
+            mutation_type: "claim_field",
+            issue_ref: Some(&issue.identifier),
+            target: Some(format!("Review Agent={worker}")),
+            from_state: Some(issue.state),
+            to_state: None,
+            reason: "manual review agent claim",
+        },
+    );
+    println!(
+        "review_claim=ok issue_ref={} field=\"Review Agent\" value={worker}",
+        issue.identifier
+    );
+    Ok(())
+}
+
+fn review_clear_claim(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let issue = adapter
+        .get_issue(&issue_ref)?
+        .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
+    if !write {
+        println!(
+            "review_clear_claim_dry_run action=clear_claim_field issue_ref={} field=\"Review Agent\"",
+            issue.identifier
+        );
+        return Ok(());
+    }
+    adapter.clear_project_field(&issue.identifier, "Review Agent")?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "review-clear-claim",
+            mutation_type: "claim_field_clear",
+            issue_ref: Some(&issue.identifier),
+            target: Some("Review Agent".into()),
+            from_state: Some(issue.state),
+            to_state: None,
+            reason: "manual review agent claim clear",
+        },
+    );
+    println!(
+        "review_clear_claim=ok issue_ref={} field=\"Review Agent\"",
+        issue.identifier
+    );
+    Ok(())
+}
+
+fn review_manual_pass(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    evidence: String,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let issue = adapter
+        .get_issue(&issue_ref)?
+        .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
+    if issue.normalized_state() != "agent review" {
+        return Err(format!(
+            "manual review pass requires Agent Review state; {} is currently {}",
+            issue.identifier, issue.state
+        )
+        .into());
+    }
+
+    let target_state = "human_review";
+    let workpad = render_manual_review_workpad(&issue, "passed", target_state, &evidence, true);
+    if !write {
+        println!(
+            "review_pass_dry_run action=workpad issue_ref={} evidence=manual_review_pass",
+            issue.identifier
+        );
+        println!(
+            "review_pass_dry_run action=clear_claim_field issue_ref={} field=\"Review Agent\"",
+            issue.identifier
+        );
+        println!(
+            "review_pass_dry_run action=set_state issue_ref={} target_state={target_state}",
+            issue.identifier
+        );
+        return Ok(());
+    }
+    adapter.upsert_workpad(&issue.identifier, &workpad)?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "review-pass",
+            mutation_type: "workpad_write",
+            issue_ref: Some(&issue.identifier),
+            target: None,
+            from_state: Some(issue.state.clone()),
+            to_state: Some(target_state.into()),
+            reason: "manual review pass evidence",
+        },
+    );
+    clear_manual_review_claim(&config, adapter.as_ref(), &issue.identifier, &issue.state)?;
+    adapter.set_state(&issue.identifier, target_state)?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "review-pass",
+            mutation_type: "state_change",
+            issue_ref: Some(&issue.identifier),
+            target: None,
+            from_state: Some(issue.state),
+            to_state: Some(target_state.into()),
+            reason: "manual review pass routing",
+        },
+    );
+    println!(
+        "review_pass=ok issue_ref={} target_state={target_state}",
+        issue.identifier
+    );
+    Ok(())
+}
+
+fn review_manual_reject(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    evidence: String,
+    target_state: String,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let normalized_target = normalize_state(&target_state);
+    if normalized_target == "human_review" {
+        return Err("review-reject cannot target Human Review".into());
+    }
+    if !matches!(
+        normalized_target.as_str(),
+        "agent_review" | "agent review" | "rework" | "need_human_input" | "need human input"
+    ) {
+        return Err(
+            "review-reject target must be agent_review, rework, or need_human_input".into(),
+        );
+    }
+
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let issue = adapter
+        .get_issue(&issue_ref)?
+        .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
+    if issue.normalized_state() != "agent review" {
+        return Err(format!(
+            "manual review reject requires Agent Review state; {} is currently {}",
+            issue.identifier, issue.state
+        )
+        .into());
+    }
+
+    let workpad =
+        render_manual_review_workpad(&issue, "not passed", &target_state, &evidence, false);
+    if !write {
+        println!(
+            "review_reject_dry_run action=workpad issue_ref={} evidence=manual_review_reject",
+            issue.identifier
+        );
+        println!(
+            "review_reject_dry_run action=clear_claim_field issue_ref={} field=\"Review Agent\"",
+            issue.identifier
+        );
+        println!(
+            "review_reject_dry_run action=set_state issue_ref={} target_state={target_state}",
+            issue.identifier
+        );
+        return Ok(());
+    }
+    adapter.upsert_workpad(&issue.identifier, &workpad)?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "review-reject",
+            mutation_type: "workpad_write",
+            issue_ref: Some(&issue.identifier),
+            target: None,
+            from_state: Some(issue.state.clone()),
+            to_state: Some(target_state.clone()),
+            reason: "manual review reject evidence",
+        },
+    );
+    clear_manual_review_claim(&config, adapter.as_ref(), &issue.identifier, &issue.state)?;
+    adapter.set_state(&issue.identifier, &target_state)?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "review-reject",
+            mutation_type: "state_change",
+            issue_ref: Some(&issue.identifier),
+            target: None,
+            from_state: Some(issue.state),
+            to_state: Some(target_state.clone()),
+            reason: "manual review reject routing",
+        },
+    );
+    println!(
+        "review_reject=ok issue_ref={} target_state={target_state}",
+        issue.identifier
+    );
+    Ok(())
+}
+
+fn render_manual_review_workpad(
+    issue: &TrackerIssue,
+    decision: &str,
+    target_state: &str,
+    evidence: &str,
+    pass: bool,
+) -> String {
+    let mut lines = vec![
+        "## Agent Review".to_string(),
+        String::new(),
+        format!("- Issue: {} {}", issue.identifier, issue.title),
+        "- Reviewer backend: manual-operator".into(),
+        format!("- Decision: Manual independent review {decision}."),
+        format!("- Target state: `{target_state}`"),
+        String::new(),
+        "### Manual Review Evidence".into(),
+    ];
+    lines.extend(
+        evidence
+            .trim()
+            .lines()
+            .map(|line| format!("- {}", line.trim()))
+            .collect::<Vec<_>>(),
+    );
+    if pass {
+        lines.push(String::new());
+        lines.push("- Review pass evidence: `recorded`".into());
+        lines.push("Evidence recorded. Independent Review Agent may move this issue to Human Review; the main implementation agent must not.".into());
+    } else {
+        lines.push(String::new());
+        lines.push(
+            "- Review did not pass; unavailable or inconclusive review must not move to Human Review."
+                .into(),
+        );
+    }
+    lines.join("\n")
+}
+
+fn clear_manual_review_claim(
+    config: &RuntimeConfig,
+    adapter: &dyn TrackerAdapter,
+    issue_ref: &str,
+    from_state: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    adapter.clear_project_field(issue_ref, "Review Agent")?;
+    append_tracker_mutation_audit(
+        config,
+        TrackerMutationAudit {
+            command: "manual-review-routing",
+            mutation_type: "claim_field_clear",
+            issue_ref: Some(issue_ref),
+            target: Some("Review Agent".into()),
+            from_state: Some(from_state.into()),
+            to_state: None,
+            reason: "manual review terminal routing",
+        },
+    );
     Ok(())
 }
 
@@ -2296,6 +2627,83 @@ fn project_state(options: ProjectStateOptions) -> Result<(), Box<dyn std::error:
             )
             .into())
         }
+    }
+}
+
+fn project_issue(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let mut issue = adapter
+        .get_issue(&issue_ref)?
+        .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
+    issue.linked_pull_requests = adapter
+        .list_linked_pull_requests(&issue.identifier)
+        .unwrap_or_else(|_| issue.linked_pull_requests.clone());
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&issue)?);
+        return Ok(());
+    }
+
+    println!("issue={}", issue.identifier);
+    println!("title={}", issue.title);
+    println!("state={}", issue.state);
+    println!("tracker={}", issue.tracker_kind);
+    if let Some(item_id) = &issue.item_id {
+        println!("project_item={item_id}");
+    }
+    if !issue.assignees.is_empty() {
+        println!("assignees={}", issue.assignees.join(","));
+    }
+    if !issue.blocked_by.is_empty() {
+        let blockers = issue
+            .blocked_by
+            .iter()
+            .map(|blocker| {
+                blocker
+                    .identifier
+                    .as_deref()
+                    .or(blocker.id.as_deref())
+                    .unwrap_or("unknown")
+                    .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join(",");
+        println!("blocked_by={blockers}");
+    } else {
+        println!("blocked_by=");
+    }
+    if !issue.linked_pull_requests.is_empty() {
+        for pr in &issue.linked_pull_requests {
+            let pr_ref = pr
+                .url
+                .clone()
+                .or_else(|| pr.number.map(|number| format!("#{number}")))
+                .unwrap_or_else(|| "unknown".into());
+            println!(
+                "linked_pr={} state={}",
+                pr_ref,
+                pr.state.as_deref().unwrap_or("unknown")
+            );
+        }
+    }
+    for (name, value) in &issue.project_fields {
+        println!("field.{name}={}", compact_json_value(value));
+    }
+    Ok(())
+}
+
+fn compact_json_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(value) => value.clone(),
+        serde_json::Value::Bool(value) => value.to_string(),
+        serde_json::Value::Number(value) => value.to_string(),
+        serde_json::Value::Null => "null".into(),
+        _ => serde_json::to_string(value).unwrap_or_else(|_| "<unprintable>".into()),
     }
 }
 
@@ -5506,6 +5914,11 @@ enum Command {
     ProjectState {
         options: ProjectStateOptions,
     },
+    ProjectIssue {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        json: bool,
+    },
     Doctor {
         options: DoctorOptions,
     },
@@ -5581,6 +5994,30 @@ enum Command {
     ReviewOnce {
         workflow_path: PathBuf,
         issue_ref: String,
+        write: bool,
+    },
+    ReviewClaim {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        worker: String,
+        write: bool,
+    },
+    ReviewClearClaim {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        write: bool,
+    },
+    ReviewPass {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        evidence: String,
+        write: bool,
+    },
+    ReviewReject {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        evidence: String,
+        target_state: String,
         write: bool,
     },
     ReviewFreshness {
@@ -5799,6 +6236,8 @@ enum CliCommand {
     Inspect(InspectArgs),
     #[command(name = "project-state", alias = "project-state-health")]
     ProjectState(ProjectStateArgs),
+    #[command(name = "project-issue")]
+    ProjectIssue(ProjectIssueArgs),
     #[command(alias = "audit-project")]
     Doctor(DoctorArgs),
     #[command(name = "doctor-repair-human-review")]
@@ -5832,6 +6271,14 @@ enum CliCommand {
     ReviewFake(ReviewFakeArgs),
     #[command(name = "review-once")]
     ReviewOnce(ReviewOnceArgs),
+    #[command(name = "review-claim")]
+    ReviewClaim(ReviewClaimArgs),
+    #[command(name = "review-clear-claim")]
+    ReviewClearClaim(ReviewClearClaimArgs),
+    #[command(name = "review-pass")]
+    ReviewPass(ReviewEvidenceArgs),
+    #[command(name = "review-reject")]
+    ReviewReject(ReviewRejectArgs),
     #[command(name = "review-freshness")]
     ReviewFreshness(ReviewFreshnessArgs),
     #[command(name = "review-loop")]
@@ -5877,6 +6324,19 @@ struct ProjectStateArgs {
     workflow_path: PathBuf,
     #[arg(long, value_enum, default_value_t = CliDisplayMode::Plain)]
     display: CliDisplayMode,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+    #[arg(long = "write")]
+    _write: bool,
+}
+
+#[derive(Debug, Args)]
+struct ProjectIssueArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long)]
+    json: bool,
     #[arg(long = "dry-run")]
     _dry_run: bool,
     #[arg(long = "write")]
@@ -6190,6 +6650,58 @@ struct ReviewOnceArgs {
 }
 
 #[derive(Debug, Args)]
+struct ReviewClaimArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long)]
+    worker: String,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct ReviewClearClaimArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct ReviewEvidenceArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long = "evidence-file")]
+    evidence_file: PathBuf,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct ReviewRejectArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long = "evidence-file")]
+    evidence_file: PathBuf,
+    #[arg(long = "target-state", default_value = "agent_review")]
+    target_state: String,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
 struct ReviewFreshnessArgs {
     #[arg(long = "issue")]
     issue_ref: String,
@@ -6408,6 +6920,11 @@ impl TryFrom<Cli> for Command {
                             display: args.display.into(),
                         },
                     }),
+                    CliCommand::ProjectIssue(args) => Ok(Self::ProjectIssue {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
+                        json: args.json,
+                    }),
                     CliCommand::Doctor(args) => Ok(Self::Doctor {
                         options: DoctorOptions {
                             workflow_path: args.workflow_path,
@@ -6534,6 +7051,30 @@ impl TryFrom<Cli> for Command {
                     CliCommand::ReviewOnce(args) => Ok(Self::ReviewOnce {
                         workflow_path: args.workflow_path,
                         issue_ref: args.issue_ref,
+                        write: args.write,
+                    }),
+                    CliCommand::ReviewClaim(args) => Ok(Self::ReviewClaim {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
+                        worker: args.worker,
+                        write: args.write,
+                    }),
+                    CliCommand::ReviewClearClaim(args) => Ok(Self::ReviewClearClaim {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
+                        write: args.write,
+                    }),
+                    CliCommand::ReviewPass(args) => Ok(Self::ReviewPass {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
+                        evidence: read_required_file(args.evidence_file)?,
+                        write: args.write,
+                    }),
+                    CliCommand::ReviewReject(args) => Ok(Self::ReviewReject {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
+                        evidence: read_required_file(args.evidence_file)?,
+                        target_state: args.target_state,
                         write: args.write,
                     }),
                     CliCommand::ReviewFreshness(args) => Ok(Self::ReviewFreshness {
@@ -7735,6 +8276,83 @@ mod tests {
                 write: true
             }
         );
+    }
+
+    #[test]
+    fn parses_project_issue_read_surface() {
+        assert_eq!(
+            parse(&[
+                "project-issue",
+                "examples/github-project-workflow.md",
+                "#235",
+                "--json"
+            ]),
+            Command::ProjectIssue {
+                workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                issue_ref: "#235".into(),
+                json: true
+            }
+        );
+    }
+
+    #[test]
+    fn parses_manual_review_authority_commands() {
+        assert_eq!(
+            parse(&[
+                "review-claim",
+                "examples/github-project-workflow.md",
+                "#235",
+                "--worker",
+                "Gemini A",
+                "--write"
+            ]),
+            Command::ReviewClaim {
+                workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                issue_ref: "#235".into(),
+                worker: "Gemini A".into(),
+                write: true
+            }
+        );
+
+        assert_eq!(
+            parse(&[
+                "review-clear-claim",
+                "examples/github-project-workflow.md",
+                "#235",
+                "--write"
+            ]),
+            Command::ReviewClearClaim {
+                workflow_path: PathBuf::from("examples/github-project-workflow.md"),
+                issue_ref: "#235".into(),
+                write: true
+            }
+        );
+    }
+
+    #[test]
+    fn manual_review_pass_workpad_records_doctor_evidence_marker() {
+        let issue = tracker_issue("Agent Review");
+        let workpad =
+            render_manual_review_workpad(&issue, "passed", "human_review", "Gemini: pass", true);
+
+        assert!(workpad.contains("Reviewer backend: manual-operator"));
+        assert!(workpad.contains("Review pass evidence: `recorded`"));
+        assert!(workpad.contains("main implementation agent must not"));
+    }
+
+    #[test]
+    fn manual_review_reject_workpad_does_not_record_pass_marker() {
+        let issue = tracker_issue("Agent Review");
+        let workpad = render_manual_review_workpad(
+            &issue,
+            "not passed",
+            "agent_review",
+            "Gemini: inconclusive",
+            false,
+        );
+
+        assert!(!workpad.contains("Review pass evidence: `recorded`"));
+        assert!(workpad.contains("must not move to Human Review"));
     }
 
     #[test]

--- a/workflows/prompts/main-agent.md
+++ b/workflows/prompts/main-agent.md
@@ -14,9 +14,10 @@ preserve prior evidence unless it is stale or incorrect.
 ## Mission
 
 You are the main implementation agent for Jade Symphony. Use GitHub Project v2
-project #9 as the tracker state machine and implement the current issue exactly
-as contracted. Jade Symphony is orchestration infrastructure, not downstream
-product business logic.
+project #9 as the tracker state machine, with Jade Symphony CLI as the authority
+for Project reads and mutations. Implement the current issue exactly as
+contracted. Jade Symphony is orchestration infrastructure, not downstream product
+business logic.
 
 This lane owns implementation only. It may claim `Todo` or `Rework`, create one
 workspace, one branch, and one PR, and then stop at `Agent Review`. It does not
@@ -42,8 +43,11 @@ question, but do not edit files under
 
 ## Operating Loop
 
-1. Refresh tracker state, linked PR state, local git state, and any existing
-   issue workpad before implementation.
+1. Refresh tracker state, Project fields, claim locks, linked PR state, local
+   git state, and any existing issue workpad through Jade Symphony CLI before
+   implementation. Direct `gh issue view` / `gh pr view` is acceptable for raw
+   issue and PR content, but do not use raw Project GraphQL or the Project UI
+   for normal Project state reads or mutations.
 2. Confirm the issue is still executable with the Issue Quality Gate. If the
    issue is not executable, leave a precise workpad note, move it to
    `Need to Clarify`, and stop this issue. The gate must include explicit

--- a/workflows/prompts/merge-agent.md
+++ b/workflows/prompts/merge-agent.md
@@ -13,6 +13,10 @@ approval boundaries. The Merge Agent consumes `Merging` issues only. It checks
 the linked PR, records evidence, merges only clean and authorized PRs, closes
 the issue when supported, and routes blockers with a clear workpad.
 
+Use Jade Symphony CLI for Project state, Project fields, claim locks, workpad
+updates, and merge routing. Direct GitHub PR reads are acceptable for raw PR
+context, but raw Project GraphQL or Project UI changes are break-glass only.
+
 ## Current Issue Contract
 
 {{ issue.description }}

--- a/workflows/prompts/review-agent.md
+++ b/workflows/prompts/review-agent.md
@@ -13,6 +13,10 @@ only: inspect the linked PR, check the workpad evidence, classify findings, and
 route the issue according to the review result. Do not implement unrelated code
 changes while acting as the Review Agent.
 
+Use Jade Symphony CLI for Project state, Project fields, claim locks, workpad
+updates, and review routing. Direct GitHub issue/PR reads are acceptable for raw
+context, but raw Project GraphQL or Project UI changes are break-glass only.
+
 ## Current Issue Contract
 
 {{ issue.description }}
@@ -20,6 +24,8 @@ changes while acting as the Review Agent.
 ## Review Contract
 
 - Confirm the issue is in `Agent Review` before starting review.
+- Claim `Review Agent` through `review-claim` or the configured `review-loop`
+  before starting manual or automated review work.
 - Confirm there is one clear PR or handoff target.
 - Compare the PR against the issue goal, guardrails, expected outcome, and
   verification evidence.
@@ -30,9 +36,9 @@ changes while acting as the Review Agent.
 ## Allowed Transitions
 
 - If review passes and evidence is recorded, the Review Agent may move the issue
-  to `Human Review`.
+  to `Human Review` through `review-pass` or the configured review command.
 - If confirmed findings require implementation work, move the issue to `Rework`
-  with the finding summary and reproduction evidence.
+  with the finding summary and reproduction evidence through `review-reject`.
 - If review cannot complete because of missing PR evidence, unavailable review
   backend, credentials, or an ambiguous decision, keep the issue out of
   `Human Review` and record the next operator action.


### PR DESCRIPTION
## Summary

- Add `project-issue` as the CLI read surface for per-issue Project state, fields, blockers, claim locks, and linked PRs.
- Add manual Review Agent CLI surfaces: `review-claim`, `review-clear-claim`, `review-pass`, and `review-reject`, including dry-run previews and audit/workpad evidence.
- Update operator docs and lane prompts so Project reads/mutations go through Jade Symphony CLI; direct issue/PR reads remain allowed for raw context.

## Verification

- `cargo fmt --check`
- `cargo test --quiet`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- project-issue workflows/jade-symphony.md '#235' --json`
- `cargo run -- review-claim workflows/jade-symphony.md '#226' --worker 'Manual Gemini Review' --dry-run`
- `cargo run -- review-pass workflows/jade-symphony.md '#226' --evidence-file /private/tmp/jade-symphony-review-evidence-smoke.md --dry-run`
- `cargo run -- review-reject workflows/jade-symphony.md '#226' --evidence-file /private/tmp/jade-symphony-review-evidence-smoke.md --target-state human_review --dry-run` failed as expected with `review-reject cannot target Human Review`
- `cargo run -- set-state workflows/jade-symphony.md '#235' human_review --write` failed as expected with `main implementation agent cannot set Human Review`
- `cargo run -- project-state workflows/jade-symphony.md`
- `cargo run -- doctor workflows/jade-symphony.md`

Closes #235
