### PR TITLE
Enforce verified PR linkage for lane handoffs

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -63,8 +63,7 @@ evidence and runs `gh pr ready`; `doctor --auto-fix` never marks PRs ready.
 | Command | Purpose | Boundary |
 | --- | --- | --- |
 | `run-once` | Execute one selected issue through the configured backend. | Fixture-safe by default when the workflow has `tracker.fixture_path`. |
-| `run-loop` | Poll/select/claim/run/handoff in bounded or idle-loop modes. | Live write mode requires `--write` and a real main-agent backend; tmux sessions stay active instead of auto-handing off; Agent Review handoff requires a ready, non-draft PR. |
-| `dogfood-smoke` | Supervised preflight for one controlled dogfood issue. | Dry-run inspection by default; live readiness does not bypass review or merge gates. |
+| `run-loop` | Poll/select/claim/run/handoff in bounded or idle-loop modes. | Live write mode requires `--write` and a real main-agent backend; tmux sessions stay active instead of auto-handing off; Agent Review handoff requires a verified Project-visible, ready, non-draft PR. |
 
 Examples:
 
@@ -73,7 +72,6 @@ cargo run -- run-once examples/dry-run-workflow.md
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run
 cargo run -- run-loop examples/dry-run-workflow.md --max-iterations 1 --dry-run --display tui
 cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --pool 2 --dry-run
-cargo run -- dogfood-smoke workflows/jade-symphony.md --dry-run
 cargo run -- clean plan workflows/jade-symphony.md
 cargo run -- clean audit workflows/jade-symphony.md
 ```
@@ -93,6 +91,13 @@ example `v=1 lane=main actor=codex source=loop issue=#244 run=... state=active
 thread=unknown registry=run/...`. The Project field stores the compact pointer;
 the session registry and workpad store the durable paths, logs, and handoff
 evidence for the same `run=`.
+
+PR relationship verification is a lane invariant, not just evidence text. A PR
+URL found in a workpad, issue comment, or local branch can help operators
+identify the intended PR, but the issue must expose that PR through the
+Project/issue linked-PR read surface before Main handoff, Review routing, or
+Merge landing. If Jade Symphony cannot verify the relationship after a repair
+attempt, it routes the issue to `Need Human Input` with the blocker preserved.
 
 The canonical `workflows/jade-symphony.md` file uses the local `tmux` main-agent
 backend. A launched tmux session records its session name, log path, workspace,

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -41,10 +41,11 @@ and operator prompts should be promoted into `workflows/`, `examples/`, or
 `docs/` before they become the canonical run path. Normal operator workflow
 config belongs in `workflows/`; `examples/` is fixture/reference material.
 
-The controlled live smoke runbook is in `docs/dogfood-smoke.md`. It keeps the
-first dogfood acceptance path supervised and bounded to one controlled issue;
-`examples/dogfood-smoke-workflow.md` provides a credential-free fixture
-rehearsal of the same candidate filtering path.
+Normal dogfood should exercise `project-state`, `run-loop`, `review-loop`,
+`merge-loop`, `doctor`, and related lane preflight surfaces directly.
+`docs/dogfood-smoke.md` and `examples/dogfood-smoke-workflow.md` remain legacy
+fixture references for the older controlled smoke helper, not the canonical
+operator entrypoint.
 
 The bootstrap completion audit is in `docs/bootstrap-parity-audit.md`. It
 separates landed mainline capability from open `Agent Review` coverage and
@@ -115,9 +116,11 @@ Project v2 issues:
      route manual review pass/reject outcomes.
    - Mutating commands require `--write`.
    - Same-state status updates are treated as no-ops before mutation.
-   - PR linking currently uses an issue comment/autolink strategy instead of a
-     first-class relationship; linked PR discovery can read closing references
-     and PR URLs recorded in canonical Jade Symphony workpad comments.
+   - PR relationship verification is first-class for lane transitions:
+     Project/issue linked-PR reads must expose the PR before Main handoff,
+     Review routing, or Merge landing. Workpad/comment URLs are discovery
+     evidence only; if Jade Symphony can identify a PR but cannot verify or
+     repair the relationship, the issue must stop in `Need Human Input`.
    - Remaining work: idempotency checks around project-item addition and richer
      reconciliation after writes.
 
@@ -236,9 +239,10 @@ Project v2 issues:
      non-fixture GitHub mode the runtime can create/reuse the issue worktree and
      branch, run optional configured verification commands, push the branch, and
      create/reuse one PR after successful backend execution, while blocking
-     dirty or no-op branch handoff. It records the PR link through the tracker
-     adapter and marks draft PRs ready before Agent Review handoff. Remaining
-     work: cleanup, richer reconciliation, and richer verification modeling.
+     dirty or no-op branch handoff. It attempts to record the PR link through
+     the tracker adapter, verifies the Project-visible linked-PR read surface,
+     and marks draft PRs ready before Agent Review handoff. Remaining work:
+     cleanup, richer reconciliation, and richer verification modeling.
    - `cleanup-plan` can report terminal worktree candidates without deleting
      files. Remaining work: explicit write-mode artifact cleanup after operator
      review.

--- a/docs/dogfood-smoke.md
+++ b/docs/dogfood-smoke.md
@@ -1,7 +1,9 @@
 # Controlled Dogfood Smoke
 
-This is the supervised live smoke path for checking whether Jade Symphony is
+This is a legacy supervised smoke helper for checking whether Jade Symphony is
 ready to operate against GitHub Project v2 without manual per-issue prompting.
+It is not the canonical dogfood entrypoint; prefer normal lane surfaces such as
+`project-state`, `run-loop`, `review-loop`, `merge-loop`, and `doctor`.
 
 The smoke is intentionally opt-in. It does not create or merge production work
 by itself.

--- a/docs/live-github-smoke-tests.md
+++ b/docs/live-github-smoke-tests.md
@@ -22,7 +22,8 @@ JADE_LIVE_GITHUB_SMOKE=1 cargo test --test live_github_smoke
 The smoke runs:
 
 - `jade-symphony inspect workflows/jade-symphony.md`
-- `jade-symphony dogfood-smoke workflows/jade-symphony.md --dry-run`
+- `jade-symphony project-state workflows/jade-symphony.md`
+- `jade-symphony run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run`
 
 ## Expected Behavior
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -80,10 +80,13 @@ explicit confirmation flag is present. Before that mutating tick, the launcher
 runs:
 
 ```bash
