### PR TITLE
Enforce canonical checkout separation

### DIFF
--- a/docs/artifact-storage-policy.md
+++ b/docs/artifact-storage-policy.md
@@ -17,6 +17,7 @@ operator inspection, but not a substitute for tracker evidence.
 | Workpad draft | Recoverable after tracker workpad upsert | `artifacts/<namespace>/<profile>/drafts/workpads/` |
 | Reusable workflow/operator prompt | Durable repo material | `artifacts/<namespace>/<profile>/workflows/` until promoted to `docs/` or `examples/` |
 | Disposable scratch file | Disposable | `artifacts/<namespace>/<profile>/scratch/` |
+| Canonical checkout quarantine | Operator decision required | `artifacts/<namespace>/<profile>/scratch/canonical-checkout-quarantine/` |
 
 The default artifact root is `~/.jade-symphony/artifacts`. Workflows may set:
 
@@ -41,6 +42,15 @@ If `namespace` is omitted, Jade Symphony derives one from `tracker.owner` and
 `tracker.repo`, or from `tracker.project_slug`, or falls back to `local`.
 Profiles add the final namespace segment so multiple worker identities do not
 share worktrees, logs, or runtime state by accident.
+
+The canonical checkout is not an artifact store. It is the trusted launch
+checkout for CLI and operator commands, while implementation, review, and merge
+edits belong in verified issue worktrees. Live write lanes inspect the canonical
+checkout before mutating tracker state. Tracked dirty files block the lane.
+Recognized untracked runtime/log/prompt/evidence/draft scratch files are moved
+under `scratch/canonical-checkout-quarantine/` with a manifest. Unclassified
+untracked files block the lane so the operator can choose the correct issue
+worktree, artifact location, or `.gitignore` rule.
 
 ## Promotion Rules
 

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -84,8 +84,13 @@ mode previews up to `N` eligible main-lane issues after skipping items whose
 `Main Agent` Project field is already owned by another worker. Write mode still
 processes one main work item at a time because the runtime state tracks one
 active issue, but it uses the same lane claim check and stamps `Main Agent`
-before tracker mutation. `run-loop`, `review-loop`, and `merge-once` print
-compact `Latest:` status bars in addition to their detailed line logs.
+before tracker mutation. `run-loop --write`, `review-loop --write`, and
+`merge-loop --write` also enforce a clean canonical launch checkout before the
+first tracker mutation. Tracked dirty files block the lane; recognized
+untracked runtime/log/prompt/evidence/draft artifacts are moved to artifact
+quarantine with a warning; unclassified untracked files block for operator
+repair. `run-loop`, `review-loop`, and `merge-once` print compact `Latest:`
+status bars in addition to their detailed line logs.
 New lane claims are written as single-line `v=1` key/value audit pointers, for
 example `v=1 lane=main actor=codex source=loop issue=#244 run=... state=active
 thread=unknown registry=run/...`. The Project field stores the compact pointer;
@@ -185,7 +190,7 @@ invariants, and repair evidence.
 | --- | --- | --- |
 | `clean plan` | Grouped read-only alias for `cleanup-plan`. | Reports terminal clean worktrees that are cleanup candidates; never deletes. |
 | `cleanup-plan` | Compatibility path for existing scripts. | Same output and read-only boundary as `clean plan`. |
-| `clean audit` | Classify configured artifact/workspace residue by persistence action. | Read-only; categories include `promote_to_repo`, `attach_to_tracker`, `safe_to_keep`, `cleanup_candidate`, and `needs_human_decision`. |
+| `clean audit` | Classify configured artifact/workspace residue by persistence action. | Read-only; categories include `promote_to_repo`, `attach_to_tracker`, `safe_to_keep`, `cleanup_candidate`, `needs_human_decision`, and canonical checkout quarantine. |
 
 Examples:
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -197,10 +197,19 @@ target/debug/jade-symphony run-loop workflows/jade-symphony.md --max-iterations 
 
 Use `project-state` before claiming work when multiple operators are active. A
 healthy read prints `project_state_access=ok`, `trusted=true`, the issue count,
-and a state summary. A failed read prints `project_state_access=blocked`,
+and a state summary, plus a read-only `canonical_checkout` cleanliness line for
+the launch checkout. A failed read prints `project_state_access=blocked`,
 `trusted=false`, and a `failure_kind` such as `auth`, `network`, `rate_limit`,
 `schema`, `partial_response`, or `payload`; treat that as a blocker, not as an
 empty queue.
