### PR TITLE
Restructure Forge CLI command group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jade-symphony"
 version = "0.1.0"
 edition = "2021"
-description = "Rust implementation of an OpenAI Symphony-style orchestration harness with Jade extensions"
+description = "Rust implementation of an OpenAI Symphony-style orchestration harness with Jade Symphony extensions"
 license = "Apache-2.0"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It helps an operator turn tracked engineering work into isolated agent
 workspaces, pull requests, independent review passes, and guarded merge
 decisions without losing the human control points that make the process safe.
 
-The project is an OpenAI Symphony-style Rust implementation with Jade-specific
+The project is an OpenAI Symphony-style Rust implementation with Jade Symphony-specific
 extensions for tracker-driven team workflows. It is inspired by the official
 OpenAI Symphony specification and reference implementation, and extends that
 lineage with GitHub Project v2 / Linear state machines, issue quality gates,
@@ -153,18 +153,15 @@ authority rules:
 
 ## Issue Forge
 
-Issue Forge helps turn rough operator intent into executable issue contracts.
-It can discover local candidates, ask focused clarification questions, validate
-Markdown against the issue template, repair thin drafts, and create tracker
-issues only when the operator explicitly confirms the write path.
+Issue Forge turns complete issue bodies into Project-aware tracker mutations.
+Conversation, reflection, and draft repair now live in Codex skills; the Jade Symphony CLI stays deterministic and scriptable.
 
 Typical dry-run entrypoints:
 
 ```bash
-cargo run -- forge-discover --intent "Add review timeout recovery"
-cargo run -- forge-interactive --workflow workflows/jade-symphony.md
-cargo run -- forge-validate --title "Thin issue" --file examples/fixtures/thin-issue.md
-cargo run -- forge-repair --title "Thin issue" --file examples/fixtures/thin-issue.md
+cargo run -- forge validate --status Backlog --title "Backlog seed" --body-file examples/fixtures/repaired-issue.md
+cargo run -- forge validate --status Todo --title "Executable issue" --body-file examples/fixtures/repaired-issue.md
+cargo run -- forge create --status Backlog --title "Backlog: follow-up" --body-file examples/fixtures/repaired-issue.md --dry-run
 ```
 
 Tracker creation requires explicit write flags, an assignee, and project
@@ -187,7 +184,7 @@ selection. See the command reference before using live creation:
   capability inventory and parity status.
 - [`docs/artifact-storage-policy.md`](docs/artifact-storage-policy.md):
   durable, recoverable, and disposable artifact policy.
-- [`docs/bootstrap/`](docs/bootstrap/): Jade extension spec, workflow notes,
+- [`docs/bootstrap/`](docs/bootstrap/): Jade Symphony extension spec, workflow notes,
   parity references, and official Symphony source index.
 - [`examples/`](examples/): fixture workflows and safe local examples.
 

--- a/docs/bootstrap/JADE_SYMPHONY_SPEC.md
+++ b/docs/bootstrap/JADE_SYMPHONY_SPEC.md
@@ -6,7 +6,7 @@ Status: Bootstrap v0
 
 Jade Symphony is a private-first team harness for orchestrating coding agents
 against tracked engineering work. It is a Rust implementation of an
-OpenAI-Symphony-style orchestration system with Jade-specific workflow
+OpenAI-Symphony-style orchestration system with Jade Symphony-specific workflow
 extensions.
 
 This document is an extension spec. It does not replace the official OpenAI
@@ -23,7 +23,7 @@ Source order:
 2. `docs/bootstrap/references/openai-symphony/elixir/README.md`
 3. `docs/bootstrap/references/openai-symphony/elixir/WORKFLOW.md`
 4. `docs/bootstrap/references/openai-symphony/elixir/lib/`
-5. Jade-specific bootstrap docs in `docs/bootstrap/`
+5. Jade Symphony-specific bootstrap docs in `docs/bootstrap/`
 
 `SPEC.md` is the normative protocol baseline. The Elixir implementation is the
 feature-parity baseline. Jade Symphony may use different Rust architecture, but
@@ -62,7 +62,7 @@ Jade Symphony does not need to copy Elixir module structure or Phoenix
 implementation details. It does need to preserve the operational capability
 unless the parity roadmap records a deliberate difference.
 
-## Jade Extensions
+## Jade Symphony Extensions
 
 Jade Symphony adds these workflow capabilities on top of the official baseline:
 

--- a/docs/bootstrap/JADE_WORKFLOW.md
+++ b/docs/bootstrap/JADE_WORKFLOW.md
@@ -1,8 +1,8 @@
-# Jade Workflow
+# Jade Symphony Workflow
 
 Status: Bootstrap v0
 
-This file describes the Jade-specific workflow policy. It should be used after
+This file describes the Jade Symphony-specific workflow policy. It should be used after
 reading the official reference workflow at:
 
 `docs/bootstrap/references/openai-symphony/elixir/WORKFLOW.md`
@@ -18,7 +18,7 @@ Jade Symphony keeps the official Symphony shape:
 - update tracker/workpad.
 - reconcile state.
 
-Jade-specific additions are:
+Jade Symphony-specific additions are:
 
 - GitHub Project v2 as the first tracker.
 - assignee filtering for multiple owners.

--- a/docs/bootstrap/OFFICIAL_REFERENCE_INDEX.md
+++ b/docs/bootstrap/OFFICIAL_REFERENCE_INDEX.md
@@ -16,13 +16,13 @@ submodule for source-faithful bootstrap work.
 - `docs/bootstrap/references/openai-symphony/SPEC.md`
 
 Use this as the protocol baseline. If Jade Symphony diverges, document the
-divergence explicitly in Jade-specific docs.
+divergence explicitly in Jade Symphony-specific docs.
 
 ## Official Reference Workflow
 
 - `docs/bootstrap/references/openai-symphony/elixir/WORKFLOW.md`
 
-Use this as the source-faithful workflow reference. Jade-specific workflow
+Use this as the source-faithful workflow reference. Jade Symphony-specific workflow
 changes belong in `docs/bootstrap/JADE_WORKFLOW.md`, not inside the upstream
 file.
 

--- a/docs/bootstrap/README.md
+++ b/docs/bootstrap/README.md
@@ -8,7 +8,7 @@ private-first team harness for orchestrating coding agents.
 - Official OpenAI Symphony material lives under
   `docs/bootstrap/references/openai-symphony` as a Git submodule.
 - Do not edit the official submodule directly.
-- Jade-specific interpretation and implementation decisions live in this
+- Jade Symphony-specific interpretation and implementation decisions live in this
   directory.
 - Future implementation code should live outside `docs/bootstrap`.
 

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -103,7 +103,7 @@ Project fields, or writing workpads.
 
 When the tmux agent command is Codex, `run-loop --write` captures the pane before
 prompt injection. The default behavior auto-advances the Codex workspace trust
-prompt only inside the configured Jade issue worktree root, then injects the
+prompt only inside the configured Jade Symphony issue worktree root, then injects the
 rendered prompt after a ready viewport is observed. Set
 `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` to opt out; a visible trust prompt or missing
 readiness then fails closed and preserves attach/log evidence for inspection.
@@ -130,7 +130,7 @@ These commands can mutate live tracker state and require `--write`.
 | --- | --- | --- |
 | `set-state` | Move one issue to a normalized workflow state. | Refuses `Human Review` from the main implementation role. |
 | `workpad` | Upsert the canonical issue workpad comment. | Use for durable evidence before state transitions. |
-| `create-follow-up` | Create a follow-up issue from a body file. | Lower-level creation path; prefer `forge-create` for quality-gated issues. |
+| `create-follow-up` | Create a follow-up issue from a body file. | Lower-level creation path; prefer `forge create` for quality-gated issues. |
 | `add-to-project` | Add an existing GitHub issue node to the configured Project. | Initializes configured Project status where supported. |
 
 Examples:
@@ -177,23 +177,18 @@ cargo run -- gate-apply workflows/jade-symphony.md '#123' --write
 
 | Command | Purpose | Boundary |
 | --- | --- | --- |
-| `forge-discover` | Discover local candidate issue intent from free text. | Read-only. |
-| `forge-discuss` | Ask focused clarification for a draft issue. | Read-only. |
-| `forge-draft` | Build a quality-template issue draft from title/goal. | Read-only. |
-| `forge-validate` | Validate an issue body against the quality gate. | Read-only. |
-| `forge-repair` | Repair thin Markdown into an executable issue shape. | Read-only. |
-| `forge-interactive` | Conversation-first issue shaping from natural-language intent. | Starts with only `--workflow`; creation requires `--write --confirm-create --assignee`. |
-| `forge-reflect` | Reflect over local context and print candidate issues. | Read-only. |
-| `forge-create` | Create a quality-gated tracker issue. | Requires explicit `--write`; live GitHub creation requires `--assignee`; can add to Project with `--add-to-project`. |
+| `forge validate` | Validate a body file or existing issue for `Backlog` or `Todo`. | Read-only; `Todo` uses the full Issue Quality Gate, `Backlog` uses the lighter seed gate. |
+| `forge create` | Create a Project-backed issue in `Backlog` or `Todo`. | Dry-run by default unless `--write` is supplied; live `Todo` creation requires `--assignee`. |
+| `forge promote` | Promote one existing Backlog issue in place by editing title/body and moving it to `Todo`. | Dry-run by default unless `--write` is supplied; reports the checkpoint where any failure stopped. |
 
 Examples:
 
 ```bash
-cargo run -- forge-validate --title "Thin Forge issue" --file examples/fixtures/thin-issue.md
-cargo run -- forge-interactive --workflow workflows/jade-symphony.md
-cargo run -- forge-interactive --workflow workflows/jade-symphony.md --intent "make run-loop explain retry backoff better"
-cargo run -- forge-reflect --context-file docs/dogfood-readiness.md --limit 1
-cargo run -- forge-create --workflow workflows/jade-symphony.md --title "Follow-up title" --file /tmp/issue.md --assignee Alive24 --add-to-project --write
+cargo run -- forge validate --workflow workflows/jade-symphony.md --status Backlog --title "Backlog seed" --body-file /tmp/issue.md
+cargo run -- forge validate --workflow workflows/jade-symphony.md --status Todo --title "Executable issue" --body-file /tmp/issue.md
+cargo run -- forge create --workflow workflows/jade-symphony.md --status Backlog --title "Backlog: follow-up title" --body-file /tmp/issue.md --dry-run
+cargo run -- forge create --workflow workflows/jade-symphony.md --status Todo --title "Follow-up title" --body-file /tmp/issue.md --assignee Alive24 --write
+cargo run -- forge promote '#241' --workflow workflows/jade-symphony.md --title "Executable title" --body-file /tmp/issue.md --dry-run
 ```
 
 ## Review Agent Lane
@@ -213,7 +208,7 @@ changes.
 | `review-reject` | Record failed/inconclusive manual review evidence and route to `Agent Review`, `Rework`, or `Need Human Input`. | Refuses `Human Review`. |
 | `review-freshness` | Record/inspect review freshness evidence. | Used around merging/rework conflict repair. |
 | `agent-session start` | Start an attachable local tmux session for a selected lane. | Manual recovery path; it claims only the chosen lane and does not advance workflow state. |