-target/debug/jade-symphony dogfood-smoke workflows/jade-symphony.md --dry-run
+target/debug/jade-symphony project-state workflows/jade-symphony.md
+target/debug/jade-symphony run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
 ```
 
-If the smoke preflight fails, the launcher exits before claiming tracker work.
+If the normal preflight surfaces fail, the launcher exits before claiming
+tracker work. `dogfood-smoke` remains a hidden legacy smoke helper for older
+fixtures; it is not the canonical operator entrypoint.
 The canonical workflow now uses the local `tmux` main-agent backend. A write
 tick starts an attachable tmux session, records its attach command and log path,
 persists a session registry record under the configured artifact root, and
@@ -95,10 +98,14 @@ only then pastes the rendered issue prompt. Set
 `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` to opt out; when disabled, or when readiness
 cannot be confirmed, the tick fails closed with attach/log evidence and does not
 hand off to `Agent Review`.
-Main handoff also requires the linked PR to be ready, not draft. When all other
-handoff evidence is valid, `run-loop --write` may run `gh pr ready` before
-moving the issue to `Agent Review`; if that readiness mutation fails, keep the
-issue out of `Agent Review` and preserve the blocker in the workpad.
+Main handoff also requires the PR relationship to be visible through Jade
+Symphony's Project/issue linked-PR read surface, and the linked PR must be
+ready, not draft. Workpad or comment URLs can identify the intended PR, but
+they are not a permanent substitute for the verified relationship. When all
+other handoff evidence is valid, `run-loop --write` may run `gh pr ready`
+before moving the issue to `Agent Review`; if relationship verification or
+readiness mutation fails, keep the issue out of `Agent Review`, route to
+`Need Human Input`, and preserve the blocker in the workpad.
 Routine status output reads the durable session registry, probes bounded pane
 and log tails, and reports a conservative session classification such as
 `running`, `waiting_for_trust`, `waiting_for_approval`, `usage_limited`,

--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -62,17 +62,19 @@ Review the output before mutating anything. In particular, check for:
 - dirty Merging PRs;
 - integration gaps.
 
-## Controlled Smoke
+## Normal Preflight
 
-Before the first write tick, run the controlled smoke preflight:
+Before the first write tick, run the same preflight surfaces operators use for
+normal work:
 
 ```bash
