### PR TITLE
#228: Surface tmux session supervision in operator flows

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -110,6 +110,10 @@ Agent`, or `Merging Agent`), and records session evidence in the workpad.
 `agent-session list WORKFLOW` shows active tmux sessions with attach commands,
 and `agent-session attach WORKFLOW SESSION` prints the exact attach command
 without joining the terminal unless `--exec` is provided.
+`status` and `status-api` include registered tmux session summaries from the
+durable session registry. `doctor` flags stale, failed, orphaned, usage-limited,
+or runtime/session mismatch cases, while `clean audit` classifies the registry,
+rendered prompts, tmux logs, and individual sessions without deleting them.
 
 ## Tracker Writes
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -101,6 +101,10 @@ and log tails, and reports a conservative session classification such as
 `failed`, `completed`, `stale`, or `unknown`. The status surface includes only
 compact evidence snippets plus attach/log locations; attach manually when raw
 scrollback is needed.
+`doctor` reads the same registry and reports stale, orphaned, or attention
+requiring sessions next to tracker/runtime findings. `clean audit` treats the
+session registry, rendered prompts, and tmux logs as recovery evidence, and only
+classifies completed sessions as cleanup candidates.
 If an operator switches the workflow back to `agent.backend: dry-run`, the
 mutating tick exits before runtime-state writes, worktree creation, Project
 claims, or workpad mutation.
@@ -243,6 +247,18 @@ target/debug/jade-symphony clean audit workflows/jade-symphony.md
 `promote_to_repo`, `attach_to_tracker`, `safe_to_keep`, `cleanup_candidate`, or
 `needs_human_decision`. Keep `doctor` for tracker/runtime invariants and stuck
 workflow states.
+
+Interrupted tmux recovery flow:
+
+1. Run `target/debug/jade-symphony status workflows/jade-symphony.md` and read
+   the `tmux sessions` section for the session status, attach command, and log.
+2. Run `target/debug/jade-symphony doctor workflows/jade-symphony.md` before
+   retrying or clearing runtime state; stale, failed, usage-limited, or
+   unattributed sessions require operator inspection.
+3. Run `target/debug/jade-symphony clean audit workflows/jade-symphony.md` only
+   after evidence is preserved. Active or uncertain sessions stay
+   `needs_human_decision`; completed sessions and terminal clean worktrees may
+   become cleanup candidates.
 
 For supervised parallel operators, pass `--pool N` to preview eligible slots and
 apply lane-specific claim checks. Main work uses the `Main Agent` Project field

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::model::{normalize_state, LinkedPullRequest, TrackerIssue};
+use crate::model::{normalize_state, LinkedPullRequest, SessionStatusSnapshot, TrackerIssue};
 use crate::runtime_state::{detect_runtime_stall, RuntimeState};
 
 pub const HUMAN_REVIEW_MISSING_REVIEW_EVIDENCE: &str = "human_review_missing_review_evidence";
@@ -46,6 +46,7 @@ impl ProjectAuditReport {
 #[derive(Debug, Clone)]
 pub struct ProjectDoctorContext {
     pub runtime_state: Option<RuntimeState>,
+    pub sessions: Vec<SessionStatusSnapshot>,
     pub now_ms: u64,
     pub stale_after_ms: u64,
 }
@@ -163,6 +164,10 @@ pub fn audit_project_issues_with_context(
         if let Some(context) = context {
             audit_runtime_consistency(issue, &state, context, &mut violations);
         }
+    }
+
+    if let Some(context) = context {
+        audit_session_consistency(issues, context, &mut violations);
     }
 
     ProjectAuditReport {
@@ -459,6 +464,174 @@ fn audit_runtime_consistency(
     }
 }
 
+fn audit_session_consistency(
+    issues: &[TrackerIssue],
+    context: &ProjectDoctorContext,
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    for session in &context.sessions {
+        let status = session.status.trim();
+        let issue = session
+            .issue_identifier
+            .as_deref()
+            .and_then(|identifier| find_issue_by_ref(issues, identifier));
+
+        if session
+            .issue_identifier
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .is_empty()
+        {
+            violations.push(session_violation(
+                session,
+                "tmux_session_missing_issue",
+                "Registered tmux session has no issue identifier.",
+                "Inspect the session registry and attach/log evidence before cleaning or reusing the session.",
+            ));
+            continue;
+        }
+
+        let Some(issue) = issue else {
+            violations.push(session_violation(
+                session,
+                "tmux_session_orphaned_issue",
+                "Registered tmux session points at an issue that is not present in the current Project read.",
+                "Inspect the registry entry, tracker state, and worktree before cleaning or reassigning the session.",
+            ));
+            continue;
+        };
+
+        if status == "stale" {
+            violations.push(violation(
+                issue,
+                AuditSeverity::Warning,
+                "tmux_session_stale",
+                &format!(
+                    "Registered tmux session `{}` is stale: {}.",
+                    session.session_id, session.evidence
+                ),
+                "Attach to the session or inspect its log before clearing runtime state or cleaning artifacts.",
+            ));
+        } else if session_status_needs_operator(status) {
+            violations.push(violation(
+                issue,
+                AuditSeverity::Warning,
+                "tmux_session_needs_operator_attention",
+                &format!(
+                    "Registered tmux session `{}` is `{}` from {} evidence.",
+                    session.session_id, session.status, session.evidence_source
+                ),
+                "Use the recorded attach command or log path to decide whether to resume, retry, or route the issue with evidence.",
+            ));
+        }
+
+        if session_status_active(status) && normalize_state(&issue.state) == "done" {
+            violations.push(violation(
+                issue,
+                AuditSeverity::Warning,
+                "tmux_session_active_for_terminal_issue",
+                &format!(
+                    "Registered tmux session `{}` still appears active for a Done issue.",
+                    session.session_id
+                ),
+                "Confirm the session is finished and evidence is preserved before cleanup.",
+            ));
+        }
+    }
+
+    let Some(runtime_state) = context.runtime_state.as_ref() else {
+        return;
+    };
+    let Some(active_issue) = runtime_state.active_issue.as_ref() else {
+        return;
+    };
+    let Some(runtime_session_id) = runtime_state.backend_session_id.as_deref() else {
+        return;
+    };
+    let Some(issue) = find_issue_by_ref(issues, &active_issue.identifier) else {
+        return;
+    };
+    let matching_session = context
+        .sessions
+        .iter()
+        .find(|session| session.session_id == runtime_session_id);
+    let Some(session) = matching_session else {
+        violations.push(violation(
+            issue,
+            AuditSeverity::Warning,
+            "runtime_session_missing_registry",
+            "Runtime state references a tmux session that is missing from the session registry.",
+            "Inspect runtime-state.json and tmux sessions before clearing or retrying the run.",
+        ));
+        return;
+    };
+    if session
+        .issue_identifier
+        .as_deref()
+        .is_some_and(|identifier| !issue_refs_match(identifier, &active_issue.identifier))
+    {
+        violations.push(violation(
+            issue,
+            AuditSeverity::Warning,
+            "runtime_session_issue_mismatch",
+            "Runtime state active issue and registered tmux session issue do not match.",
+            "Inspect both records before dispatching another worker or cleaning artifacts.",
+        ));
+    }
+}
+
+fn session_status_active(status: &str) -> bool {
+    matches!(
+        status,
+        "starting"
+            | "running"
+            | "waiting_for_trust"
+            | "waiting_for_approval"
+            | "waiting_for_human_input"
+            | "usage_limited"
+            | "unknown"
+    )
+}
+
+fn session_status_needs_operator(status: &str) -> bool {
+    matches!(
+        status,
+        "waiting_for_trust"
+            | "waiting_for_approval"
+            | "waiting_for_human_input"
+            | "usage_limited"
+            | "failed"
+            | "unknown"
+    )
+}
+
+fn session_violation(
+    session: &SessionStatusSnapshot,
+    code: &str,
+    message: &str,
+    suggestion: &str,
+) -> ProjectAuditViolation {
+    ProjectAuditViolation {
+        issue_ref: format!("session:{}", session.session_id),
+        title: session
+            .issue_title
+            .clone()
+            .unwrap_or_else(|| "Unattributed tmux session".into()),
+        state: session.status.clone(),
+        severity: AuditSeverity::Warning,
+        code: code.into(),
+        message: message.into(),
+        suggestion: suggestion.into(),
+    }
+}
+
+fn find_issue_by_ref<'a>(issues: &'a [TrackerIssue], issue_ref: &str) -> Option<&'a TrackerIssue> {
+    issues
+        .iter()
+        .find(|issue| issue_refs_match(&issue.identifier, issue_ref))
+}
+
 fn bool_project_field(issue: &TrackerIssue, key: &str) -> bool {
     issue
         .project_fields
@@ -565,8 +738,24 @@ mod tests {
         runtime_state.updated_at_ms = Some(updated_at_ms);
         ProjectDoctorContext {
             runtime_state: Some(runtime_state),
+            sessions: Vec::new(),
             now_ms: 20_000,
             stale_after_ms: 10_000,
+        }
+    }
+
+    fn session(identifier: Option<&str>, status: &str) -> SessionStatusSnapshot {
+        SessionStatusSnapshot {
+            session_id: "jade-main-202-attempt-1-runtime".into(),
+            lane: "main".into(),
+            status: status.into(),
+            evidence_source: "registry".into(),
+            evidence: "registry record has not updated for 19000ms".into(),
+            issue_identifier: identifier.map(str::to_string),
+            issue_title: Some("Runtime session".into()),
+            attach_command: Some("tmux attach-session -t jade-main-202-attempt-1-runtime".into()),
+            log_path: Some("/tmp/jade/logs/tmux/jade-main-202-attempt-1-runtime.log".into()),
+            updated_at_ms: 1_000,
         }
     }
 
@@ -825,5 +1014,47 @@ mod tests {
             .violations
             .iter()
             .any(|violation| violation.code == "runtime_active_issue_disagrees"));
+    }
+
+    #[test]
+    fn reports_stale_tmux_session_for_matching_issue() {
+        let issue = issue("#202", "In Progress");
+        let mut context = runtime_context("#202", 19_000);
+        context.sessions = vec![session(Some("#202"), "stale")];
+
+        let report = audit_project_issues_with_context(&[issue], Some(&context));
+
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.code == "tmux_session_stale"));
+    }
+
+    #[test]
+    fn reports_runtime_session_missing_registry() {
+        let issue = issue("#202", "In Progress");
+        let mut context = runtime_context("#202", 19_000);
+        context.runtime_state.as_mut().unwrap().backend_session_id = Some("missing-session".into());
+
+        let report = audit_project_issues_with_context(&[issue], Some(&context));
+
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.code == "runtime_session_missing_registry"));
+    }
+
+    #[test]
+    fn reports_unattributed_tmux_session() {
+        let context = ProjectDoctorContext {
+            runtime_state: None,
+            sessions: vec![session(None, "running")],
+            now_ms: 20_000,
+            stale_after_ms: 10_000,
+        };
+
+        let report = audit_project_issues_with_context(&[], Some(&context));
+
+        assert_eq!(report.violations[0].code, "tmux_session_missing_issue");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2833,8 +2833,16 @@ fn doctor(options: DoctorOptions) -> Result<(), Box<dyn std::error::Error>> {
             None
         }
     };
+    let sessions = match session_status_snapshots(&config) {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            integration_gaps.push(format!("tmux_session_status_unavailable: {error}"));
+            Vec::new()
+        }
+    };
     let context = ProjectDoctorContext {
         runtime_state,
+        sessions,
         now_ms: current_time_ms(),
         stale_after_ms: options.stale_after_ms,
     };
@@ -3338,10 +3346,20 @@ fn clean_audit_command(workflow_path: PathBuf) -> Result<(), Box<dyn std::error:
     let terminal_issues = adapter.fetch_issues_by_states(&config.tracker.terminal_states)?;
     let layout = artifact_layout(&config);
     let plan = cleanup_plan(&config, &terminal_issues);
+    let sessions = session_status_snapshots(&config).unwrap_or_else(|error| {
+        println!("clean_audit_warning kind=tmux_session_status reason={error}");
+        Vec::new()
+    });
 
     println!("clean_audit=read_only");
     println!("artifact_root={}", layout.root.display());
     println!("workspace_root={}", config.workspace.root.display());
+    print_clean_audit_path(
+        "safe_to_keep",
+        "session_registry",
+        session_registry_path(&config),
+        "durable tmux session evidence until session state is reconciled",
+    );
     print_clean_audit_path(
         "safe_to_keep",
         "runtime_state",
@@ -3353,6 +3371,18 @@ fn clean_audit_command(workflow_path: PathBuf) -> Result<(), Box<dyn std::error:
         "event_log",
         layout.class_path(ArtifactClass::EventLog),
         "local execution evidence",
+    );
+    print_clean_audit_path(
+        "attach_to_tracker",
+        "rendered_agent_prompt",
+        config.observability.logs_root.join("prompts"),
+        "prompt artifacts should stay available until tracker evidence names the run",
+    );
+    print_clean_audit_path(
+        "safe_to_keep",
+        "tmux_log",
+        config.observability.logs_root.join("tmux"),
+        "tmux logs are operator recovery evidence for interrupted sessions",
     );
     print_clean_audit_path(
         "safe_to_keep",
@@ -3405,6 +3435,27 @@ fn clean_audit_command(workflow_path: PathBuf) -> Result<(), Box<dyn std::error:
                 candidate.issue_identifier,
                 candidate.path.display(),
                 clean_audit_blocker_summary(candidate)
+            );
+        }
+    }
+    for session in &sessions {
+        if session.status == "completed" {
+            cleanup_candidates += 1;
+            println!(
+                "clean_audit_item category=cleanup_candidate kind=tmux_session issue={} session={} log={} prompt=unknown reason=session_completed_and_registry_evidence_present",
+                session.issue_identifier.as_deref().unwrap_or("n/a"),
+                session.session_id,
+                session.log_path.as_deref().unwrap_or("n/a")
+            );
+        } else {
+            human_decisions += 1;
+            println!(
+                "clean_audit_item category=needs_human_decision kind=tmux_session issue={} session={} status={} attach={} log={} reason=session_not_completed",
+                session.issue_identifier.as_deref().unwrap_or("n/a"),
+                session.session_id,
+                session.status,
+                session.attach_command.as_deref().unwrap_or("n/a"),
+                session.log_path.as_deref().unwrap_or("n/a")
             );
         }
     }


### PR DESCRIPTION
Closes #228

## Summary

- wires registered tmux session snapshots into `doctor` checks for stale, orphaned, attention-required, and runtime/session mismatch cases
- extends `clean audit` to classify the session registry, rendered prompts, tmux logs, and individual session records without deleting anything
- documents the operator recovery path across `status`, `doctor`, and `clean audit`

## Verification

- `cargo fmt --check`
- `cargo test -- --test-threads=1`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- status workflows/jade-symphony.md`
- `cargo run -- doctor workflows/jade-symphony.md`
- `cargo run -- clean audit workflows/jade-symphony.md`

## Boundary

This keeps cleanup read-only and keeps doctor diagnostic-only. It does not bypass review or merge lane authority.