+
+The canonical checkout is only the harness launch directory. Do not use it as a
+Main, Review, or Merge issue worktree, and do not leave runtime state, logs,
+prompts, drafts, or evidence there. `run-loop --write`, `review-loop --write`,
+and `merge-loop --write` check the launch checkout before tracker mutation:
+tracked dirty files block the lane, recognized local artifacts are moved to the
+artifact quarantine with a warning, and unclassified untracked files block until
+the operator moves them to an issue worktree or artifact location.
 
 Use `project-issue` for per-issue Project status, Project fields, blocker
 relationships, claim locks, and linked PRs. Raw `gh issue view` and `gh pr view`

--- a/src/canonical_checkout.rs
+++ b/src/canonical_checkout.rs
@@ -1,0 +1,444 @@
+use std::fmt;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::artifacts::artifact_layout;
+use crate::config::RuntimeConfig;
+use crate::workspace::safe_identifier;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalCheckoutReport {
+    pub root: PathBuf,
+    pub tracked_dirty: Vec<String>,
+    pub untracked: Vec<CanonicalUntrackedPath>,
+    pub migrated: Vec<CanonicalMigratedPath>,
+    pub quarantine_root: PathBuf,
+}
+
+impl CanonicalCheckoutReport {
+    pub fn is_clean(&self) -> bool {
+        self.tracked_dirty.is_empty() && self.untracked.is_empty()
+    }
+
+    pub fn unclassified_untracked(&self) -> Vec<&CanonicalUntrackedPath> {
+        self.untracked
+            .iter()
+            .filter(|entry| entry.kind.is_none())
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalUntrackedPath {
+    pub path: PathBuf,
+    pub kind: Option<CanonicalArtifactKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalMigratedPath {
+    pub source: PathBuf,
+    pub destination: PathBuf,
+    pub kind: CanonicalArtifactKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CanonicalArtifactKind {
+    Runtime,
+    Log,
+    Prompt,
+    Evidence,
+    Draft,
+    Scratch,
+}
+
+impl fmt::Display for CanonicalArtifactKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Runtime => "runtime",
+            Self::Log => "log",
+            Self::Prompt => "prompt",
+            Self::Evidence => "evidence",
+            Self::Draft => "draft",
+            Self::Scratch => "scratch",
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CanonicalCheckoutError {
+    #[error("canonical checkout git status failed in {root}: status={status} stdout={stdout} stderr={stderr}")]
+    GitStatusFailed {
+        root: PathBuf,
+        status: i32,
+        stdout: String,
+        stderr: String,
+    },
+    #[error("canonical checkout is blocked: tracked dirty files in {root}: {paths}. Move these edits into an issue worktree, commit them, or restore them before running a live write lane.")]
+    TrackedDirty { root: PathBuf, paths: String },
+    #[error("canonical checkout is blocked: unclassified untracked files in {root}: {paths}. Move them to an issue worktree or artifact location, or add legitimate ignored files to .gitignore before running a live write lane.")]
+    UnclassifiedUntracked { root: PathBuf, paths: String },
+    #[error(
+        "failed to migrate canonical checkout artifact {artifact_path} to {destination}: {error}"
+    )]
+    MigrationFailed {
+        artifact_path: PathBuf,
+        destination: PathBuf,
+        error: String,
+    },
+    #[error("canonical checkout io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub fn inspect_canonical_checkout(
+    root: &Path,
+    config: &RuntimeConfig,
+) -> Result<CanonicalCheckoutReport, CanonicalCheckoutError> {
+    let root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    let status = git_status_entries(&root)?;
+    let quarantine_root = canonical_quarantine_root(config);
+    let mut tracked_dirty = Vec::new();
+    let mut untracked = Vec::new();
+
+    for entry in status {
+        match entry {
+            GitStatusEntry::Tracked(path) => tracked_dirty.push(path),
+            GitStatusEntry::Untracked(path) => {
+                let kind = classify_untracked_artifact(&path);
+                untracked.push(CanonicalUntrackedPath { path, kind });
+            }
+        }
+    }
+
+    Ok(CanonicalCheckoutReport {
+        root,
+        tracked_dirty,
+        untracked,
+        migrated: Vec::new(),
+        quarantine_root,
+    })
+}
+
+pub fn enforce_clean_canonical_checkout_for_write(
+    root: &Path,
+    config: &RuntimeConfig,
+) -> Result<CanonicalCheckoutReport, CanonicalCheckoutError> {
+    let mut report = inspect_canonical_checkout(root, config)?;
+    if !report.tracked_dirty.is_empty() {
+        return Err(CanonicalCheckoutError::TrackedDirty {
+            root: report.root.clone(),
+            paths: report.tracked_dirty.join(", "),
+        });
+    }
+
+    let unclassified_paths = report
+        .unclassified_untracked()
+        .iter()
+        .map(|entry| entry.path.display().to_string())
+        .collect::<Vec<_>>();
+    if !unclassified_paths.is_empty() {
+        return Err(CanonicalCheckoutError::UnclassifiedUntracked {
+            root: report.root.clone(),
+            paths: unclassified_paths.join(", "),
+        });
+    }
+
+    let run_root = report
+        .quarantine_root
+        .join(format!("run-{}", unix_timestamp_ms()));
+    for entry in report.untracked.clone() {
+        let Some(kind) = entry.kind else {
+            continue;
+        };
+        let source = report.root.join(&entry.path);
+        let destination = run_root.join(kind.to_string()).join(&entry.path);
+        move_path(&source, &destination).map_err(|error| {
+            CanonicalCheckoutError::MigrationFailed {
+                artifact_path: source.clone(),
+                destination: destination.clone(),
+                error: error.to_string(),
+            }
+        })?;
+        report.migrated.push(CanonicalMigratedPath {
+            source,
+            destination,
+            kind,
+        });
+    }
+
+    if !report.migrated.is_empty() {
+        write_manifest(&run_root, &report.migrated)?;
+    }
+
+    Ok(report)
+}
+
+pub fn canonical_checkout_status_line(report: &CanonicalCheckoutReport) -> String {
+    let unclassified = report.unclassified_untracked().len();
+    format!(
+        "canonical_checkout root={} clean={} tracked_dirty={} untracked={} unclassified={} migrated={} quarantine={}",
+        report.root.display(),
+        report.is_clean(),
+        report.tracked_dirty.len(),
+        report.untracked.len(),
+        unclassified,
+        report.migrated.len(),
+        report.quarantine_root.display()
+    )
+}
+
+pub fn canonical_checkout_warning_lines(report: &CanonicalCheckoutReport) -> Vec<String> {
+    report
+        .migrated
+        .iter()
+        .map(|entry| {
+            format!(
+                "canonical_checkout_migrated kind={} source={} destination={}",
+                entry.kind,
+                entry.source.display(),
+                entry.destination.display()
+            )
+        })
+        .collect()
+}
+
+pub fn canonical_quarantine_root(config: &RuntimeConfig) -> PathBuf {
+    artifact_layout(config)
+        .scratch
+        .join("canonical-checkout-quarantine")
+}
+
+enum GitStatusEntry {
+    Tracked(String),
+    Untracked(PathBuf),
+}
+
+fn git_status_entries(root: &Path) -> Result<Vec<GitStatusEntry>, CanonicalCheckoutError> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain=v1", "-z", "--untracked-files=all"])
+        .current_dir(root)
+        .output()?;
+    if !output.status.success() {
+        return Err(CanonicalCheckoutError::GitStatusFailed {
+            root: root.to_path_buf(),
+            status: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+
+    let mut entries = Vec::new();
+    for raw in output.stdout.split(|byte| *byte == 0) {
+        if raw.is_empty() {
+            continue;
+        }
+        let text = String::from_utf8_lossy(raw).to_string();
+        if let Some(path) = text.strip_prefix("?? ") {
+            entries.push(GitStatusEntry::Untracked(PathBuf::from(path)));
+        } else {
+            entries.push(GitStatusEntry::Tracked(text));
+        }
+    }
+    Ok(entries)
+}
+
+fn classify_untracked_artifact(path: &Path) -> Option<CanonicalArtifactKind> {
+    let normalized = path
+        .components()
+        .filter_map(component_text)
+        .map(|component| safe_identifier(&component).to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    let text = normalized.join("/");
+    let file = normalized.last().map(String::as_str).unwrap_or_default();
+
+    if text.contains("runtime") || file.ends_with(".runtime.json") {
+        return Some(CanonicalArtifactKind::Runtime);
+    }
+    if text.contains("prompt") || file.ends_with(".prompt.md") || file == "jade_symphony_prompt_md"
+    {
+        return Some(CanonicalArtifactKind::Prompt);
+    }
+    if text.contains("evidence") || text.contains("handoff") || text.contains("ledger") {
+        return Some(CanonicalArtifactKind::Evidence);
+    }
+    if text.contains("workpad") || text.contains("pr_body") || text.contains("draft") {
+        return Some(CanonicalArtifactKind::Draft);
+    }
+    if file.ends_with(".log") || file.ends_with(".jsonl") || text.contains("logs") {
+        return Some(CanonicalArtifactKind::Log);
+    }
+    if text.contains("jade_symphony") || text.contains("scratch") || text.contains("tmp") {
+        return Some(CanonicalArtifactKind::Scratch);
+    }
+
+    None
+}
+
+fn component_text(component: Component<'_>) -> Option<String> {
+    match component {
+        Component::Normal(value) => Some(value.to_string_lossy().to_string()),
+        _ => None,
+    }
+}
+
+fn move_path(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    match fs::rename(source, destination) {
+        Ok(()) => Ok(()),
+        Err(rename_error) => {
+            let metadata = fs::symlink_metadata(source)?;
+            if metadata.is_file() {
+                fs::copy(source, destination)?;
+                fs::remove_file(source)
+            } else if metadata.is_dir() {
+                copy_dir_recursive(source, destination)?;
+                fs::remove_dir_all(source)
+            } else {
+                Err(rename_error)
+            }
+        }
+    }
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let metadata = entry.metadata()?;
+        if metadata.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else if metadata.is_file() {
+            fs::copy(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn write_manifest(
+    run_root: &Path,
+    migrated: &[CanonicalMigratedPath],
+) -> Result<(), CanonicalCheckoutError> {
+    fs::create_dir_all(run_root)?;
+    let mut lines = vec![
+        "# Canonical Checkout Quarantine Manifest".to_string(),
+        String::new(),
+        "These files were moved out of the canonical checkout before a live write lane mutated tracker state.".to_string(),
+        String::new(),
+    ];
+    for entry in migrated {
+        lines.push(format!(
+            "- kind={} source={} destination={}",
+            entry.kind,
+            entry.source.display(),
+            entry.destination.display()
+        ));
+    }
+    fs::write(run_root.join("MANIFEST.md"), lines.join("\n"))?;
+    Ok(())
+}
+
+fn unix_timestamp_ms() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::WorkflowDefinition;
+    use std::process::Command;
+
+    fn config(root: &Path) -> RuntimeConfig {
+        let markdown = format!(
+            "---\ntracker:\n  kind: memory\nartifacts:\n  root: {}\nworkspace:\n  root: {}/worktrees\nobservability:\n  logs_root: {}/logs\n---\nPrompt",
+            root.display(),
+            root.display(),
+            root.display()
+        );
+        let workflow = WorkflowDefinition::parse("/tmp/WORKFLOW.md", &markdown).unwrap();
+        RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap()
+    }
+
+    fn init_repo(path: &Path) {
+        fs::create_dir_all(path).unwrap();
+        Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(path)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(path)
+            .status()
+            .unwrap();
+        fs::write(path.join("tracked.txt"), "clean\n").unwrap();
+        Command::new("git")
+            .args(["add", "tracked.txt"])
+            .current_dir(path)
+            .status()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-qm", "init"])
+            .current_dir(path)
+            .status()
+            .unwrap();
+    }
+
+    #[test]
+    fn tracked_dirty_blocks_live_write() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        init_repo(&repo);
+        fs::write(repo.join("tracked.txt"), "dirty\n").unwrap();
+
+        let error =
+            enforce_clean_canonical_checkout_for_write(&repo, &config(temp.path())).unwrap_err();
+
+        assert!(error.to_string().contains("tracked dirty files"));
+        assert!(error.to_string().contains("tracked.txt"));
+    }
+
+    #[test]
+    fn unclassified_untracked_blocks_live_write() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        init_repo(&repo);
+        fs::write(repo.join("notes.txt"), "operator notes\n").unwrap();
+
+        let error =
+            enforce_clean_canonical_checkout_for_write(&repo, &config(temp.path())).unwrap_err();
+
+        assert!(error.to_string().contains("unclassified untracked files"));
+        assert!(repo.join("notes.txt").exists());
+    }
+
+    #[test]
+    fn classified_untracked_artifact_is_migrated() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        init_repo(&repo);
+        fs::write(repo.join("handoff-evidence.md"), "evidence\n").unwrap();
+
+        let report =
+            enforce_clean_canonical_checkout_for_write(&repo, &config(temp.path())).unwrap();
+
+        assert_eq!(report.migrated.len(), 1);
+        assert!(!repo.join("handoff-evidence.md").exists());
+        assert!(report.migrated[0].destination.exists());
+        assert_eq!(report.migrated[0].kind, CanonicalArtifactKind::Evidence);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod artifacts;
+pub mod canonical_checkout;
 pub mod codex_app_server;
 pub mod config;
 pub mod doctor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,10 @@ use jade_symphony::agent::{
     TmuxBackend, UsageLimitPause,
 };
 use jade_symphony::artifacts::{artifact_layout, cleanup_plan, ArtifactClass, CleanupPlan};
+use jade_symphony::canonical_checkout::{
+    canonical_checkout_status_line, canonical_checkout_warning_lines, canonical_quarantine_root,
+    enforce_clean_canonical_checkout_for_write, inspect_canonical_checkout,
+};
 use jade_symphony::config::RuntimeConfig;
 use jade_symphony::doctor::{
     audit_project_issues, audit_project_issues_with_context, draft_pr_repair_candidates,
@@ -1599,6 +1603,9 @@ fn review_loop(options: ReviewLoopOptions) -> Result<(), Box<dyn std::error::Err
         let workflow = WorkflowDefinition::load(&options.workflow_path)?;
         let config = RuntimeConfig::from_workflow(&workflow, &options.workflow_path)?;
         config.validate()?;
+        if options.write {
+            enforce_canonical_checkout_before_write(&config, "review_loop")?;
+        }
         let adapter = adapter_from_config(&config);
         let issues = adapter
             .fetch_issues_by_states(std::slice::from_ref(&config.tracker.state_map.agent_review))?;
@@ -1884,6 +1891,9 @@ fn merge_once_tick(
     let workflow = WorkflowDefinition::load(&workflow_path)?;
     let config = RuntimeConfig::from_workflow(&workflow, &workflow_path)?;
     config.validate()?;
+    if write {
+        enforce_canonical_checkout_before_write(&config, "merge_loop")?;
+    }
     let _merge_prompt = workflow.prompt_for_lane(AgentLane::MergeAgent);
 
     let adapter = adapter_from_config(&config);
@@ -2943,6 +2953,9 @@ fn project_state(options: ProjectStateOptions) -> Result<(), Box<dyn std::error:
             println!("issues={}", issues.len());
             println!("empty_queue={}", issues.is_empty());
             println!("{}", render_state_summary(&issues));
+            for line in report_canonical_checkout_readonly(&config) {
+                println!("{line}");
+            }
             for gap in integration_gaps {
                 println!("integration_gap={gap}");
             }
@@ -3118,6 +3131,7 @@ fn doctor(options: DoctorOptions) -> Result<(), Box<dyn std::error::Error>> {
     };
     let mut report = audit_project_issues_with_context(&issues, Some(&context));
     report.integration_gaps = integration_gaps;
+    append_canonical_checkout_doctor_violations(&mut report, &config);
     append_workspace_doctor_violations(&mut report, &config, &issues);
 
     match &options.action {
@@ -3264,6 +3278,68 @@ fn apply_doctor_auto_fix(
         }
     }
     Ok(())
+}
+
+fn append_canonical_checkout_doctor_violations(
+    report: &mut ProjectAuditReport,
+    config: &RuntimeConfig,
+) {
+    let root = match std::env::current_dir() {
+        Ok(root) => root,
+        Err(error) => {
+            report
+                .integration_gaps
+                .push(format!("canonical_checkout_unavailable: {error}"));
+            return;
+        }
+    };
+    let checkout = match inspect_canonical_checkout(&root, config) {
+        Ok(report) => report,
+        Err(error) => {
+            report
+                .integration_gaps
+                .push(format!("canonical_checkout_unavailable: {error}"));
+            return;
+        }
+    };
+    report
+        .integration_gaps
+        .push(canonical_checkout_status_line(&checkout));
+
+    if !checkout.tracked_dirty.is_empty() {
+        report.violations.push(ProjectAuditViolation {
+            issue_ref: "canonical".into(),
+            title: "Canonical checkout has tracked dirty files".into(),
+            state: "local".into(),
+            severity: AuditSeverity::Blocker,
+            code: "canonical_checkout_tracked_dirty".into(),
+            message: format!(
+                "Canonical checkout has tracked dirty files: {}",
+                checkout.tracked_dirty.join(", ")
+            ),
+            suggestion: "Move the edits into the correct issue worktree, commit them, or restore them before running any live write lane.".into(),
+        });
+    }
+
+    let unclassified = checkout.unclassified_untracked();
+    if !unclassified.is_empty() {
+        report.violations.push(ProjectAuditViolation {
+            issue_ref: "canonical".into(),
+            title: "Canonical checkout has unclassified untracked files".into(),
+            state: "local".into(),
+            severity: AuditSeverity::Warning,
+            code: "canonical_checkout_unclassified_untracked".into(),
+            message: format!(
+                "Canonical checkout has unclassified untracked files: {}",
+                unclassified
+                    .iter()
+                    .map(|entry| entry.path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            suggestion: "Move unclassified files to an issue worktree or artifact location, or add legitimate ignored files to .gitignore.".into(),
+        });
+    }
 }
 
 fn append_workspace_doctor_violations(
@@ -3857,6 +3933,12 @@ fn clean_audit_command(workflow_path: PathBuf) -> Result<(), Box<dyn std::error:
         "disposable_scratch",
         layout.class_path(ArtifactClass::DisposableScratch),
         "scratch files are disposable after operator review",
+    );
+    print_clean_audit_path(
+        "needs_human_decision",
+        "canonical_checkout_quarantine",
+        canonical_quarantine_root(&config),
+        "files moved out of the canonical checkout before live write lanes should be archived or deleted after tracker evidence is settled",
     );
 
     let mut cleanup_candidates = 0;
@@ -4565,6 +4647,32 @@ fn print_latest_status(status: &LatestStatus) {
     println!("{}", render_latest_status_bar(status));
 }
 
+fn report_canonical_checkout_readonly(config: &RuntimeConfig) -> Vec<String> {
+    let root = match std::env::current_dir() {
+        Ok(root) => root,
+        Err(error) => {
+            return vec![format!("canonical_checkout_error={error}")];
+        }
+    };
+    match inspect_canonical_checkout(&root, config) {
+        Ok(report) => vec![canonical_checkout_status_line(&report)],
+        Err(error) => vec![format!("canonical_checkout_error={error}")],
+    }
+}
+
+fn enforce_canonical_checkout_before_write(
+    config: &RuntimeConfig,
+    command: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let root = std::env::current_dir()?;
+    let report = enforce_clean_canonical_checkout_for_write(&root, config)?;
+    println!("{}", canonical_checkout_status_line(&report));
+    for line in canonical_checkout_warning_lines(&report) {
+        println!("{command}_{line}");
+    }
+    Ok(())
+}
+
 fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
     let limit = options.iteration_limit();
     let mut iterations = 0usize;
@@ -4584,6 +4692,7 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         config.validate()?;
         if options.write {
             ensure_write_mode_main_agent_backend(&options.workflow_path, &config, "run-loop")?;
+            enforce_canonical_checkout_before_write(&config, "run_loop")?;
         }
         let adapter = adapter_from_config(&config);
         if options.write {

--- a/workflows/prompts/main-agent.md
+++ b/workflows/prompts/main-agent.md
@@ -54,7 +54,9 @@ question, but do not edit files under
    dependency semantics: either no blocking dependencies, or named
    blockers/overlaps with the condition that makes the issue claimable.
 3. Work in exactly one isolated workspace and branch for this issue. Do not mix
-   unrelated issue scopes in this branch or PR.
+   unrelated issue scopes in this branch or PR. The canonical checkout is only
+   the launch directory; do not write implementation edits, runtime state, logs,
+   prompts, drafts, or evidence there.
 4. Use `workspace show` when resuming or handoff evidence is ambiguous, and use
    `workspace adopt` only for an operator-selected worktree that matches the
    issue branch.


### PR DESCRIPTION
## Summary
- Add a reusable canonical checkout guard that blocks tracked dirty launch checkouts before live write lanes mutate tracker state.
- Migrate recognized untracked runtime/log/prompt/evidence/draft artifacts into artifact quarantine with manifest evidence, while blocking unclassified untracked files.
- Surface canonical checkout status in project-state and doctor, expose quarantine in clean audit, and document launch checkout versus issue worktree responsibilities.

## Verification
- cargo fmt --check
- cargo test canonical_checkout -- --nocapture
- cargo test agent::tests -- --nocapture
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -- project-state workflows/jade-symphony.md

Closes #257