-cargo run -- dogfood-smoke workflows/jade-symphony.md --dry-run
+cargo run -- project-state workflows/jade-symphony.md
+cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
 ```
 
-Proceed only when there is exactly one executable controlled smoke candidate,
-the tracker is not fixture-backed, and the report shows no blocking integration
-gaps.
+Proceed only when tracker access is trusted, the selected issue is claimable,
+and the dry-run shows no blocking integration gaps. `dogfood-smoke` is kept as
+a hidden legacy fixture helper, not a product dogfood lane.
 
 ## One Implementation Tick
 
@@ -121,13 +123,16 @@ Expected outcome for successful main-agent work:
 - the configured backend runs in that workspace;
 - runtime state and event logs are written;
 - a PR is created or reused;
+- the PR relationship is verified through the Project/issue linked-PR read
+  surface;
 - the linked PR is ready, not draft;
 - the workpad records durable handoff evidence;
 - the issue moves to `Agent Review`, not `Human Review`.
 
-If the run reports usage limits, retry backoff, missing PR evidence, draft PR
-handoff, failed handoff, stale runtime state, or missing human input, stop and
-resolve that specific blocker before running another write tick.
+If the run reports usage limits, retry backoff, missing or unverified PR
+relationship evidence, draft PR handoff, failed handoff, stale runtime state,
+or missing human input, stop and resolve that specific blocker before running
+another write tick.
 
 Before manual Review or Merge recovery, check the issue workspace first:
 
@@ -204,7 +209,7 @@ cargo run -- merge-once workflows/jade-symphony.md --write
 The merge lane should:
 
 - inspect only `Merging` issues;
-- require exactly one linked PR;
+- require exactly one verified linked PR;
 - check PR state, base branch, checks, review/approval signal, and mergeability;
 - merge clean approved work;
 - route dirty or failing work to `Rework` with workpad evidence;

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -43,6 +43,7 @@ pub struct AgentReviewHandoffEvidence {
     pub workspace_path: PathBuf,
     pub branch_name: String,
     pub pull_request_url: Option<String>,
+    pub project_pr_link_verified: Option<bool>,
     pub pull_request_is_draft: Option<bool>,
     pub validation_summary: String,
     pub last_transition: String,
@@ -116,6 +117,7 @@ impl AgentReviewHandoffEvidence {
             workspace_path: plan.workspace_path.clone(),
             branch_name: plan.branch_name.clone(),
             pull_request_url: None,
+            project_pr_link_verified: None,
             pull_request_is_draft: None,
             validation_summary: validation_summary.into(),
             last_transition: last_transition.into(),
@@ -160,6 +162,11 @@ pub fn evaluate_agent_review_handoff(
         missing.push("pull request url or explicit no-PR blocker".into());
     }
     if has_pr {
+        match evidence.project_pr_link_verified {
+            Some(true) => {}
+            Some(false) => missing.push("Project-visible pull request linkage".into()),
+            None => missing.push("Project-visible pull request linkage status".into()),
+        }
         match evidence.pull_request_is_draft {
             Some(false) => {}
             Some(true) => missing.push("non-draft pull request".into()),
@@ -167,7 +174,11 @@ pub fn evaluate_agent_review_handoff(
         }
     }
 
-    if missing.is_empty() && has_pr && evidence.pull_request_is_draft == Some(false) {
+    if missing.is_empty()
+        && has_pr
+        && evidence.project_pr_link_verified == Some(true)
+        && evidence.pull_request_is_draft == Some(false)
+    {
         AgentReviewHandoffReport {
             status: AgentReviewHandoffStatus::Ready,
             missing,
@@ -208,6 +219,13 @@ pub fn render_agent_review_handoff_workpad(
         format!(
             "- Pull request: `{}`",
             evidence.pull_request_url.as_deref().unwrap_or("missing")
+        ),
+        format!(
+            "- Project PR linkage verified: `{}`",
+            evidence
+                .project_pr_link_verified
+                .map(|verified| verified.to_string())
+                .unwrap_or_else(|| "unknown".into())
         ),
         format!(
             "- Pull request draft: `{}`",
@@ -741,6 +759,7 @@ mod tests {
         let mut evidence =
             AgentReviewHandoffEvidence::from_plan(&plan, "cargo test passed", "completed");
         evidence.pull_request_url = Some("https://github.com/Alive24/jade-symphony/pull/21".into());
+        evidence.project_pr_link_verified = Some(true);
         evidence.pull_request_is_draft = Some(false);
 
         let report = evaluate_agent_review_handoff(&evidence);
@@ -750,11 +769,28 @@ mod tests {
     }
 
     #[test]
+    fn agent_review_handoff_blocks_unverified_project_pr_linkage() {
+        let plan = plan_issue_handoff(Path::new("/tmp/jade-workspaces"), &issue(), "main").unwrap();
+        let mut evidence =
+            AgentReviewHandoffEvidence::from_plan(&plan, "cargo test passed", "completed");
+        evidence.pull_request_url = Some("https://github.com/Alive24/jade-symphony/pull/21".into());
+        evidence.pull_request_is_draft = Some(false);
+
+        let report = evaluate_agent_review_handoff(&evidence);
+
+        assert!(!report.is_ready());
+        assert!(report
+            .missing
+            .contains(&"Project-visible pull request linkage status".into()));
+    }
+
+    #[test]
     fn agent_review_handoff_blocks_draft_pr() {
         let plan = plan_issue_handoff(Path::new("/tmp/jade-workspaces"), &issue(), "main").unwrap();
         let mut evidence =
             AgentReviewHandoffEvidence::from_plan(&plan, "cargo test passed", "completed");
         evidence.pull_request_url = Some("https://github.com/Alive24/jade-symphony/pull/21".into());
+        evidence.project_pr_link_verified = Some(true);
         evidence.pull_request_is_draft = Some(true);
 
         let report = evaluate_agent_review_handoff(&evidence);
@@ -769,6 +805,7 @@ mod tests {
         let mut evidence =
             AgentReviewHandoffEvidence::from_plan(&plan, "cargo test passed", "completed");
         evidence.pull_request_url = Some("https://github.com/Alive24/jade-symphony/pull/21".into());
+        evidence.project_pr_link_verified = Some(true);
 
         let report = evaluate_agent_review_handoff(&evidence);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4379,6 +4379,7 @@ struct RunLoopLiveHandoff {
     worktree: LiveWorktreeResult,
     publication: PullRequestPublication,
     verification: String,
+    project_pr_link_verified: Option<bool>,
     pull_request_ready: Option<PullRequestReadyStatus>,
 }
 
@@ -5167,6 +5168,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
                                 worktree,
                                 publication,
                                 verification: verification.summary,
+                                project_pr_link_verified: None,
                                 pull_request_ready: None,
                             });
                         }
@@ -5470,6 +5472,54 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
                     Some(format!("retry in {retry_delay_ms}ms")),
                 ));
                 break;
+            }
+            if result.message.contains("handoff PR link") {
+                runtime_state = run_loop_runtime_state_with_transition(
+                    runtime_state,
+                    Some(latest.state.clone()),
+                    "need_human_input",
+                    "handoff PR linkage invariant failed",
+                );
+                mark_runtime_state_updated(&mut runtime_state, current_time_ms());
+                save_runtime_state(&config, &runtime_state)?;
+                write_lane_claim_state(
+                    &config,
+                    adapter.as_ref(),
+                    &latest,
+                    WorkerLane::Main,
+                    &main_claim,
+                    LaneClaimState::Failed,
+                )?;
+                adapter.set_state(&latest.identifier, "need_human_input")?;
+                append_tracker_mutation_audit(
+                    &config,
+                    TrackerMutationAudit {
+                        command: "run-loop",
+                        mutation_type: "state_change",
+                        issue_ref: Some(&latest.identifier),
+                        target: result
+                            .live_handoff
+                            .as_ref()
+                            .map(|handoff| handoff.publication.pr_url.clone()),
+                        from_state: Some(latest.state.clone()),
+                        to_state: Some("need_human_input".into()),
+                        reason: "handoff PR linkage invariant failed",
+                    },
+                );
+                clear_runtime_state(&config)?;
+                println!(
+                    "run_loop_action=blocked issue={} target_state=need_human_input reason=handoff_pr_linkage_invariant_failed",
+                    latest.identifier
+                );
+                print_latest_status(&latest_status_for_issue(
+                    &config,
+                    &latest,
+                    "main",
+                    "blocked",
+                    "handoff_pr_linkage",
+                    Some("Need Human Input".into()),
+                ));
+                continue;
             }
             if runtime_state.attempt_count < config.agent.max_turns {
                 record_runtime_retry(
@@ -6703,7 +6753,20 @@ fn record_live_handoff_pr_link(
 
     adapter
         .link_pull_request(issue_ref, &handoff.publication.pr_url)
-        .map_err(|error| format!("handoff PR link failed: {error}"))
+        .map_err(|error| format!("handoff PR link repair failed: {error}"))?;
+
+    let linked = adapter
+        .list_linked_pull_requests(issue_ref)
+        .map_err(|error| format!("handoff PR link verification failed: {error}"))?;
+
+    if linked_pull_requests_contain(&linked, &handoff.publication.pr_url) {
+        Ok(())
+    } else {
+        Err(format!(
+            "handoff PR link was not Project-visible after repair attempt: {}",
+            handoff.publication.pr_url
+        ))
+    }
 }
 
 fn apply_live_handoff_pr_link(
@@ -6716,13 +6779,44 @@ fn apply_live_handoff_pr_link(
     }
 
     match record_live_handoff_pr_link(adapter, issue_ref, result) {
-        Ok(()) => true,
+        Ok(()) => {
+            if let Some(handoff) = result.live_handoff.as_mut() {
+                handoff.project_pr_link_verified = Some(true);
+            }
+            true
+        }
         Err(error) => {
+            if let Some(handoff) = result.live_handoff.as_mut() {
+                handoff.project_pr_link_verified = Some(false);
+            }
             result.success = false;
             result.message = error;
             false
         }
     }
+}
+
+fn linked_pull_requests_contain(
+    linked_pull_requests: &[jade_symphony::model::LinkedPullRequest],
+    pr_url: &str,
+) -> bool {
+    let expected_url = pr_url.trim();
+    let expected_number = pull_request_number_from_url(expected_url);
+    linked_pull_requests.iter().any(|linked| {
+        linked
+            .url
+            .as_deref()
+            .is_some_and(|url| url.trim() == expected_url)
+            || expected_number.is_some() && linked.number == expected_number
+    })
+}
+
+fn pull_request_number_from_url(url: &str) -> Option<u64> {
+    url.trim()
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .and_then(|segment| segment.parse().ok())
 }
 
 fn run_loop_agent_review_handoff_evidence(
@@ -6767,6 +6861,17 @@ fn run_loop_agent_review_handoff_evidence(
                 .iter()
                 .find(|pr| pr.url.as_deref() == Some(url))
                 .and_then(|pr| pr.is_draft)
+        });
+    evidence.project_pr_link_verified = result
+        .live_handoff
+        .as_ref()
+        .and_then(|handoff| handoff.project_pr_link_verified)
+        .or_else(|| {
+            let url = evidence.pull_request_url.as_deref()?;
+            Some(linked_pull_requests_contain(
+                &issue.linked_pull_requests,
+                url,
+            ))
         });
     if evidence.pull_request_url.is_none() {
         evidence.no_pr_blocker = Some(
@@ -7201,7 +7306,7 @@ enum CliCommand {
     #[command(name = "doctor-repair-human-review")]
     DoctorRepairHumanReview(DoctorRepairArgs),
     Profiles(WorkflowPathArgs),
-    #[command(name = "dogfood-smoke")]
+    #[command(name = "dogfood-smoke", hide = true)]
     DogfoodSmoke(DogfoodSmokeArgs),
     #[command(name = "cleanup-plan")]
     CleanupPlan(WorkflowPathArgs),
@@ -8548,11 +8653,41 @@ mod tests {
         issue
     }
 
-    #[derive(Default)]
+    fn review_issue_with_ref(identifier: &str, title: &str) -> TrackerIssue {
+        let mut issue = tracker_issue_with_ref(identifier, title, "Agent Review");
+        let number = identifier.trim_start_matches('#');
+        issue
+            .linked_pull_requests
+            .push(jade_symphony::model::LinkedPullRequest {
+                number: number.parse().ok(),
+                url: Some(format!(
+                    "https://github.com/Alive24/jade-symphony/pull/{number}"
+                )),
+                state: Some("OPEN".into()),
+                is_draft: Some(false),
+                ..Default::default()
+            });
+        issue
+    }
+
     struct RecordingAdapter {
         operations: RefCell<Vec<String>>,
+        linked_pull_requests: RefCell<Vec<jade_symphony::model::LinkedPullRequest>>,
         fail_workpad: bool,
         fail_link_pr: bool,
+        confirm_link_pr: bool,
+    }
+
+    impl Default for RecordingAdapter {
+        fn default() -> Self {
+            Self {
+                operations: RefCell::new(Vec::new()),
+                linked_pull_requests: RefCell::new(Vec::new()),
+                fail_workpad: false,
+                fail_link_pr: false,
+                confirm_link_pr: true,
+            }
+        }
     }
 
     impl RecordingAdapter {
@@ -8648,6 +8783,17 @@ mod tests {
             self.operations
                 .borrow_mut()
                 .push(format!("link_pr:{issue_ref}:{pr_ref}"));
+            if self.confirm_link_pr {
+                self.linked_pull_requests.borrow_mut().push(
+                    jade_symphony::model::LinkedPullRequest {
+                        number: pull_request_number_from_url(pr_ref),
+                        url: Some(pr_ref.to_string()),
+                        state: Some("OPEN".into()),
+                        is_draft: Some(false),
+                        ..Default::default()
+                    },
+                );
+            }
             Ok(())
         }
 
@@ -8658,7 +8804,7 @@ mod tests {
             Vec<jade_symphony::model::LinkedPullRequest>,
             jade_symphony::tracker::TrackerError,
         > {
-            Ok(Vec::new())
+            Ok(self.linked_pull_requests.borrow().clone())
         }
 
         fn close_issue(&self, issue_ref: &str) -> Result<(), jade_symphony::tracker::TrackerError> {
@@ -9612,9 +9758,9 @@ mod tests {
     fn review_worker_selection_respects_concurrency_limit() {
         let selected = select_review_worker_issues(
             &[
-                tracker_issue_with_ref("#67", "First review", "Agent Review"),
-                tracker_issue_with_ref("#68", "Second review", "Agent Review"),
-                tracker_issue_with_ref("#69", "Third review", "Agent Review"),
+                review_issue_with_ref("#67", "First review"),
+                review_issue_with_ref("#68", "Second review"),
+                review_issue_with_ref("#69", "Third review"),
             ],
             "Agent Review",
             "fake-reviewer",
@@ -9632,12 +9778,12 @@ mod tests {
 
     #[test]
     fn review_worker_selection_skips_existing_worker_marker() {
-        let mut queued = tracker_issue_with_ref("#67", "Queued review", "Agent Review");
+        let mut queued = review_issue_with_ref("#67", "Queued review");
         queued.project_fields.insert(
             "Review Worker".into(),
             serde_json::Value::String("queued review:#67:fake-reviewer".into()),
         );
-        let ready = tracker_issue_with_ref("#68", "Ready review", "Agent Review");
+        let ready = review_issue_with_ref("#68", "Ready review");
 
         let selected =
             select_review_worker_issues(&[queued, ready], "Agent Review", "fake-reviewer", 2);
@@ -9648,13 +9794,13 @@ mod tests {
 
     #[test]
     fn review_worker_selection_skips_review_agent_field_claim() {
-        let mut queued = tracker_issue_with_ref("#67", "Queued review", "Agent Review");
+        let mut queued = review_issue_with_ref("#67", "Queued review");
         let claim = review_claim_for_issue(&queued, "review:#67:fake-reviewer");
         queued.project_fields.insert(
             "Review Agent".into(),
             serde_json::Value::String(claim.render()),
         );
-        let ready = tracker_issue_with_ref("#68", "Ready review", "Agent Review");
+        let ready = review_issue_with_ref("#68", "Ready review");
 
         let selected =
             select_review_worker_issues(&[queued, ready], "Agent Review", "fake-reviewer", 2);
@@ -9666,8 +9812,7 @@ mod tests {
     #[test]
     fn review_workspace_uses_issue_handoff_workspace() {
         let config = test_config();
-        let issue =
-            tracker_issue_with_ref("#67", "Add parallel review worker pool", "Agent Review");
+        let issue = review_issue_with_ref("#67", "Add parallel review worker pool");
 
         let workspace = review_workspace_for_issue(&config, &issue);
 
@@ -10370,6 +10515,7 @@ mod tests {
                     pr_created: true,
                 },
                 verification: "skipped:not_configured".into(),
+                project_pr_link_verified: Some(true),
                 pull_request_ready: Some(PullRequestReadyStatus {
                     pr_url: "https://github.com/Alive24/jade-symphony/pull/45".into(),
                     was_draft: false,
@@ -10451,9 +10597,8 @@ mod tests {
         let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
         let mut result = successful_live_handoff_result(&handoff);
         let adapter = RecordingAdapter {
-            operations: RefCell::new(Vec::new()),
-            fail_workpad: false,
             fail_link_pr: true,
+            ..Default::default()
         };
 
         assert!(!apply_live_handoff_pr_link(
@@ -10463,7 +10608,42 @@ mod tests {
         ));
 
         assert!(!result.success);
-        assert!(result.message.contains("handoff PR link failed"));
+        assert!(result.message.contains("handoff PR link repair failed"));
+        assert_eq!(
+            result
+                .live_handoff
+                .as_ref()
+                .and_then(|handoff| handoff.project_pr_link_verified),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn live_run_loop_handoff_requires_verified_project_pr_linkage() {
+        let config = test_config();
+        let issue = tracker_issue("In Progress");
+        let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+        let mut result = successful_live_handoff_result(&handoff);
+        let adapter = RecordingAdapter {
+            confirm_link_pr: false,
+            ..Default::default()
+        };
+
+        assert!(!apply_live_handoff_pr_link(
+            &adapter,
+            &issue.identifier,
+            &mut result
+        ));
+
+        assert!(!result.success);
+        assert!(result.message.contains("not Project-visible"));
+        assert_eq!(
+            result
+                .live_handoff
+                .as_ref()
+                .and_then(|handoff| handoff.project_pr_link_verified),
+            Some(false)
+        );
     }
 
     fn successful_live_handoff_result(handoff: &IssueHandoffPlan) -> IssueExecutionResult {
@@ -10501,6 +10681,7 @@ mod tests {
                     pr_created: true,
                 },
                 verification: "skipped:not_configured".into(),
+                project_pr_link_verified: Some(true),
                 pull_request_ready: Some(PullRequestReadyStatus {
                     pr_url: "https://github.com/Alive24/jade-symphony/pull/45".into(),
                     was_draft: false,
@@ -10590,9 +10771,8 @@ mod tests {
     #[test]
     fn rework_transition_does_not_set_state_when_workpad_write_fails() {
         let adapter = RecordingAdapter {
-            operations: RefCell::new(Vec::new()),
             fail_workpad: true,
-            fail_link_pr: false,
+            ..Default::default()
         };
         let issue = tracker_issue("Agent Review");
         let diagnostic = ReworkDiagnostic::validation_failure(

--- a/src/review.rs
+++ b/src/review.rs
@@ -622,6 +622,12 @@ pub fn review_run_eligibility(
         };
     }
 
+    if issue.linked_pull_requests.is_empty() {
+        return ReviewRunEligibility::InvalidHandoff {
+            reason: "Agent Review handoff has no verified Project-visible linked PR; Main Agent or operator repair must establish the PR relationship before normal review.".into(),
+        };
+    }
+
     if issue
         .linked_pull_requests
         .iter()
@@ -1142,7 +1148,12 @@ mod tests {
             assignees: vec![],
             priority: None,
             branch_name: None,
-            linked_pull_requests: vec![],
+            linked_pull_requests: vec![crate::model::LinkedPullRequest {
+                url: Some("https://github.com/Alive24/jade-symphony/pull/1".into()),
+                state: Some("OPEN".into()),
+                is_draft: Some(false),
+                ..Default::default()
+            }],
             blocked_by: vec![],
             project_fields: Default::default(),
             created_at: None,
@@ -1822,8 +1833,17 @@ mod tests {
 
     #[test]
     fn review_run_eligibility_accepts_agent_review_issue() {
+        let mut issue = issue();
+        issue
+            .linked_pull_requests
+            .push(crate::model::LinkedPullRequest {
+                url: Some("https://github.com/Alive24/jade-symphony/pull/1".into()),
+                state: Some("OPEN".into()),
+                is_draft: Some(false),
+                ..Default::default()
+            });
         assert_eq!(
-            review_run_eligibility(&issue(), "Agent Review", "fake"),
+            review_run_eligibility(&issue, "Agent Review", "fake"),
             ReviewRunEligibility::Eligible {
                 worker_key: "review:#1:fake".into()
             }
@@ -1841,6 +1861,18 @@ mod tests {
                 current_state: "Todo".into()
             }
         );
+    }
+
+    #[test]
+    fn review_run_eligibility_rejects_agent_review_missing_pr_linkage() {
+        let mut issue = issue();
+        issue.linked_pull_requests.clear();
+
+        assert!(matches!(
+            review_run_eligibility(&issue, "Agent Review", "fake"),
+            ReviewRunEligibility::InvalidHandoff { reason }
+                if reason.contains("no verified Project-visible linked PR")
+        ));
     }
 
     #[test]

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -1,4 +1,6 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
+#[cfg(test)]
+use std::collections::BTreeSet;
 use std::fs;
 use std::process::Command;
 use std::thread;
@@ -1065,12 +1067,7 @@ impl GithubProjectV2GhClient {
         issue_ref: &str,
     ) -> Result<Vec<LinkedPullRequest>, TrackerError> {
         let issue = self.resolve_issue(issue_ref)?;
-        let marker = &self.config.tracker.workpad.marker;
-        let workpad_bodies = self.find_workpad_comment_bodies(&issue.id, marker)?;
-        Ok(merge_linked_pull_requests(
-            issue.linked_pull_requests,
-            linked_pull_requests_from_workpads(&workpad_bodies),
-        ))
+        Ok(issue.linked_pull_requests)
     }
 
     fn close_issue(&self, issue_ref: &str) -> Result<(), TrackerError> {
@@ -1112,27 +1109,6 @@ impl GithubProjectV2GhClient {
                 } else {
                     None
                 }
-            })
-            .collect())
-    }
-
-    fn find_workpad_comment_bodies(
-        &self,
-        issue_id: &str,
-        marker: &str,
-    ) -> Result<Vec<String>, TrackerError> {
-        let response = self.graphql(
-            GITHUB_ISSUE_COMMENTS_QUERY,
-            &[("issueId", issue_id.to_string())],
-        )?;
-        Ok(response
-            .pointer("/data/node/comments/nodes")
-            .and_then(serde_json::Value::as_array)
-            .into_iter()
-            .flatten()
-            .filter_map(|comment| {
-                let body = comment.get("body")?.as_str()?;
-                body.contains(marker).then(|| body.to_string())
             })
             .collect())
     }
@@ -2305,6 +2281,7 @@ fn pull_requests_from_issue(issue: &serde_json::Value) -> Vec<LinkedPullRequest>
         .collect()
 }
 
+#[cfg(test)]
 fn linked_pull_requests_from_workpads(workpad_bodies: &[String]) -> Vec<LinkedPullRequest> {
     let mut seen = BTreeSet::new();
     let mut linked = Vec::new();
@@ -2318,6 +2295,7 @@ fn linked_pull_requests_from_workpads(workpad_bodies: &[String]) -> Vec<LinkedPu
     linked
 }
 
+#[cfg(test)]
 fn merge_linked_pull_requests(
     existing: Vec<LinkedPullRequest>,
     discovered: Vec<LinkedPullRequest>,
@@ -2335,12 +2313,14 @@ fn merge_linked_pull_requests(
     merged
 }
 
+#[cfg(test)]
 fn github_pull_request_urls(text: &str) -> Vec<String> {
     text.split(|character: char| character.is_whitespace() || character == '<' || character == '>')
         .filter_map(clean_github_pull_request_url)
         .collect()
 }
 
+#[cfg(test)]
 fn clean_github_pull_request_url(raw: &str) -> Option<String> {
     let value = raw.trim_matches(|character: char| {
         matches!(
@@ -2363,6 +2343,7 @@ fn clean_github_pull_request_url(raw: &str) -> Option<String> {
         .then(|| base.to_string())
 }
 
+#[cfg(test)]
 fn linked_pull_request_from_url(url: &str) -> LinkedPullRequest {
     LinkedPullRequest {
         id: None,

--- a/workflows/prompts/main-agent.md
+++ b/workflows/prompts/main-agent.md
@@ -70,9 +70,11 @@ question, but do not edit files under
    evidence, PR summaries, and workpad updates.
 9. Open or update exactly one PR for this issue with concise validation
    evidence.
-10. Confirm the linked PR is ready, not draft. If every other handoff invariant
-   is satisfied and the PR is still draft, mark it ready before moving state;
-   if that fails, keep the issue out of `Agent Review` and record the blocker.
+10. Confirm the linked PR is Project-visible, ready, and not draft. Workpad or
+   comment PR URLs can identify the intended PR, but they are not a substitute
+   for verified Project/issue linked-PR state. If every other handoff invariant
+   is satisfied but PR relationship verification or draft repair fails, keep
+   the issue out of `Agent Review` and record the blocker.
 11. Move locally complete main-agent work to `Agent Review` only.
 12. Return to tracker selection only after this issue has a PR/workpad handoff
     or a documented blocked state.

--- a/workflows/prompts/merge-agent.md
+++ b/workflows/prompts/merge-agent.md
@@ -41,8 +41,8 @@ context, but raw Project GraphQL or Project UI changes are break-glass only.
 
 - Dirty, conflicted, stale, or failing PRs go to `Rework` with diagnostic
   evidence.
-- Ambiguous PR targets or missing approvals go to `Need Human Input` with one
-  concrete question.
+- Missing or ambiguous verified PR targets and missing approvals go to
+  `Need Human Input` with one concrete question.
 - Transient unknown mergeability can remain in `Merging` for retry when the
   command can prove it is transient.
 

--- a/workflows/prompts/review-agent.md
+++ b/workflows/prompts/review-agent.md
@@ -28,7 +28,7 @@ context, but raw Project GraphQL or Project UI changes are break-glass only.
   before starting manual or automated review work.
 - Preserve the assigned structured claim `run=` in review evidence, workpad
   notes, and any handoff summary.
-- Confirm there is one clear PR or handoff target.
+- Confirm there is one verified Project-visible linked PR.
 - Confirm the linked PR is ready, not draft. If the PR is draft, do not run a
   normal review; record invalid handoff evidence and leave the issue out of
   `Human Review`.


### PR DESCRIPTION
## Summary
- require Main handoff evidence to include verified Project-visible PR linkage before Agent Review
- stop Review routing without a verified linked PR and verify run-loop PR repair attempts after linking
- make dogfood-smoke a hidden legacy helper and document normal lane preflight surfaces

## Verification
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- run-loop workflows/jade-symphony.md --max-iterations 1 --dry-run
- cargo run -- project-issue workflows/jade-symphony.md '#245' --json

Closes #245