-| `agent-session list` | List active Jade tmux sessions by configured prefix. | Read-only operator summary. |
+| `agent-session list` | List active Jade Symphony tmux sessions by configured prefix. | Read-only operator summary. |
 | `agent-session attach` | Print or execute the tmux attach command for one session. | Defaults to printing the command; `--exec` enters tmux. |
 
 Example:

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -3,7 +3,7 @@
 Status: native tmux supervision dogfood baseline with read-only GitHub Project v2
 loading through the `gh` CLI and a `run-loop` skeleton that can launch
 attachable lane sessions without treating session creation as completion.
-The live GitHub Project workflow now carries a real Jade operating prompt, but
+The live GitHub Project workflow now carries a real Jade Symphony operating prompt, but
 Jade Symphony is not ready for unattended live GitHub Project v2 execution yet.
 
 ## Current Capability Status
@@ -17,11 +17,11 @@ Jade Symphony is not ready for unattended live GitHub Project v2 execution yet.
 | GitHub Project v2 tracker | Fixture-backed mode plus live loading and explicit write operations through `gh api graphql`. `run-loop` can coordinate existing primitives, idle-poll in unbounded write mode, and use claim decision helpers before write-mode dispatch; auth diagnostics distinguish fixture mode, env-token auth, usable `gh api graphql` auth, missing `gh`, and unusable auth. Same-state status writes are skipped, Project item addition initializes the configured `Status` field to `Todo`, marker workpad upsert is idempotent for the canonical marker, and claim decision helpers distinguish claimable, active, and externally changed states. Full claim reconciliation is not implemented yet. |
 | Linear tracker | Implemented behind the same trait for fixture-backed planning plus live GraphQL reads, state updates, marker workpad comments, follow-up issue creation, and project assignment. Credential-gated smoke coverage is still missing. |
 | Issue Quality Gate | Implemented as a Markdown contract check plus deterministic source-alignment preflight where workflow/repo context is available. It verifies the template `UAT Required` field, relationship-first dependency semantics, target repository, referenced local paths, and supported verification command shapes. Structured `blocked_by` tracker relationships are authoritative for dispatch blocking; missing Markdown dependency boilerplate no longer blocks otherwise independent work, while body-only blocker claims still require clarification or a structured relationship. Optional local command-backed LLM gate mode exists as disabled/advisory/required; richer semantic validation and hosted providers are still follow-ups. |
-| Issue Forge | Local CLI flows exist for discover, discuss, draft, validate, repair, CLI-first interactive issue shaping with dependency sections, conservative reflective follow-up candidate generation that surfaces likely dependency/overlap signals, and explicit `forge-create` tracker issue creation from quality-gated Markdown with duplicate-title guarding. Interactive creation requires `--write` and `--confirm-create`; reflective mode only prints candidates. Initial Project `Status` setup is available through the GitHub add-to-project path, `forge-create --add-to-project` can set GitHub Project v2 single-select fields such as `Capability` with repeatable `--project-field NAME=VALUE` flags, and live GitHub `forge-create` requires `--assignee` before adding executable Project items. Text/number/date field setup is not implemented yet. |
+| Issue Forge | The Jade Symphony CLI exposes a compact `forge` command group: `forge validate`, `forge create`, and `forge promote`. Conversation, reflection, and repair are owned by Codex skills. `forge create --status Backlog` uses a lighter Backlog seed gate, `forge create --status Todo` uses the full Issue Quality Gate, creation always adds the issue to the configured Project, and live `Todo` creation requires `--assignee` before adding executable Project items. `forge promote` updates an existing Backlog issue in place with explicit dry-run and failure-checkpoint reporting. Text/number/date field setup is not implemented yet. |
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, dependency preflight for `Todo` / `Rework`, runtime-state persistence, tracker-visible advisory ownership markers, resume preflight, retry backoff records, stall detection, live PR handoff plus tracker PR link recording in non-fixture GitHub mode, guarded `merge-once` and bounded `merge-loop` lanes for `Merging` issues, first-slice `--pool` selection guarded by `Main Agent` / `Merging Agent` Project fields, a controlled `dogfood-smoke` preflight report with blocking-vs-warning integration gap severity, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, unbounded merge idle polling, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, grouped read-only `clean plan` / `clean audit` cleanup and persistence classification, guarded terminal cleanup planning, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, dirty/no-op guards before branch push, optional configured verification commands before PR handoff, branch push, PR create-or-reuse, tracker PR link recording, run-loop handoff evidence, profile-scoped workspace keys, parsed-but-unused SSH worker host config, a namespaced artifact layout, and dry-run cleanup planning exist. Automatic runtime cleanup, write-mode artifact cleanup, and live SSH execution are not wired yet. |
-| Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
-| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. A local `tmux` backend can launch attachable lane sessions, capture the Codex pane before prompt injection, auto-advance the Codex workspace trust prompt inside Jade-created issue worktrees by default, paste rendered prompts only after readiness is observed, record the session name, attach command, prompt artifact, log path, lane, actor, profile/instance metadata, and durable session registry record, and leave workflow state unchanged until normal lane evidence is ready. `run-loop` uses that backend for Main Agent execution, while `agent-session start --lane main|review|merge`, `review-session`, and `merge-session` provide manual recovery for all lane prompts and claim fields. `status` classifies recent registered sessions from bounded pane/log evidence as `starting`, `running`, `waiting_for_trust`, `waiting_for_approval`, `waiting_for_human_input`, `usage_limited`, `failed`, `completed`, `stale`, or `unknown`. `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` opts out and fails closed if the trust prompt is visible. Prepared runs include selected profile/instance metadata and profile environment context. The Codex subprocess backend safely refuses `codex app-server` commands because that transport is not implemented yet. A first-slice Codex app-server event normalizer maps fixture JSON-RPC stream lines into Jade `AgentEvent` values, including completion, failure, cancellation, input-required, token usage, notification, and malformed events. Full Codex app-server transport and Claude Code protocol parity remain follow-ups. |
+| Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade Symphony treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
+| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. A local `tmux` backend can launch attachable lane sessions, capture the Codex pane before prompt injection, auto-advance the Codex workspace trust prompt inside Jade Symphony-created issue worktrees by default, paste rendered prompts only after readiness is observed, record the session name, attach command, prompt artifact, log path, lane, actor, profile/instance metadata, and durable session registry record, and leave workflow state unchanged until normal lane evidence is ready. `run-loop` uses that backend for Main Agent execution, while `agent-session start --lane main|review|merge`, `review-session`, and `merge-session` provide manual recovery for all lane prompts and claim fields. `status` classifies recent registered sessions from bounded pane/log evidence as `starting`, `running`, `waiting_for_trust`, `waiting_for_approval`, `waiting_for_human_input`, `usage_limited`, `failed`, `completed`, `stale`, or `unknown`. `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` opts out and fails closed if the trust prompt is visible. Prepared runs include selected profile/instance metadata and profile environment context. The Codex subprocess backend safely refuses `codex app-server` commands because that transport is not implemented yet. A first-slice Codex app-server event normalizer maps fixture JSON-RPC stream lines into Jade Symphony `AgentEvent` values, including completion, failure, cancellation, input-required, token usage, notification, and malformed events. Full Codex app-server transport and Claude Code protocol parity remain follow-ups. |
 | Prompt rendering | Strict prompt rendering supports `issue.*`, `attempt`, and basic `{% if %}` / `{% else %}` blocks. The supported subset is documented in `docs/prompt-template-contract.md`; full Liquid compatibility remains a parity gap. |
 | Dynamic tools | A first-slice dynamic-tool registry can describe planned backend-specific tools such as Codex `linear_graphql` without coupling them to the orchestrator. Tool execution and Codex app-server dynamic-tool protocol wiring are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings and completed-but-inconclusive automatic reviews, review-freshness evidence for Merging conflict repair, bounded `review-loop` worker selection/reconciliation with one issue per worker slot, Project `Review Agent` claim markers before backend launch, terminal failure/timeout claim cleanup for retry, durable JSON review job ledger records, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
@@ -52,8 +52,8 @@ deferred parity work.
 
 ## Native tmux Supervision Contract
 
-Jade's tmux layer is now an operator-supervised terminal substrate owned by the
-Jade runtime, not a second workflow engine. The tracker remains authoritative
+Jade Symphony's tmux layer is now an operator-supervised terminal substrate owned by the
+Jade Symphony runtime, not a second workflow engine. The tracker remains authoritative
 for issue lifecycle, while the session registry and logs provide durable local
 evidence for attach, diagnosis, and cleanup.
 
@@ -117,7 +117,7 @@ Project v2 issues:
    - Same-state status updates are treated as no-ops before mutation.
    - PR linking currently uses an issue comment/autolink strategy instead of a
      first-class relationship; linked PR discovery can read closing references
-     and PR URLs recorded in canonical Jade workpad comments.
+     and PR URLs recorded in canonical Jade Symphony workpad comments.
    - Remaining work: idempotency checks around project-item addition and richer
      reconciliation after writes.
 
@@ -188,7 +188,7 @@ Project v2 issues:
    - Preserve fixture mode for credential-free development.
 
 6. Live agent execution.
-   - The live dogfood workflow prompt now embeds enough Jade protocol for an
+   - The live dogfood workflow prompt now embeds enough Jade Symphony protocol for an
      isolated backend agent to understand the issue work cycle, workpad, review
      boundary, and stop conditions.
    - Keep the prompt aligned with `docs/bootstrap/JADE_WORKFLOW.md` as the
@@ -290,29 +290,23 @@ Project v2 issues:
      `https://github.com/jlcodes99/cockpit-tools` uses a camelCase `InstanceStore`
      (`instances`, `defaultSettings`) and `InstanceProfile` records with
      `id`, `name`, `userDataDir`, `workingDir`, `extraArgs`, launch metadata,
-     and account binding fields. Jade reads only non-secret instance identity
+     and account binding fields. Jade Symphony reads only non-secret instance identity
      and path/argument context.
 
 10. Issue Forge tracker completion.
-   - `forge-create` can create a tracker issue and optionally add it to the
-     configured project through the normalized adapter with initial `Todo`
-     status in GitHub ProjectV2 mode.
-   - `forge-interactive` can start from only the canonical workflow path, read
-     natural-language intent from stdin or `--intent`, infer a title, select a
-     lightweight issue skill/template, ask a focused clarification question for
-     thin intent, and print a quality-gated issue draft before any live tracker
-     write.
-   - `forge-reflect` can scan local context for conservative follow-up signals
-     and print quality-gated draft candidates without creating live issues.
-   - `forge-create --add-to-project` can set GitHub Project v2 single-select
-     fields by name with repeatable `--project-field NAME=VALUE` flags, covering
-     the immediate `Capability` classification need.
-   - Live GitHub `forge-create` accepts repeatable `--assignee LOGIN` values,
-     uses them during draft validation, assigns the created issue before Project
-     insertion, and rejects missing assignees when live dispatch would reject
-     unassigned issues.
-   - Remaining work: text/number/date field writes and a richer multi-step
-     conversation surface if CLI steps become too thin.
+   - `forge validate` can validate body files or existing issues for `Backlog`
+     or `Todo`, using the seed gate for Backlog and the full Issue Quality Gate
+     for Todo.
+   - `forge create` creates tracker issues, always inserts them into the
+     configured Project, supports `--status Backlog|Todo`, and accepts repeatable
+     `--project-field NAME=VALUE` assignments.
+   - `forge promote` reads a Backlog issue, validates an explicit replacement
+     title/body with the Todo gate, edits the same issue in place, sets Project
+     status to `Todo`, and performs readback verification.
+   - Reflection, discussion, and repair are skill-owned workflows, not
+     Jade Symphony CLI subcommands.
+   - Remaining work: text/number/date field writes and richer Project selection
+     beyond the configured workflow Project.
 
 ## Recommended Next GitHub Issues
 
@@ -487,7 +481,7 @@ GitHub Project v2 execution is hardened.
 `workflows/jade-symphony.md` is the canonical non-fixture workflow for manual
 live Project v2 reads and explicit tracker writes through `gh`. It uses the
 local `tmux` backend for supervised lane execution, while prompt bodies remain
-the real Jade dogfood operating contracts. `run-loop --write` records
+the real Jade Symphony dogfood operating contracts. `run-loop --write` records
 attachable tmux session metadata, writes `session-registry.json` under the
 configured artifact root, and keeps the issue active until real implementation
 evidence is available for the existing handoff path. `agent-session`,

--- a/docs/implementation_notes.md
+++ b/docs/implementation_notes.md
@@ -64,9 +64,9 @@ Feature-parity baseline from the Elixir implementation:
 - `LogFile`, logging docs, token-accounting docs, CLI guardrail acknowledgement,
   optional `--logs-root` and `--port`, and test-only memory tracker.
 
-## Jade Extensions To Preserve
+## Jade Symphony Extensions To Preserve
 
-Jade-specific bootstrap docs require:
+Jade Symphony-specific bootstrap docs require:
 
 - GitHub Project v2 as the first concrete tracker adapter.
 - Future Linear adapter preserved behind the same normalized tracker abstraction.
@@ -96,7 +96,7 @@ Initial crate layout:
   decisions, snapshots, retries, and agent events.
 - `tracker`: trait plus dry-run memory, GitHub Project v2, and Linear adapters.
   GitHub/Linear API calls stay inside adapters.
-- `quality_gate`: executable-issue classifier based on the Jade issue contract.
+- `quality_gate`: executable-issue classifier based on the Jade Symphony issue contract.
 - `issue_forge`: candidate/draft/validation structures and clarification loop
   primitives.
 - `workspace`: safe workspace keys, root containment, lifecycle hooks, and future
@@ -185,7 +185,7 @@ eligibility. Orchestrator must not dispatch a `Todo` issue until the gate return
 `Ready` or `Ready With Assumptions`; critical missing context routes to
 `Need to Clarify`.
 
-The initial gate checks for the Jade template's required sections and classifies
+The initial gate checks for the Jade Symphony template's required sections and classifies
 missing execution-critical fields. Later iterations can add source-alignment,
 duplication, and tracker-write repair flows without changing orchestrator shape.
 
@@ -218,11 +218,11 @@ duplication, and tracker-write repair flows without changing orchestrator shape.
 
 | Capability | Source | Status | Reason For Delay | Planned Path |
 | --- | --- | --- | --- | --- |
-| Full Codex app-server stdio protocol | `SPEC.md`, `elixir/lib/symphony_elixir/codex/app_server.ex` | Partial | A conservative workspace-bound Codex subprocess backend exists, and a first-slice event normalizer maps fixture JSON-RPC stream lines into Jade `AgentEvent` values. Full app-server protocol framing, request/response transport, continuation turns, and live Codex validation still require protocol-specific implementation. | Replace or extend the subprocess path with `agent::codex` app-server transport, reuse the event normalizer for runtime events, then add protocol fixtures and live smoke profile. |
+| Full Codex app-server stdio protocol | `SPEC.md`, `elixir/lib/symphony_elixir/codex/app_server.ex` | Partial | A conservative workspace-bound Codex subprocess backend exists, and a first-slice event normalizer maps fixture JSON-RPC stream lines into Jade Symphony `AgentEvent` values. Full app-server protocol framing, request/response transport, continuation turns, and live Codex validation still require protocol-specific implementation. | Replace or extend the subprocess path with `agent::codex` app-server transport, reuse the event normalizer for runtime events, then add protocol fixtures and live smoke profile. |
 | Full Liquid-compatible prompt engine | `SPEC.md`, `elixir/lib/symphony_elixir/prompt_builder.ex` | Partial | Initial slice uses a documented strict subset for `issue.*`, `attempt`, and basic `if` / `else` blocks; unsupported tags and unknown variables fail. | Replace with a vetted Liquid crate or complete parser behind `agent::PromptRenderer`. |
 | GitHub Project v2 live GraphQL adapter | `TRACKER_GITHUB_PROJECT_V2.md` | Partial | Initial adapter is dry-run/fixture capable to proceed without credentials. | Add GraphQL client, field/option cache, mutations, and credential-gated integration tests. |
 | Linear live adapter | `SPEC.md`, `elixir/lib/symphony_elixir/linear/*` | Partial | Linear now has a live GraphQL adapter and fixture mode, but credential-gated smoke tests have not run in this environment and schema-sensitive mutations still need live confirmation. | Add skipped-by-default live smoke tests for reads, state update, workpad upsert, follow-up creation, and project assignment. |
-| Workspace lifecycle hooks with timeout/remote SSH parity | `SPEC.md`, `elixir/lib/symphony_elixir/workspace.ex`, `SPEC.md Appendix A` | Partial | Local hooks now support timeout handling, stdout/stderr capture, `before_remove`, and safe cleanup. Jade also parses optional `worker.ssh_hosts` and `worker.max_concurrent_agents_per_host` config for future scheduling, but live SSH execution is deferred. | Add SSH worker trait, host scheduling, remote workspace handling, and runtime reconciliation cleanup wiring. |
+| Workspace lifecycle hooks with timeout/remote SSH parity | `SPEC.md`, `elixir/lib/symphony_elixir/workspace.ex`, `SPEC.md Appendix A` | Partial | Local hooks now support timeout handling, stdout/stderr capture, `before_remove`, and safe cleanup. Jade Symphony also parses optional `worker.ssh_hosts` and `worker.max_concurrent_agents_per_host` config for future scheduling, but live SSH execution is deferred. | Add SSH worker trait, host scheduling, remote workspace handling, and runtime reconciliation cleanup wiring. |
 | Runtime workflow reload with last-known-good config | `SPEC.md`, `elixir/lib/symphony_elixir/workflow_store.ex` | Partial | `WorkflowStore` can reload an explicit workflow path and preserve the last known good workflow after parse/load failures, but CLI/runtime commands still perform one-shot loads. | Wire the store into long-running polling runtimes, then add watcher/polling reload policy and status diagnostics. |
 | Retry timers, stall detection, and worker supervision | `SPEC.md`, `elixir/lib/symphony_elixir/orchestrator.ex` | Partial | Initial orchestrator creates deterministic dispatch plans and retry metadata only. | Add async runtime worker lifecycle, timers, continuation retry, and stall restart tests. |
 | Runtime state persistence and resume wiring | `SPEC.md`, `elixir/lib/symphony_elixir/orchestrator.ex` | Partial | Tracker-neutral state model and file helpers exist, but the run loop does not yet write each transition or resume from it. | Wire runtime state into claim, workspace preparation, backend session start, event logging, handoff, and interruption recovery. |

--- a/docs/live-linear-smoke-tests.md
+++ b/docs/live-linear-smoke-tests.md
@@ -11,7 +11,7 @@ without credentials.
 - `JADE_LINEAR_PROJECT_SLUG` names a Linear project visible to that token.
 
 No tokens or secrets are written to the generated workflow file. The workflow
-uses `$LINEAR_API_KEY`, which Jade resolves at runtime.
+uses `$LINEAR_API_KEY`, which Jade Symphony resolves at runtime.
 
 ## Run
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -88,8 +88,8 @@ The canonical workflow now uses the local `tmux` main-agent backend. A write
 tick starts an attachable tmux session, records its attach command and log path,
 persists a session registry record under the configured artifact root, and
 leaves the issue active until real implementation/handoff evidence exists.
-For Codex-backed tmux sessions, Jade captures the pane before prompt injection.
-If the Codex workspace trust prompt is visible in a Jade-created issue worktree,
+For Codex-backed tmux sessions, Jade Symphony captures the pane before prompt injection.
+If the Codex workspace trust prompt is visible in a Jade Symphony-created issue worktree,
 the backend sends two `C-m` submissions, waits for a ready Codex viewport, and
 only then pastes the rendered issue prompt. Set
 `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` to opt out; when disabled, or when readiness
@@ -150,7 +150,7 @@ If Gemini exits, refuses the workspace trust check, or times out before
 returning a review report, `review-loop` records terminal workpad/ledger
 evidence, clears the `Review Agent` Project claim, and leaves the issue in
 `Agent Review` for retry after the operator fixes the backend environment.
-The Gemini subprocess receives the rendered prompt on stdin and Jade closes
+The Gemini subprocess receives the rendered prompt on stdin and Jade Symphony closes
 stdin after writing so headless commands that wait for EOF can proceed.
 
 If Gemini returns successfully but says it could not inspect the PR, workspace,

--- a/docs/prompt-template-contract.md
+++ b/docs/prompt-template-contract.md
@@ -4,7 +4,7 @@ Status: strict subset, not full Liquid compatibility.
 
 Jade Symphony renders the workflow prompt before launching an agent backend. The
 official reference requires strict template rendering for `issue` and `attempt`
-context and records Liquid-compatible semantics as sufficient. Jade currently
+context and records Liquid-compatible semantics as sufficient. Jade Symphony currently
 implements a deliberate subset so prompt failures are easy to diagnose during
 dogfood.
 
@@ -26,7 +26,7 @@ numbers, objects, and booleans, render as JSON text.
 
 ## Supported Tags
 
-Jade supports one level of basic conditionals:
+Jade Symphony supports one level of basic conditionals:
 
 ```liquid
 {% if issue.description %}

--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -94,8 +94,8 @@ prints the `tmux attach-session` command, records the prompt artifact, session
 registry entry, and log path, and keeps the issue active. A running tmux session
 alone is not completion evidence and must not move the issue to `Agent Review`.
 Codex tmux startup captures the pane before sending the issue prompt. By
-default, if a Jade-created issue worktree shows the Codex workspace trust
-prompt, Jade sends two `C-m` submissions and waits until the pane reaches a
+default, if a Jade Symphony-created issue worktree shows the Codex workspace trust
+prompt, Jade Symphony sends two `C-m` submissions and waits until the pane reaches a
 ready Codex viewport. Set `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` to disable this
 auto-trust behavior. If the prompt cannot be cleared, the write tick stops with
 the tmux attach command and log path preserved for manual inspection.

--- a/examples/fixtures/repaired-issue.md
+++ b/examples/fixtures/repaired-issue.md
@@ -5,7 +5,7 @@
 
 ## Issue Goal
 
-Make Issue Forge validate rough ideas and repair them into executable Jade issue contracts.
+Make Issue Forge validate rough ideas and repair them into executable Jade Symphony issue contracts.
 
 ## Why Now
 
@@ -16,14 +16,14 @@ Operators need a local way to turn rough issue text into a dispatchable contract
 Source input captured by Issue Forge:
 
 ```md
-Make Issue Forge validate rough ideas and repair them into executable Jade issue contracts.
+Make Issue Forge validate rough ideas and repair them into executable Jade Symphony issue contracts.
 ```
 
 ## Decisions / Assumptions
 
 ### Decisions
 
-- Use Issue Forge repair to convert rough input into the Jade quality template.
+- Use Issue Forge repair to convert rough input into the Jade Symphony quality template.
 
 ### Assumptions
 
@@ -63,7 +63,7 @@ Make Issue Forge validate rough ideas and repair them into executable Jade issue
 
 ## Current State
 
-Rough issue input exists and has been repaired into the Jade issue contract shape.
+Rough issue input exists and has been repaired into the Jade Symphony issue contract shape.
 
 ## Deliverable Shape
 
@@ -85,7 +85,7 @@ An executable issue contract that can pass the Issue Quality Gate before dispatc
 
 ### Functional Verification
 
-- Run `jade-symphony forge-validate` on the repaired draft.
+- Run `jade-symphony forge validate` on the repaired draft.
 
 ### UAT
 

--- a/examples/fixtures/thin-issue.md
+++ b/examples/fixtures/thin-issue.md
@@ -1,1 +1,1 @@
-Make Issue Forge validate rough ideas and repair them into executable Jade issue contracts.
+Make Issue Forge validate rough ideas and repair them into executable Jade Symphony issue contracts.

--- a/src/config.rs
+++ b/src/config.rs
@@ -979,7 +979,7 @@ mod tests {
     fn parses_actor_and_git_identity_config() {
         let workflow = WorkflowDefinition::parse(
             "/tmp/WORKFLOW.md",
-            "---\nidentity:\n  actor_role: review_agent\n  actor_label: Gemini Review Runner\n  git:\n    name: Jade Review Bot\n    email: jade-review@example.invalid\n    signing_key: ABC123\n    extra:\n      jade.actorRole: review_agent\n---\nPrompt",
+            "---\nidentity:\n  actor_role: review_agent\n  actor_label: Gemini Review Runner\n  git:\n    name: Jade Symphony Review Bot\n    email: jade-review@example.invalid\n    signing_key: ABC123\n    extra:\n      jade.actorRole: review_agent\n---\nPrompt",
         )
         .unwrap();
         let config =
@@ -989,7 +989,7 @@ mod tests {
         assert_eq!(config.identity.actor_label, "Gemini Review Runner");
         assert_eq!(
             config.identity.git.author().as_deref(),
-            Some("Jade Review Bot <jade-review@example.invalid>")
+            Some("Jade Symphony Review Bot <jade-review@example.invalid>")
         );
         assert_eq!(
             config

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -88,7 +88,7 @@ pub fn audit_project_issues_with_context(
                     AuditSeverity::Blocker,
                     "merging_missing_pr_target",
                     "Merging issue has no reliable PR target.",
-                    "Record exactly one PR link in the Project field, issue closing reference, or Jade workpad before attempting to land.",
+                    "Record exactly one PR link in the Project field, issue closing reference, or Jade Symphony workpad before attempting to land.",
                 ));
             }
             "merging" if reliable_pr_targets(issue).len() > 1 => {

--- a/src/issue_forge.rs
+++ b/src/issue_forge.rs
@@ -561,7 +561,7 @@ fn issue_markdown_from_interactive_input(
     );
     draft = draft.replace(
         "### Completion Criteria\n\n- TBD",
-        "### Completion Criteria\n\n- The issue contract passes `jade-symphony forge-validate`.\n- Implementation and documentation are limited to the issue scope.",
+        "### Completion Criteria\n\n- The issue contract passes `jade-symphony forge validate`.\n- Implementation and documentation are limited to the issue scope.",
     );
     draft = draft.replace(
         "### Functional Verification\n\n- TBD",
@@ -788,7 +788,7 @@ fn repaired_draft(title: &str, markdown: &str, decision: &GateDecision) -> Strin
     );
     draft = draft.replace(
         "### Decisions\n\n- TBD",
-        "### Decisions\n\n- Use Issue Forge repair to convert rough input into the Jade quality template.",
+        "### Decisions\n\n- Use Issue Forge repair to convert rough input into the Jade Symphony quality template.",
     );
     let assumptions = if decision.missing.is_empty() {
         "- Existing source input is sufficient for an initial executable draft.".to_string()
@@ -816,7 +816,7 @@ fn repaired_draft(title: &str, markdown: &str, decision: &GateDecision) -> Strin
     );
     draft = draft.replace(
         "## Current State\n\nTBD",
-        "## Current State\n\nRough issue input exists and has been repaired into the Jade issue contract shape.",
+        "## Current State\n\nRough issue input exists and has been repaired into the Jade Symphony issue contract shape.",
     );
     draft = draft.replace(
         "## Deliverable Shape\n\nTBD",
@@ -836,7 +836,7 @@ fn repaired_draft(title: &str, markdown: &str, decision: &GateDecision) -> Strin
     );
     draft = draft.replace(
         "### Functional Verification\n\n- TBD",
-        "### Functional Verification\n\n- Run `jade-symphony forge-validate` on the repaired draft.",
+        "### Functional Verification\n\n- Run `jade-symphony forge validate` on the repaired draft.",
     );
     draft
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::io::{self, Read};
+use std::io;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
@@ -31,11 +31,7 @@ use jade_symphony::handoff::{
     render_agent_review_handoff_workpad, AgentReviewHandoffEvidence, HandoffError,
     IssueHandoffPlan,
 };
-use jade_symphony::issue_forge::{
-    conversational_title_from_intent, discover_candidates, draft_from_template, find_issue_skill,
-    interactive_forge, next_clarification_question, reflective_candidates_from_context,
-    repair_markdown, validate_markdown, InteractiveForgeInput,
-};
+use jade_symphony::issue_forge::{next_clarification_question, ForgeValidationReport};
 use jade_symphony::lane_claim::{
     LaneClaim, LaneClaimActor, LaneClaimLane, LaneClaimSource, LaneClaimState,
 };
@@ -248,68 +244,42 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             apply,
             write,
         } => quality_gate(workflow_path, issue_ref, apply, write),
-        Command::ForgeDiscover { source } => {
-            for (index, candidate) in discover_candidates(&source).iter().enumerate() {
-                println!(
-                    "{}. {:?}: {}",
-                    index + 1,
-                    candidate.classification,
-                    candidate.title
-                );
-                println!("   {}", candidate.rationale);
-            }
-            Ok(())
-        }
-        Command::ForgeDiscuss { title, markdown } => {
-            let report = validate_markdown(&title, &markdown);
-            if let Some(question) = report.question {
-                println!("question={}", question.question);
-                println!("why={}", question.why_it_matters);
-            } else {
-                println!("question=none");
-                println!("gate={:?}", report.decision.kind);
-            }
-            Ok(())
-        }
-        Command::ForgeDraft { title, goal } => {
-            println!("{}", draft_from_template(&title, &goal));
-            Ok(())
-        }
-        Command::ForgeValidate { title, markdown } => {
-            let report = validate_markdown(&title, &markdown);
-            print_forge_validation(&report);
-            Ok(())
-        }
-        Command::ForgeRepair { title, markdown } => {
-            let report = repair_markdown(&title, &markdown);
-            print_forge_validation(&report.validation);
-            println!("\n--- repaired draft ---\n");
-            println!("{}", report.repaired_markdown);
-            Ok(())
-        }
+        Command::ForgeValidate {
+            workflow_path,
+            status,
+            title,
+            markdown,
+            issue_ref,
+        } => forge_validate(workflow_path, status, title, markdown, issue_ref),
         Command::ForgeCreate {
             workflow_path,
             title,
             markdown,
-            add_to_project,
+            status,
+            project,
             project_fields,
             assignees,
             write,
-        } => forge_create(
+            dry_run,
+        } => forge_create(ForgeCreateOptions {
             workflow_path,
             title,
             markdown,
-            add_to_project,
+            status,
+            project,
             project_fields,
             assignees,
             write,
-        ),
-        Command::ForgeInteractive { options } => forge_interactive(options),
-        Command::ForgeReflect {
-            context,
-            skill,
-            limit,
-        } => forge_reflect(context, skill, limit),
+            dry_run,
+        }),
+        Command::ForgePromote {
+            workflow_path,
+            issue_ref,
+            title,
+            markdown,
+            write,
+            dry_run,
+        } => forge_promote(workflow_path, issue_ref, title, markdown, write, dry_run),
         Command::Help(text) => {
             print!("{text}");
             Ok(())
@@ -689,31 +659,63 @@ fn create_follow_up(
     Ok(())
 }
 
-fn forge_create(
+#[derive(Debug, Clone)]
+struct ForgeCreateOptions {
     workflow_path: PathBuf,
     title: String,
     markdown: String,
-    add_to_project: bool,
+    status: ForgeStatusArg,
+    project: Option<String>,
     project_fields: Vec<ProjectFieldAssignment>,
     assignees: Vec<String>,
     write: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    require_write_intent(write)?;
-    if !project_fields.is_empty() && !add_to_project {
-        return Err("forge-create --project-field requires --add-to-project".into());
+    dry_run: bool,
+}
+
+fn forge_create(options: ForgeCreateOptions) -> Result<(), Box<dyn std::error::Error>> {
+    let ForgeCreateOptions {
+        workflow_path,
+        title,
+        markdown,
+        status,
+        project,
+        project_fields,
+        assignees,
+        write,
+        dry_run,
+    } = options;
+    if write && dry_run {
+        return Err("forge create cannot use --write and --dry-run together".into());
     }
+    let dry_run = !write || dry_run;
     let config = load_config(&workflow_path)?;
+    let project_label = validate_forge_project_selection(&config, project.as_deref())?;
     let assignees = normalize_forge_assignees(assignees);
-    if forge_create_requires_assignee(&config) && assignees.is_empty() {
-        return Err("forge-create requires --assignee for live GitHub issue creation".into());
+    if forge_create_requires_assignee(&config, status) && assignees.is_empty() {
+        return Err(
+            "forge create --status Todo requires --assignee for live GitHub issue creation".into(),
+        );
     }
-    let report = validate_forge_create_contract(&title, &markdown, &config, &assignees)
-        .inspect_err(|_message| {
-            let report =
-                validate_forge_create_report_with_assignees(&title, &markdown, &config, &assignees)
-                    .unwrap_or_else(|_| validate_markdown(&title, &markdown));
-            print_forge_validation(&report);
-        })?;
+    let report = forge_validation_report(status, &title, &markdown, &config, &assignees)?;
+    print_forge_validation(&report);
+    if !report.decision.is_dispatchable() {
+        return Err(format!(
+            "forge create validation failed for status {}; tracker issue was not created",
+            status.as_str()
+        )
+        .into());
+    }
+
+    if dry_run {
+        println!(
+            "forge_create_dry_run=ok status={} project={} title={:?} project_fields={}",
+            status.as_str(),
+            project_label,
+            report.title,
+            project_fields.len()
+        );
+        return Ok(());
+    }
 
     let adapter = adapter_from_config(&config);
     let existing_issues = adapter.list_dispatchable_issues()?;
@@ -737,7 +739,7 @@ fn forge_create(
     append_tracker_mutation_audit(
         &config,
         TrackerMutationAudit {
-            command: "forge-create",
+            command: "forge create",
             mutation_type: "issue_create",
             issue_ref: None,
             target: Some(issue_id.clone()),
@@ -747,42 +749,280 @@ fn forge_create(
         },
     );
 
-    if add_to_project {
-        adapter.add_issue_to_project(&issue_id)?;
+    adapter.add_issue_to_project(&issue_id)?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "forge create",
+            mutation_type: "project_add",
+            issue_ref: Some(&issue_id),
+            target: Some(project_label),
+            from_state: None,
+            to_state: Some("todo".into()),
+            reason: "forge issue added to project",
+        },
+    );
+    if status != ForgeStatusArg::Todo {
+        adapter.set_state(&issue_id, status.normalized_state())?;
         append_tracker_mutation_audit(
             &config,
             TrackerMutationAudit {
-                command: "forge-create",
-                mutation_type: "project_add",
+                command: "forge create",
+                mutation_type: "status",
                 issue_ref: Some(&issue_id),
-                target: Some("Project item".into()),
-                from_state: None,
-                to_state: Some("todo".into()),
-                reason: "forge issue added to project",
+                target: Some(status.as_str().into()),
+                from_state: Some("todo".into()),
+                to_state: Some(status.normalized_state().into()),
+                reason: "forge issue initial status",
             },
         );
-        for assignment in &project_fields {
-            adapter.set_project_field(&issue_id, assignment)?;
-            append_tracker_mutation_audit(
-                &config,
-                TrackerMutationAudit {
-                    command: "forge-create",
-                    mutation_type: "project_field",
-                    issue_ref: Some(&issue_id),
-                    target: Some(format!("{}={}", assignment.name, assignment.value)),
-                    from_state: None,
-                    to_state: None,
-                    reason: "forge project field assignment",
-                },
-            );
-        }
+    }
+    for assignment in &project_fields {
+        adapter.set_project_field(&issue_id, assignment)?;
+        append_tracker_mutation_audit(
+            &config,
+            TrackerMutationAudit {
+                command: "forge create",
+                mutation_type: "project_field",
+                issue_ref: Some(&issue_id),
+                target: Some(format!("{}={}", assignment.name, assignment.value)),
+                from_state: None,
+                to_state: None,
+                reason: "forge project field assignment",
+            },
+        );
     }
 
     println!(
-        "forge_create=ok issue_id={issue_id} added_to_project={add_to_project} project_fields={}",
+        "forge_create=ok issue_id={issue_id} status={} project_fields={}",
+        status.as_str(),
         project_fields.len()
     );
     Ok(())
+}
+
+fn forge_promote(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    title: String,
+    markdown: String,
+    write: bool,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if write && dry_run {
+        return Err("forge promote cannot use --write and --dry-run together".into());
+    }
+    let dry_run = !write || dry_run;
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let source = adapter
+        .get_issue(&issue_ref)
+        .map_err(|error| format!("forge promote stopped at read_source: {error}"))?
+        .ok_or_else(|| {
+            format!("forge promote stopped at read_source: issue not found: {issue_ref}")
+        })?;
+    if normalize_state(&source.state) != normalize_state(&config.tracker.state_map.backlog) {
+        return Err(format!(
+            "forge promote stopped at preflight: {} is in {:?}, expected Backlog",
+            source.identifier, source.state
+        )
+        .into());
+    }
+
+    let report = forge_validation_report(
+        ForgeStatusArg::Todo,
+        &title,
+        &markdown,
+        &config,
+        &source.assignees,
+    )
+    .map_err(|error| format!("forge promote stopped at validate: {error}"))?;
+    print_forge_validation(&report);
+    if !report.decision.is_dispatchable() {
+        return Err("forge promote stopped at validate: promoted body failed Todo gate".into());
+    }
+
+    if dry_run {
+        println!(
+            "forge_promote_dry_run=ok issue={} from=Backlog to=Todo title={:?}",
+            source.identifier, report.title
+        );
+        return Ok(());
+    }
+
+    adapter
+        .update_issue_content(&source.identifier, &report.title, &markdown)
+        .map_err(|error| format!("forge promote stopped at edit_issue: {error}"))?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "forge promote",
+            mutation_type: "issue_edit",
+            issue_ref: Some(&source.identifier),
+            target: Some(report.title.clone()),
+            from_state: Some(source.state.clone()),
+            to_state: None,
+            reason: "forge backlog promotion content update",
+        },
+    );
+
+    adapter
+        .set_state(&source.identifier, "todo")
+        .map_err(|error| format!("forge promote stopped at set_status: {error}"))?;
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: "forge promote",
+            mutation_type: "status",
+            issue_ref: Some(&source.identifier),
+            target: Some("Todo".into()),
+            from_state: Some(source.state.clone()),
+            to_state: Some("todo".into()),
+            reason: "forge backlog promotion status update",
+        },
+    );
+
+    let verified = adapter
+        .get_issue(&source.identifier)
+        .map_err(|error| format!("forge promote stopped at readback: {error}"))?
+        .ok_or_else(|| {
+            format!(
+                "forge promote stopped at readback: issue disappeared after update: {}",
+                source.identifier
+            )
+        })?;
+    let status_ok =
+        normalize_state(&verified.state) == normalize_state(&config.tracker.state_map.todo);
+    let title_ok = verified.title == report.title;
+    if !status_ok || !title_ok {
+        return Err(format!(
+            "forge promote stopped at readback: expected title {:?} and Todo, got title {:?} and state {:?}",
+            report.title, verified.title, verified.state
+        )
+        .into());
+    }
+
+    println!(
+        "forge_promote=ok issue={} status=Todo title={:?}",
+        verified.identifier, verified.title
+    );
+    Ok(())
+}
+
+fn forge_validate(
+    workflow_path: PathBuf,
+    status: Option<ForgeStatusArg>,
+    title: String,
+    markdown: String,
+    issue_ref: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let (status, title, markdown, assignees) = if let Some(issue_ref) = issue_ref {
+        let adapter = adapter_from_config(&config);
+        let issue = adapter
+            .get_issue(&issue_ref)?
+            .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
+        let status = status.unwrap_or_else(|| forge_status_from_issue(&config, &issue));
+        (
+            status,
+            issue.title,
+            issue.description.unwrap_or_default(),
+            issue.assignees,
+        )
+    } else {
+        (
+            status.unwrap_or(ForgeStatusArg::Todo),
+            title,
+            markdown,
+            Vec::new(),
+        )
+    };
+    let report = forge_validation_report(status, &title, &markdown, &config, &assignees)?;
+    print_forge_validation(&report);
+    println!("status={}", status.as_str());
+    Ok(())
+}
+
+fn forge_validation_report(
+    status: ForgeStatusArg,
+    title: &str,
+    markdown: &str,
+    config: &RuntimeConfig,
+    intended_assignees: &[String],
+) -> Result<ForgeValidationReport, Box<dyn std::error::Error>> {
+    match status {
+        ForgeStatusArg::Backlog => Ok(validate_backlog_seed(title, markdown)),
+        ForgeStatusArg::Todo => {
+            validate_forge_create_report_with_assignees(title, markdown, config, intended_assignees)
+        }
+    }
+}
+
+fn validate_backlog_seed(title: &str, markdown: &str) -> ForgeValidationReport {
+    let mut missing = Vec::new();
+    if title.trim().is_empty() {
+        missing.push("title".into());
+    }
+    if markdown.trim().chars().count() < 40 {
+        missing.push("body with enough context to revisit later".into());
+    }
+    if !markdown.contains("## Issue Goal") && !markdown.contains("## Issue Context") {
+        missing.push("at least one Issue Goal or Issue Context section".into());
+    }
+    let decision = if missing.is_empty() {
+        GateDecision::ready()
+    } else {
+        GateDecision {
+            kind: GateDecisionKind::NeedToClarify,
+            missing,
+            assumptions: Vec::new(),
+            notes: vec![
+                "Backlog seed gate is intentionally lighter than the Todo Issue Quality Gate."
+                    .into(),
+            ],
+        }
+    };
+    ForgeValidationReport {
+        title: title.to_string(),
+        question: next_clarification_question(&decision),
+        decision,
+    }
+}
+
+fn validate_forge_project_selection(
+    config: &RuntimeConfig,
+    project: Option<&str>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let owner = config
+        .tracker
+        .project_owner
+        .as_deref()
+        .unwrap_or("workflow");
+    let number = config
+        .tracker
+        .project_number
+        .map(|number| number.to_string())
+        .unwrap_or_else(|| "configured".into());
+    let configured = format!("{owner}/{number}");
+    let Some(project) = project.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(configured);
+    };
+    if matches!(project, "default" | "workflow") || project == number || project == configured {
+        Ok(configured)
+    } else {
+        Err(format!(
+            "forge create --project currently supports the configured workflow Project only ({configured}); got {project:?}"
+        )
+        .into())
+    }
+}
+
+fn forge_status_from_issue(config: &RuntimeConfig, issue: &TrackerIssue) -> ForgeStatusArg {
+    if normalize_state(&issue.state) == normalize_state(&config.tracker.state_map.backlog) {
+        ForgeStatusArg::Backlog
+    } else {
+        ForgeStatusArg::Todo
+    }
 }
 
 fn normalize_forge_assignees(assignees: Vec<String>) -> Vec<String> {
@@ -793,8 +1033,9 @@ fn normalize_forge_assignees(assignees: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn forge_create_requires_assignee(config: &RuntimeConfig) -> bool {
-    config.tracker.kind == "github_project_v2"
+fn forge_create_requires_assignee(config: &RuntimeConfig, status: ForgeStatusArg) -> bool {
+    status == ForgeStatusArg::Todo
+        && config.tracker.kind == "github_project_v2"
         && config.tracker.fixture_path.is_none()
         && !config.tracker.assignee_filter.allow_unassigned
 }
@@ -817,121 +1058,7 @@ fn normalized_issue_title_key(title: &str) -> String {
         .to_ascii_lowercase()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ForgeInteractiveOptions {
-    workflow_path: Option<PathBuf>,
-    title: Option<String>,
-    intent: Option<String>,
-    file: Option<PathBuf>,
-    skill: Option<String>,
-    context: Option<String>,
-    assignees: Vec<String>,
-    add_to_project: bool,
-    write: bool,
-    confirm_create: bool,
-}
-
-fn forge_interactive(options: ForgeInteractiveOptions) -> Result<(), Box<dyn std::error::Error>> {
-    let intent = resolve_interactive_intent(options.intent, options.file)?;
-    let title = options
-        .title
-        .unwrap_or_else(|| conversational_title_from_intent(&intent));
-    let report = interactive_forge(InteractiveForgeInput {
-        title: title.clone(),
-        intent,
-        skill: options.skill,
-        context: options.context,
-        assignees: options.assignees.clone(),
-    });
-    println!("forge_interactive_session=conversation");
-    println!("transcript_summary=operator_intent_captured");
-    print_interactive_forge_report(&report);
-
-    if options.write {
-        if !options.confirm_create {
-            return Err("forge-interactive --write requires --confirm-create".into());
-        }
-        if !report.validation.decision.is_dispatchable() {
-            return Err(
-                "forge-interactive refuses to create because the Issue Quality Gate failed".into(),
-            );
-        }
-        if report.question.is_some() {
-            return Err(
-                "forge-interactive refuses to create while clarification questions remain".into(),
-            );
-        }
-        if options.assignees.is_empty() {
-            return Err("forge-interactive --write requires --assignee".into());
-        }
-        let workflow_path = options
-            .workflow_path
-            .ok_or("forge-interactive --write requires --workflow")?;
-        forge_create(
-            workflow_path,
-            title,
-            report.issue_markdown,
-            options.add_to_project,
-            Vec::new(),
-            options.assignees,
-            true,
-        )?;
-    }
-
-    Ok(())
-}
-
-fn resolve_interactive_intent(
-    inline: Option<String>,
-    file: Option<PathBuf>,
-) -> Result<String, Box<dyn std::error::Error>> {
-    match (inline, file) {
-        (Some(value), None) if !value.trim().is_empty() => Ok(value),
-        (None, Some(path)) => Ok(std::fs::read_to_string(&path)
-            .map_err(|error| format!("failed to read {}: {error}", path.display()))?),
-        (None, None) => {
-            eprintln!("Describe the work you want Issue Forge to shape, then press Ctrl-D:");
-            let mut input = String::new();
-            io::stdin().read_to_string(&mut input)?;
-            if input.trim().is_empty() {
-                return Err(
-                    "forge-interactive requires operator intent from stdin, --intent, or --file"
-                        .into(),
-                );
-            }
-            Ok(input)
-        }
-        _ => Err(usage().into()),
-    }
-}
-
-fn forge_reflect(
-    context: String,
-    skill: Option<String>,
-    limit: usize,
-) -> Result<(), Box<dyn std::error::Error>> {
-    if limit == 0 {
-        return Err("forge-reflect --limit must be greater than 0".into());
-    }
-
-    let candidates = reflective_candidates_from_context(&context, skill.as_deref(), limit);
-    println!("candidates={}", candidates.len());
-    for (index, candidate) in candidates.iter().enumerate() {
-        println!("{}. {}", index + 1, candidate.title);
-        println!("skill={}", candidate.skill.key);
-        println!("gate={:?}", candidate.validation.decision.kind);
-        println!(
-            "dispatchable={}",
-            candidate.validation.decision.is_dispatchable()
-        );
-        println!("rationale={}", candidate.rationale);
-        println!("--- issue draft ---");
-        println!("{}", candidate.issue_markdown);
-    }
-
-    Ok(())
-}
-
+#[cfg(test)]
 fn validate_forge_create_contract(
     title: &str,
     markdown: &str,
@@ -956,7 +1083,7 @@ fn validate_forge_create_report_with_assignees(
 ) -> Result<jade_symphony::issue_forge::ForgeValidationReport, Box<dyn std::error::Error>> {
     let issue = TrackerIssue {
         tracker_kind: config.tracker.kind.clone(),
-        id: "forge-draft".into(),
+        id: "forge-issue-draft".into(),
         item_id: None,
         identifier: "#draft".into(),
         title: title.into(),
@@ -6361,41 +6488,31 @@ enum Command {
         apply: bool,
         write: bool,
     },
-    ForgeDraft {
-        title: String,
-        goal: String,
-    },
-    ForgeDiscover {
-        source: String,
-    },
-    ForgeDiscuss {
-        title: String,
-        markdown: String,
-    },
     ForgeValidate {
+        workflow_path: PathBuf,
+        status: Option<ForgeStatusArg>,
         title: String,
         markdown: String,
-    },
-    ForgeRepair {
-        title: String,
-        markdown: String,
+        issue_ref: Option<String>,
     },
     ForgeCreate {
         workflow_path: PathBuf,
         title: String,
         markdown: String,
-        add_to_project: bool,
+        status: ForgeStatusArg,
+        project: Option<String>,
         project_fields: Vec<ProjectFieldAssignment>,
         assignees: Vec<String>,
         write: bool,
+        dry_run: bool,
     },
-    ForgeInteractive {
-        options: ForgeInteractiveOptions,
-    },
-    ForgeReflect {
-        context: String,
-        skill: Option<String>,
-        limit: usize,
+    ForgePromote {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        title: String,
+        markdown: String,
+        write: bool,
+        dry_run: bool,
     },
     Help(String),
 }
@@ -6526,7 +6643,7 @@ impl Command {
 #[derive(Debug, Parser)]
 #[command(
     name = "jade-symphony",
-    about = "OpenAI Symphony-style orchestration harness with Jade extensions",
+    about = "OpenAI Symphony-style orchestration harness with Jade Symphony extensions",
     disable_help_subcommand = true,
     arg_required_else_help = false
 )]
@@ -6604,22 +6721,7 @@ enum CliCommand {
     Gate(GateArgs),
     #[command(name = "gate-apply")]
     GateApply(GateArgs),
-    #[command(name = "forge-discover")]
-    ForgeDiscover(ForgeDiscoverArgs),
-    #[command(name = "forge-discuss")]
-    ForgeDiscuss(ForgeMarkdownArgs),
-    #[command(name = "forge-draft")]
-    ForgeDraft(ForgeDraftArgs),
-    #[command(name = "forge-validate")]
-    ForgeValidate(ForgeMarkdownArgs),
-    #[command(name = "forge-repair")]
-    ForgeRepair(ForgeMarkdownArgs),
-    #[command(name = "forge-create")]
-    ForgeCreate(ForgeCreateArgs),
-    #[command(name = "forge-interactive")]
-    ForgeInteractive(ForgeInteractiveArgs),
-    #[command(name = "forge-reflect")]
-    ForgeReflect(ForgeReflectArgs),
+    Forge(ForgeArgs),
 }
 
 #[derive(Debug, Args)]
@@ -7126,43 +7228,38 @@ impl From<CliFakeReviewOutcome> for FakeReviewOutcome {
 }
 
 #[derive(Debug, Args)]
-struct ForgeDraftArgs {
-    #[arg(long)]
-    title: String,
-    #[arg(long)]
-    goal: String,
-}
-
-#[derive(Debug, Args)]
-struct ForgeDiscoverArgs {
-    #[arg(long)]
-    intent: Option<String>,
-    #[arg(long)]
-    file: Option<PathBuf>,
-}
-
-#[derive(Debug, Args)]
 struct ForgeMarkdownArgs {
     #[arg(long)]
-    title: String,
-    #[arg(long)]
-    file: Option<PathBuf>,
-    #[arg(long)]
     body: Option<String>,
+    #[arg(long = "body-file", alias = "file")]
+    body_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+struct ForgeArgs {
+    #[command(subcommand)]
+    command: ForgeCommandArgs,
+}
+
+#[derive(Debug, Subcommand)]
+enum ForgeCommandArgs {
+    Create(ForgeCreateArgs),
+    Promote(ForgePromoteArgs),
+    Validate(ForgeValidateArgs),
 }
 
 #[derive(Debug, Args)]
 struct ForgeCreateArgs {
-    #[arg(long)]
+    #[arg(long, default_value = "workflows/jade-symphony.md")]
     workflow: PathBuf,
     #[arg(long)]
     title: String,
+    #[command(flatten)]
+    markdown: ForgeMarkdownArgs,
+    #[arg(long, value_enum, ignore_case = true, default_value_t = ForgeStatusArg::Todo)]
+    status: ForgeStatusArg,
     #[arg(long)]
-    file: Option<PathBuf>,
-    #[arg(long)]
-    body: Option<String>,
-    #[arg(long = "add-to-project")]
-    add_to_project: bool,
+    project: Option<String>,
     #[arg(long = "project-field")]
     project_fields: Vec<String>,
     #[arg(long = "assignee")]
@@ -7170,43 +7267,58 @@ struct ForgeCreateArgs {
     #[arg(long)]
     write: bool,
     #[arg(long = "dry-run")]
-    _dry_run: bool,
+    dry_run: bool,
 }
 
 #[derive(Debug, Args)]
-struct ForgeInteractiveArgs {
+struct ForgePromoteArgs {
+    issue_ref: String,
+    #[arg(long, default_value = "workflows/jade-symphony.md")]
+    workflow: PathBuf,
     #[arg(long)]
-    workflow: Option<PathBuf>,
-    #[arg(long)]
-    title: Option<String>,
-    #[arg(long)]
-    intent: Option<String>,
-    #[arg(long)]
-    file: Option<PathBuf>,
-    #[arg(long)]
-    skill: Option<String>,
-    #[arg(long = "context-file")]
-    context_file: Option<PathBuf>,
-    #[arg(long = "assignee")]
-    assignees: Vec<String>,
-    #[arg(long = "add-to-project")]
-    add_to_project: bool,
+    title: String,
+    #[command(flatten)]
+    markdown: ForgeMarkdownArgs,
     #[arg(long)]
     write: bool,
-    #[arg(long = "confirm-create")]
-    confirm_create: bool,
     #[arg(long = "dry-run")]
-    _dry_run: bool,
+    dry_run: bool,
 }
 
 #[derive(Debug, Args)]
-struct ForgeReflectArgs {
-    #[arg(long = "context-file")]
-    context_file: PathBuf,
+struct ForgeValidateArgs {
+    #[arg(long, default_value = "workflows/jade-symphony.md")]
+    workflow: PathBuf,
+    #[arg(long, value_enum, ignore_case = true)]
+    status: Option<ForgeStatusArg>,
     #[arg(long)]
-    skill: Option<String>,
-    #[arg(long, default_value_t = 3)]
-    limit: usize,
+    title: Option<String>,
+    #[command(flatten)]
+    markdown: ForgeMarkdownArgs,
+    #[arg(long = "issue")]
+    issue_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum ForgeStatusArg {
+    Backlog,
+    Todo,
+}
+
+impl ForgeStatusArg {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Backlog => "Backlog",
+            Self::Todo => "Todo",
+        }
+    }
+
+    fn normalized_state(self) -> &'static str {
+        match self {
+            Self::Backlog => "backlog",
+            Self::Todo => "todo",
+        }
+    }
 }
 
 impl TryFrom<Cli> for Command {
@@ -7470,53 +7582,57 @@ impl TryFrom<Cli> for Command {
                         apply: true,
                         write: args.write,
                     }),
-                    CliCommand::ForgeDiscover(args) => Ok(Self::ForgeDiscover {
-                        source: read_source_arg(args.intent, args.file)?,
-                    }),
-                    CliCommand::ForgeDiscuss(args) => Ok(Self::ForgeDiscuss {
-                        title: args.title,
-                        markdown: read_source_arg(args.body, args.file)?,
-                    }),
-                    CliCommand::ForgeDraft(args) => Ok(Self::ForgeDraft {
-                        title: args.title,
-                        goal: args.goal,
-                    }),
-                    CliCommand::ForgeValidate(args) => Ok(Self::ForgeValidate {
-                        title: args.title,
-                        markdown: read_source_arg(args.body, args.file)?,
-                    }),
-                    CliCommand::ForgeRepair(args) => Ok(Self::ForgeRepair {
-                        title: args.title,
-                        markdown: read_source_arg(args.body, args.file)?,
-                    }),
-                    CliCommand::ForgeCreate(args) => Ok(Self::ForgeCreate {
-                        workflow_path: args.workflow,
-                        title: args.title,
-                        markdown: read_source_arg(args.body, args.file)?,
-                        add_to_project: args.add_to_project,
-                        project_fields: parse_project_field_assignments(args.project_fields)?,
-                        assignees: args.assignees,
-                        write: args.write,
-                    }),
-                    CliCommand::ForgeInteractive(args) => Ok(Self::ForgeInteractive {
-                        options: ForgeInteractiveOptions {
+                    CliCommand::Forge(args) => match args.command {
+                        ForgeCommandArgs::Create(args) => Ok(Self::ForgeCreate {
                             workflow_path: args.workflow,
                             title: args.title,
-                            intent: args.intent,
-                            file: args.file,
-                            skill: validate_optional_forge_skill(args.skill)?,
-                            context: read_optional_file(args.context_file)?,
+                            markdown: read_forge_markdown_arg(args.markdown)?,
+                            status: args.status,
+                            project: args.project,
+                            project_fields: parse_project_field_assignments(args.project_fields)?,
                             assignees: args.assignees,
-                            add_to_project: args.add_to_project,
                             write: args.write,
-                            confirm_create: args.confirm_create,
-                        },
-                    }),
-                    CliCommand::ForgeReflect(args) => Ok(Self::ForgeReflect {
-                        context: read_required_file(args.context_file)?,
-                        skill: validate_optional_forge_skill(args.skill)?,
-                        limit: args.limit,
-                    }),
+                            dry_run: args.dry_run,
+                        }),
+                        ForgeCommandArgs::Promote(args) => Ok(Self::ForgePromote {
+                            workflow_path: args.workflow,
+                            issue_ref: args.issue_ref,
+                            title: args.title,
+                            markdown: read_forge_markdown_arg(args.markdown)?,
+                            write: args.write,
+                            dry_run: args.dry_run,
+                        }),
+                        ForgeCommandArgs::Validate(args) => {
+                            if let Some(issue_ref) = args.issue_ref {
+                                if args.title.is_some()
+                                    || args.markdown.body.is_some()
+                                    || args.markdown.body_file.is_some()
+                                {
+                                    return Err(
+                                        "forge validate --issue cannot be combined with --title, --body, or --body-file"
+                                            .into(),
+                                    );
+                                }
+                                Ok(Self::ForgeValidate {
+                                    workflow_path: args.workflow,
+                                    status: args.status,
+                                    title: String::new(),
+                                    markdown: String::new(),
+                                    issue_ref: Some(issue_ref),
+                                })
+                            } else {
+                                Ok(Self::ForgeValidate {
+                                    workflow_path: args.workflow,
+                                    status: args.status,
+                                    title: args.title.ok_or(
+                                        "forge validate requires --title when --issue is not used",
+                                    )?,
+                                    markdown: read_forge_markdown_arg(args.markdown)?,
+                                    issue_ref: None,
+                                })
+                            }
+                        }
+                    },
                 }
             }
         }
@@ -7574,17 +7690,13 @@ fn gate_target_state(decision: &GateDecision) -> &'static str {
     }
 }
 
-fn read_source_arg(inline: Option<String>, file: Option<PathBuf>) -> Result<String, String> {
-    match (inline, file) {
+fn read_forge_markdown_arg(args: ForgeMarkdownArgs) -> Result<String, String> {
+    match (args.body, args.body_file) {
         (Some(value), None) => Ok(value),
         (None, Some(path)) => std::fs::read_to_string(&path)
             .map_err(|error| format!("failed to read {}: {error}", path.display())),
         _ => Err(usage()),
     }
-}
-
-fn read_optional_file(file: Option<PathBuf>) -> Result<Option<String>, String> {
-    file.map(read_required_file).transpose()
 }
 
 fn read_required_file(path: PathBuf) -> Result<String, String> {
@@ -7601,16 +7713,7 @@ fn parse_project_field_assignments(
         .collect()
 }
 
-fn validate_optional_forge_skill(skill: Option<String>) -> Result<Option<String>, String> {
-    if let Some(key) = skill.as_deref() {
-        if find_issue_skill(key).is_none() {
-            return Err(format!("unknown Issue Forge skill: {key}"));
-        }
-    }
-    Ok(skill)
-}
-
-fn print_forge_validation(report: &jade_symphony::issue_forge::ForgeValidationReport) {
+fn print_forge_validation(report: &ForgeValidationReport) {
     println!("title={}", report.title);
     println!("gate={:?}", report.decision.kind);
     println!("dispatchable={}", report.decision.is_dispatchable());
@@ -7624,19 +7727,6 @@ fn print_forge_validation(report: &jade_symphony::issue_forge::ForgeValidationRe
         println!("question={}", question.question);
         println!("why={}", question.why_it_matters);
     }
-}
-
-fn print_interactive_forge_report(report: &jade_symphony::issue_forge::InteractiveForgeReport) {
-    println!("skill={}", report.selected_skill.key);
-    print_forge_validation(&report.validation);
-    if let Some(question) = &report.question {
-        println!("clarification_question={}", question.question);
-        println!("clarification_why={}", question.why_it_matters);
-    } else {
-        println!("clarification_question=none");
-    }
-    println!("\n--- issue draft ---\n");
-    println!("{}", report.issue_markdown);
 }
 
 fn usage() -> String {
@@ -7688,7 +7778,7 @@ mod tests {
         let mut config = test_config();
         config.observability.logs_root = temp.path().join("logs");
         config.identity.actor_role = "merge_agent".into();
-        config.identity.actor_label = "Jade Merge Worker".into();
+        config.identity.actor_label = "Jade Symphony Merge Worker".into();
 
         append_tracker_mutation_audit(
             &config,
@@ -7709,7 +7799,10 @@ mod tests {
         let record = records.first().expect("expected audit record");
         assert_eq!(record.event, "tracker_mutation");
         assert_eq!(record.actor_role.as_deref(), Some("merge_agent"));
-        assert_eq!(record.actor_label.as_deref(), Some("Jade Merge Worker"));
+        assert_eq!(
+            record.actor_label.as_deref(),
+            Some("Jade Symphony Merge Worker")
+        );
         assert_eq!(
             record
                 .tracker_mutation
@@ -9072,7 +9165,7 @@ mod tests {
     #[test]
     fn pool_worker_selection_respects_lane_priority_and_claim_owner() {
         let config = test_config();
-        let worker = "Jade Main";
+        let worker = "Jade Symphony Main";
         let mut first = tracker_issue_with_ref("#1", "First", "Todo");
         first.priority = Some(20);
         let mut second = tracker_issue_with_ref("#2", "Second", "Rework");
@@ -9997,14 +10090,18 @@ mod tests {
     #[test]
     fn parses_forge_create_flags() {
         let command = Command::parse(vec![
-            "forge-create".into(),
+            "forge".into(),
+            "create".into(),
             "--workflow".into(),
             "examples/dry-run-workflow.md".into(),
             "--title".into(),
             "Create issue".into(),
             "--body".into(),
             forge_contract(),
-            "--add-to-project".into(),
+            "--status".into(),
+            "todo".into(),
+            "--project".into(),
+            "workflow".into(),
             "--project-field".into(),
             "Capability=CLI".into(),
             "--assignee".into(),
@@ -10017,19 +10114,22 @@ mod tests {
             workflow_path,
             title,
             markdown,
-            add_to_project,
+            status,
+            project,
             project_fields,
             assignees,
             write,
+            dry_run,
         } = command
         else {
-            panic!("expected forge-create command");
+            panic!("expected forge create command");
         };
 
         assert_eq!(workflow_path, PathBuf::from("examples/dry-run-workflow.md"));
         assert_eq!(title, "Create issue");
         assert!(markdown.contains("## Issue Goal"));
-        assert!(add_to_project);
+        assert_eq!(status, ForgeStatusArg::Todo);
+        assert_eq!(project.as_deref(), Some("workflow"));
         assert_eq!(
             project_fields,
             vec![ProjectFieldAssignment {
@@ -10039,29 +10139,43 @@ mod tests {
         );
         assert_eq!(assignees, vec!["@Alive24".to_string()]);
         assert!(write);
+        assert!(!dry_run);
     }
 
     #[test]
-    fn forge_create_project_fields_require_project_add() {
-        let error = forge_create(
-            PathBuf::from("missing-workflow.md"),
-            "Create issue".into(),
+    fn parses_forge_promote_flags() {
+        let command = Command::parse(vec![
+            "forge".into(),
+            "promote".into(),
+            "#241".into(),
+            "--workflow".into(),
+            "examples/dry-run-workflow.md".into(),
+            "--title".into(),
+            "Promoted issue".into(),
+            "--body".into(),
             forge_contract(),
-            false,
-            vec![ProjectFieldAssignment {
-                name: "Capability".into(),
-                value: "CLI".into(),
-            }],
-            Vec::new(),
-            true,
-        )
-        .unwrap_err()
-        .to_string();
+            "--dry-run".into(),
+        ])
+        .unwrap();
 
-        assert_eq!(
-            error,
-            "forge-create --project-field requires --add-to-project"
-        );
+        let Command::ForgePromote {
+            workflow_path,
+            issue_ref,
+            title,
+            markdown,
+            write,
+            dry_run,
+        } = command
+        else {
+            panic!("expected forge promote command");
+        };
+
+        assert_eq!(workflow_path, PathBuf::from("examples/dry-run-workflow.md"));
+        assert_eq!(issue_ref, "#241");
+        assert_eq!(title, "Promoted issue");
+        assert!(markdown.contains("## Issue Goal"));
+        assert!(!write);
+        assert!(dry_run);
     }
 
     #[test]
@@ -10106,91 +10220,64 @@ mod tests {
     }
 
     #[test]
-    fn parses_forge_interactive_flags() {
+    fn parses_forge_validate_issue_flags() {
         let command = Command::parse(vec![
-            "forge-interactive".into(),
+            "forge".into(),
+            "validate".into(),
             "--workflow".into(),
             "examples/github-project-workflow.md".into(),
-            "--title".into(),
-            "Add resume preflight".into(),
-            "--intent".into(),
-            "run-loop should inspect runtime state before claiming new work".into(),
-            "--skill".into(),
-            "runtime".into(),
-            "--assignee".into(),
-            "Alive24".into(),
-            "--add-to-project".into(),
-            "--write".into(),
-            "--confirm-create".into(),
+            "--issue".into(),
+            "#248".into(),
+            "--status".into(),
+            "todo".into(),
         ])
         .unwrap();
 
-        let Command::ForgeInteractive { options } = command else {
-            panic!("expected forge-interactive command");
+        let Command::ForgeValidate {
+            workflow_path,
+            status,
+            title,
+            markdown,
+            issue_ref,
+        } = command
+        else {
+            panic!("expected forge validate command");
         };
 
         assert_eq!(
-            options.workflow_path,
-            Some(PathBuf::from("examples/github-project-workflow.md"))
+            workflow_path,
+            PathBuf::from("examples/github-project-workflow.md")
         );
-        assert_eq!(options.title.as_deref(), Some("Add resume preflight"));
-        assert!(options.intent.as_deref().unwrap().contains("runtime state"));
-        assert_eq!(options.skill.as_deref(), Some("runtime"));
-        assert_eq!(options.assignees, vec!["Alive24".to_string()]);
-        assert!(options.add_to_project);
-        assert!(options.write);
-        assert!(options.confirm_create);
+        assert_eq!(status, Some(ForgeStatusArg::Todo));
+        assert!(title.is_empty());
+        assert!(markdown.is_empty());
+        assert_eq!(issue_ref.as_deref(), Some("#248"));
     }
 
     #[test]
-    fn parses_forge_interactive_without_title_for_conversational_path() {
-        let command = Command::parse(vec![
-            "forge-interactive".into(),
+    fn rejects_removed_flat_forge_commands() {
+        let error = Command::parse(vec![
+            "forge-create".into(),
             "--workflow".into(),
             "workflows/jade-symphony.md".into(),
         ])
-        .unwrap();
-
-        let Command::ForgeInteractive { options } = command else {
-            panic!("expected forge-interactive command");
-        };
-
-        assert_eq!(
-            options.workflow_path,
-            Some(PathBuf::from("workflows/jade-symphony.md"))
-        );
-        assert!(options.title.is_none());
-        assert!(options.intent.is_none());
-        assert!(options.assignees.is_empty());
-    }
-
-    #[test]
-    fn rejects_unknown_forge_skill() {
-        let error = Command::parse(vec![
-            "forge-interactive".into(),
-            "--title".into(),
-            "Add a thing".into(),
-            "--intent".into(),
-            "make the runtime loop safer".into(),
-            "--skill".into(),
-            "product-roadmap".into(),
-        ])
         .unwrap_err();
 
-        assert!(error.contains("unknown Issue Forge skill"));
+        assert!(error.contains("Usage:"));
     }
 
     #[test]
     fn rejects_forge_create_with_both_body_and_file() {
         let error = Command::parse(vec![
-            "forge-create".into(),
+            "forge".into(),
+            "create".into(),
             "--workflow".into(),
             "WORKFLOW.md".into(),
             "--title".into(),
             "Create issue".into(),
             "--body".into(),
             forge_contract(),
-            "--file".into(),
+            "--body-file".into(),
             "issue.md".into(),
         ])
         .unwrap_err();
@@ -10234,7 +10321,14 @@ mod tests {
             .unwrap_err();
 
         assert!(error.contains("tracker issue was not created"));
-        assert!(forge_create_requires_assignee(&config));
+        assert!(forge_create_requires_assignee(
+            &config,
+            ForgeStatusArg::Todo
+        ));
+        assert!(!forge_create_requires_assignee(
+            &config,
+            ForgeStatusArg::Backlog
+        ));
     }
 
     #[test]
@@ -10247,21 +10341,23 @@ mod tests {
         )
         .unwrap();
 
-        let error = forge_create(
+        let error = forge_create(ForgeCreateOptions {
             workflow_path,
-            "Create issue".into(),
-            forge_contract(),
-            false,
-            Vec::new(),
-            Vec::new(),
-            true,
-        )
+            title: "Create issue".into(),
+            markdown: forge_contract(),
+            status: ForgeStatusArg::Todo,
+            project: None,
+            project_fields: Vec::new(),
+            assignees: Vec::new(),
+            write: true,
+            dry_run: false,
+        })
         .unwrap_err()
         .to_string();
 
         assert_eq!(
             error,
-            "forge-create requires --assignee for live GitHub issue creation"
+            "forge create --status Todo requires --assignee for live GitHub issue creation"
         );
     }
 
@@ -10304,15 +10400,17 @@ mod tests {
         )
         .unwrap();
 
-        let error = forge_create(
+        let error = forge_create(ForgeCreateOptions {
             workflow_path,
-            "Create issue".into(),
-            forge_contract(),
-            true,
-            Vec::new(),
-            Vec::new(),
-            true,
-        )
+            title: "Create issue".into(),
+            markdown: forge_contract(),
+            status: ForgeStatusArg::Todo,
+            project: None,
+            project_fields: Vec::new(),
+            assignees: Vec::new(),
+            write: true,
+            dry_run: false,
+        })
         .unwrap_err()
         .to_string();
 
@@ -10331,15 +10429,17 @@ mod tests {
         )
         .unwrap();
 
-        forge_create(
+        forge_create(ForgeCreateOptions {
             workflow_path,
-            "Create issue".into(),
-            forge_contract(),
-            true,
-            Vec::new(),
-            Vec::new(),
-            true,
-        )
+            title: "Create issue".into(),
+            markdown: forge_contract(),
+            status: ForgeStatusArg::Todo,
+            project: None,
+            project_fields: Vec::new(),
+            assignees: Vec::new(),
+            write: true,
+            dry_run: false,
+        })
         .unwrap();
     }
 

--- a/src/quality_gate.rs
+++ b/src/quality_gate.rs
@@ -55,7 +55,9 @@ pub fn evaluate_issue(issue: &TrackerIssue) -> GateDecision {
             kind: GateDecisionKind::NeedToClarify,
             missing,
             assumptions: Vec::new(),
-            notes: vec!["Issue contract does not yet match the Jade quality template.".into()],
+            notes: vec![
+                "Issue contract does not yet match the Jade Symphony quality template.".into(),
+            ],
         };
     }
 

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::process::Command;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -17,6 +17,17 @@ pub trait TrackerAdapter {
     fn fetch_issues_by_states(&self, states: &[String]) -> Result<Vec<TrackerIssue>, TrackerError>;
     fn set_state(&self, issue_ref: &str, normalized_state: &str) -> Result<(), TrackerError>;
     fn upsert_workpad(&self, issue_ref: &str, markdown: &str) -> Result<(), TrackerError>;
+    fn update_issue_content(
+        &self,
+        _issue_ref: &str,
+        _title: &str,
+        _body: &str,
+    ) -> Result<(), TrackerError> {
+        Err(TrackerError::NotImplemented(format!(
+            "{} tracker does not support issue content updates",
+            self.kind()
+        )))
+    }
     fn create_follow_up_issue(&self, input: FollowUpIssueInput) -> Result<String, TrackerError>;
     fn add_issue_to_project(&self, issue_id: &str) -> Result<(), TrackerError>;
     fn set_project_field(
@@ -269,6 +280,15 @@ impl TrackerAdapter for MemoryTracker {
         Ok(())
     }
 
+    fn update_issue_content(
+        &self,
+        _issue_ref: &str,
+        _title: &str,
+        _body: &str,
+    ) -> Result<(), TrackerError> {
+        Ok(())
+    }
+
     fn create_follow_up_issue(&self, input: FollowUpIssueInput) -> Result<String, TrackerError> {
         Ok(format!("dry-run:{}", input.title))
     }
@@ -483,6 +503,21 @@ impl TrackerAdapter for GithubProjectV2Adapter {
         }
 
         GithubProjectV2GhClient::new(&self.config).upsert_workpad(issue_ref, markdown)
+    }
+
+    fn update_issue_content(
+        &self,
+        issue_ref: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<(), TrackerError> {
+        if self.config.tracker.fixture_path.is_some() {
+            return Err(TrackerError::IntegrationUnavailable(
+                "GitHub Project v2 fixture mode cannot update live issue content".into(),
+            ));
+        }
+
+        GithubProjectV2GhClient::new(&self.config).update_issue_content(issue_ref, title, body)
     }
 
     fn create_follow_up_issue(&self, input: FollowUpIssueInput) -> Result<String, TrackerError> {
@@ -802,6 +837,66 @@ impl GithubProjectV2GhClient {
                     String::from_utf8_lossy(&output.stderr).trim().to_string(),
                 ));
             }
+        }
+
+        Ok(())
+    }
+
+    fn update_issue_content(
+        &self,
+        issue_ref: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<(), TrackerError> {
+        if !gh_available() {
+            return Err(TrackerError::IntegrationUnavailable(
+                "GitHub issue editing requires the `gh` CLI on PATH".into(),
+            ));
+        }
+        let owner = self
+            .config
+            .tracker
+            .owner
+            .as_deref()
+            .ok_or_else(|| TrackerError::Payload("tracker.owner is required".into()))?;
+        let repo = self
+            .config
+            .tracker
+            .repo
+            .as_deref()
+            .ok_or_else(|| TrackerError::Payload("tracker.repo is required".into()))?;
+        let number = github_issue_number(issue_ref).ok_or_else(|| {
+            TrackerError::Payload(format!(
+                "issue ref {issue_ref:?} is not a GitHub issue number"
+            ))
+        })?;
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis())
+            .unwrap_or_default();
+        let body_path =
+            std::env::temp_dir().join(format!("jade-symphony-issue-body-{number}-{nonce}.md"));
+        fs::write(&body_path, body)
+            .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
+        let output = Command::new("gh")
+            .args([
+                "issue",
+                "edit",
+                &number.to_string(),
+                "--repo",
+                &format!("{owner}/{repo}"),
+                "--title",
+                title,
+                "--body-file",
+            ])
+            .arg(&body_path)
+            .output()
+            .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
+        let _ = fs::remove_file(&body_path);
+        if !output.status.success() {
+            return Err(TrackerError::IntegrationUnavailable(
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ));
         }
 
         Ok(())

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -364,7 +364,7 @@ mod tests {
             id: "ISSUE_48".into(),
             item_id: Some("PROJECT_ITEM_48".into()),
             identifier: "#48".into(),
-            title: "Replace placeholder dogfood workflow with real Jade prompt".into(),
+            title: "Replace placeholder dogfood workflow with real Jade Symphony prompt".into(),
             description: Some(
                 [
                     "## Issue Goal",

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -8,15 +8,9 @@ contract under `workflows/prompts/`.
 Use it for live Project #9 operations:
 
 ```bash
-jade-symphony loop workflows/jade-symphony.md --write
-jade-symphony forge workflows/jade-symphony.md --interactive
-```
-
-The current CLI command names are still the explicit debug/runtime names:
-
-```bash
 cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --write
-cargo run -- forge-interactive --workflow workflows/jade-symphony.md
+cargo run -- forge validate --workflow workflows/jade-symphony.md --status Todo --title "<title>" --body-file /private/tmp/issue.md
+cargo run -- forge create --workflow workflows/jade-symphony.md --status Todo --title "<title>" --body-file /private/tmp/issue.md --assignee Alive24 --write
 cargo run -- review-loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- merge-once workflows/jade-symphony.md --write
 cargo run -- review-session workflows/jade-symphony.md '#123' --write


### PR DESCRIPTION
## Summary

- Replace flat Forge CLI entrypoints with `forge create`, `forge promote`, and `forge validate`.
- Add Backlog seed validation, Todo quality-gate validation, dry-run create/promote flows, and checkpointed Backlog-to-Todo promotion.
- Route issue title/body edits through the tracker adapter and update docs/examples/user-facing naming to `Jade Symphony CLI` / `Jade Symphony`.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo run -- --help`
- `cargo run -- forge --help`
- `cargo run -- forge validate --workflow examples/dry-run-workflow.md --status Backlog --title 'Backlog seed fixture' --body-file examples/fixtures/repaired-issue.md`
- `cargo run -- forge validate --workflow examples/dry-run-workflow.md --status Todo --title 'Executable issue fixture' --body-file /private/tmp/jade-248-valid-issue.md`
- `cargo run -- forge create --workflow examples/dry-run-workflow.md --status Backlog --title 'Backlog: forge smoke fixture' --body-file /private/tmp/jade-248-valid-issue.md --dry-run`
- `cargo run -- forge promote '#248b' --workflow /private/tmp/jade-248-backlog-workflow.md --title 'Promote forge smoke fixture' --body-file /private/tmp/jade-248-valid-issue.md --dry-run`
- `rg --pcre2 -n "\bJade(?! Symphony|Symphony)" docs README.md Cargo.toml examples src workflows`

Closes #248
