### PR TITLE
#265: Separate lane claims from sessions

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -93,10 +93,24 @@ Tracked dirty files block the lane; recognized untracked
 runtime/log/prompt/evidence/draft artifacts are moved to artifact quarantine
 with a warning; unclassified untracked files block for operator repair.
 New lane claims are written as single-line `v=1` key/value audit pointers, for
-example `v=1 lane=main actor=codex source=loop issue=#244 run=... state=active
-thread=unknown registry=run/...`. The Project field stores the compact pointer;
-the session registry and workpad store the durable paths, logs, and handoff
-evidence for the same `run=`.
+example `v=1 lane=main actor=codex worker=codex-manual-main source=manual
+issue=#244 run=... state=active thread=unknown registry=run/...`. The Project
+field stores the compact pointer; the session registry and workpad store the
+durable paths, logs, and handoff evidence for the same `run=`.
+
+Manual claim and session control are separate operations. Claim commands write
+only the lane claim Project field and do not change Project Status:
+
+```bash
+cargo run -- main claim workflows/jade-symphony.md '#265' --worker codex-manual-main --write
+cargo run -- review claim workflows/jade-symphony.md '#265' --worker gemini-manual-review --write
+cargo run -- merge claim workflows/jade-symphony.md '#265' --worker codex-manual-merge --write
+```
+
+Live write-mode claim, session, and lane loop commands refuse to run unless the
+canonical checkout is attached to `main` and exactly matches `origin/main` after
+a fetch. They report the blocker and leave git untouched when HEAD is detached,
+the branch is not `main`, or local `main` is stale.
 
 PR relationship verification is a lane invariant, not just evidence text. A PR
 URL found in a workpad, issue comment, or local branch can help operators
@@ -123,15 +137,16 @@ rendered prompt after a ready viewport is observed. Set
 `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` to opt out; a visible trust prompt or missing
 readiness then fails closed and preserves attach/log evidence for inspection.
 
-For manual lane recovery, `agent-session start WORKFLOW ISSUE --lane
-main|review|merge --write` starts the configured local tmux command with the
-lane-specific prompt, writes the lane claim field (`Main Agent`, `Review
-Agent`, or `Merging Agent`), and records session evidence in the workpad.
-The rendered prompt includes the assigned `run=` and registry pointer so the
-spawned agent can preserve that value in its handoff evidence.
-`agent-session list WORKFLOW` shows active tmux sessions with attach commands,
-and `agent-session attach WORKFLOW SESSION` prints the exact attach command
-without joining the terminal unless `--exec` is provided.
+For manual lane recovery, first claim the lane and keep the printed `run=`.
+Then `session start WORKFLOW ISSUE --lane main|review|merge --run RUN --write`
+starts the configured local tmux command with the lane-specific prompt only
+after confirming that the Project claim field already matches the issue, lane,
+and run. `session start` never writes claim fields. The rendered prompt includes
+the assigned `run=` and registry pointer so the spawned agent can preserve that
+value in its handoff evidence.
+`session list WORKFLOW` shows active tmux sessions with attach commands, and
+`session attach WORKFLOW SESSION` prints the exact attach command without
+joining the terminal unless `--exec` is provided.
 `status` and `status-api` include registered tmux session summaries from the
 durable session registry. `doctor` flags stale, failed, orphaned, usage-limited,
 or runtime/session mismatch cases, while `clean audit` classifies the registry,
@@ -272,23 +287,24 @@ changes.
 | `review fake` | Fixture/fake review transition helper. | Local testing path. |
 | `review once` | Run one configured review backend for one issue. | Only Review Agent may advance passed reviews to `Human Review`. |
 | `review loop` | Bounded review worker selection/reconciliation. | Prevents duplicate review workers where evidence exists. |
-| `review claim` | Claim one `Agent Review` item's `Review Agent` text field for manual/operator review. | Requires `--write`; refuses non-`Agent Review` issues and writes a structured claim pointer. |
+| `review claim` | Claim one `Agent Review` item's `Review Agent` text field for manual/operator review. | Requires `--worker` and `--write`; refuses non-`Agent Review` issues and writes a structured claim pointer. |
 | `review pass` | Record manual independent review pass evidence and move to `Human Review`. | Requires `--write`, a durable evidence file containing the exact current `Review Agent` claim, and preserves the field as terminal pass evidence. |
 | `review reject` | Record failed/inconclusive manual review evidence and route to `Agent Review`, `Rework`, or `Need Human Input`. | Refuses `Human Review`, requires exact claim evidence, and preserves the field as terminal reject/failed evidence. |
-| `review session` | Start or inspect a review runtime/session. | Does not write the `Review Agent` claim; use `review claim` or `review loop` for claim ownership. |
+| `review session` | Hidden legacy review session alias. | Does not write the `Review Agent` claim; use `review claim` or `review loop` for claim ownership. |
 | `review freshness` | Record/inspect review freshness evidence. | Used around merging/rework conflict repair. |
-| `agent-session start` | Start an attachable local tmux session for a selected lane. | Manual recovery path; it claims only the chosen lane and does not advance workflow state. |
-| `agent-session list` | List active Jade Symphony tmux sessions by configured prefix. | Read-only operator summary. |
-| `agent-session attach` | Print or execute the tmux attach command for one session. | Defaults to printing the command; `--exec` enters tmux. |
+| `review-clear-claim` | Clear one issue's `Review Agent` claim through the tracker adapter. | Requires `--write`; use after terminal manual review routing. |
+| `session start` | Start an attachable local tmux session for a selected lane and `run`. | Manual recovery path; validates an existing lane claim and does not write Project claim fields. |
+| `session list` | List active Jade Symphony tmux sessions by configured prefix. | Read-only operator summary. |
+| `session attach` | Print or execute the tmux attach command for one session. | Defaults to printing the command; `--exec` enters tmux. |
 
 Example:
 
 ```bash
 cargo run -- review loop examples/review-fixture-workflow.md --max-iterations 1 --dry-run
 cargo run -- review loop workflows/jade-symphony.md --max-iterations 1 --write
-cargo run -- agent-session start workflows/jade-symphony.md '#220' --lane review --write
-cargo run -- agent-session list workflows/jade-symphony.md
 cargo run -- review claim workflows/jade-symphony.md '#226' --worker "Manual Gemini Review" --write
+cargo run -- session start workflows/jade-symphony.md '#226' --lane review --run <RUN_ID> --write
+cargo run -- session list workflows/jade-symphony.md
 cargo run -- review pass workflows/jade-symphony.md '#226' --evidence-file /tmp/review-evidence.md --write
 cargo run -- review reject workflows/jade-symphony.md '#226' --evidence-file /tmp/review-evidence.md --target-state rework --write
 ```

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -21,7 +21,7 @@ Jade Symphony is not ready for unattended live GitHub Project v2 execution yet.
 | Orchestrator | Deterministic dispatch planning and a CLI `run-loop` skeleton with bounded modes, idle polling, claim-helper use, dependency preflight for `Todo` / `Rework`, runtime-state persistence, tracker-visible advisory ownership markers, resume preflight, retry backoff records, stall detection, live PR handoff plus tracker PR link recording in non-fixture GitHub mode, ready/non-draft PR enforcement before Agent Review handoff, guarded `merge-once` and bounded `merge-loop` lanes for `Merging` issues, first-slice `--pool` selection guarded by `Main Agent` / `Merging Agent` Project fields, a controlled `dogfood-smoke` preflight report with blocking-vs-warning integration gap severity, and a bounded operator launcher script exist. No long-running worker supervision, automated stall restart, full multi-worker runtime resume reconciliation, unbounded merge idle polling, or full state reconciliation yet. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, grouped read-only `clean plan` / `clean audit` cleanup and persistence classification, guarded terminal cleanup planning, repository-local git identity application, workspace/branch/PR handoff planning, live git worktree/branch creation, issue-level `workspace list` / `workspace show` / `workspace adopt` discovery across registry, workpad, PR, and local git worktree evidence, dirty/no-op guards before branch push, optional configured verification commands before PR handoff, branch push, PR create-or-reuse, tracker PR link recording, run-loop handoff evidence, profile-scoped workspace keys, parsed-but-unused SSH worker host config, a namespaced artifact layout, and dry-run cleanup planning exist. Automatic runtime cleanup, write-mode artifact cleanup, and live SSH execution are not wired yet. |
 | Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Jade Symphony treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
-| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. A local `tmux` backend can launch attachable lane sessions, capture the Codex pane before prompt injection, auto-advance the Codex workspace trust prompt inside Jade Symphony-created issue worktrees by default, paste rendered prompts only after readiness is observed, record the session name, attach command, prompt artifact, log path, lane, actor, profile/instance metadata, and durable session registry record, and leave workflow state unchanged until normal lane evidence is ready. `run-loop` uses that backend for Main Agent execution, while `agent-session start --lane main|review|merge`, `review session`, and `merge-session` provide manual recovery for lane prompts; `review session` does not write the `Review Agent` claim because claim ownership belongs to `review claim` or `review loop`. `status` classifies recent registered sessions from bounded pane/log evidence as `starting`, `running`, `waiting_for_trust`, `waiting_for_approval`, `waiting_for_human_input`, `usage_limited`, `failed`, `completed`, `stale`, or `unknown`. `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` opts out and fails closed if the trust prompt is visible. Prepared runs include selected profile/instance metadata and profile environment context. The Codex subprocess backend safely refuses `codex app-server` commands because that transport is not implemented yet. A first-slice Codex app-server event normalizer maps fixture JSON-RPC stream lines into Jade Symphony `AgentEvent` values, including completion, failure, cancellation, input-required, token usage, notification, and malformed events. Full Codex app-server transport and Claude Code protocol parity remain follow-ups. |
+| Agent backends | Dry-run backend plus conservative Codex and Claude Code subprocess backends exist. A local `tmux` backend can launch attachable lane sessions, capture the Codex pane before prompt injection, auto-advance the Codex workspace trust prompt inside Jade Symphony-created issue worktrees by default, paste rendered prompts only after readiness is observed, record the session name, attach command, prompt artifact, log path, lane, actor, profile/instance metadata, and durable session registry record, and leave workflow state unchanged until normal lane evidence is ready. `run-loop` uses that backend for Main Agent execution, while manual recovery now claims with `main claim`, `review claim`, or `merge claim` before starting runtime with `session start --run <RUN_ID>`. `status` classifies recent registered sessions from bounded pane/log evidence as `starting`, `running`, `waiting_for_trust`, `waiting_for_approval`, `waiting_for_human_input`, `usage_limited`, `failed`, `completed`, `stale`, or `unknown`. `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` opts out and fails closed if the trust prompt is visible. Prepared runs include selected profile/instance metadata and profile environment context. The Codex subprocess backend safely refuses `codex app-server` commands because that transport is not implemented yet. A first-slice Codex app-server event normalizer maps fixture JSON-RPC stream lines into Jade Symphony `AgentEvent` values, including completion, failure, cancellation, input-required, token usage, notification, and malformed events. Full Codex app-server transport and Claude Code protocol parity remain follow-ups. |
 | Prompt rendering | Strict prompt rendering supports `issue.*`, `attempt`, and basic `{% if %}` / `{% else %}` blocks. The supported subset is documented in `docs/prompt-template-contract.md`; full Liquid compatibility remains a parity gap. |
 | Dynamic tools | A first-slice dynamic-tool registry can describe planned backend-specific tools such as Codex `linear_graphql` without coupling them to the orchestrator. Tool execution and Codex app-server dynamic-tool protocol wiring are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, Gemini CLI subprocess backend, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings and completed-but-inconclusive automatic reviews, invalid-handoff evidence when Agent Review receives a draft PR, `review freshness` evidence for Merging conflict repair, bounded `review loop` worker selection/reconciliation with one issue per worker slot, Project `Review Agent` claim markers before backend launch, terminal manual review claim preservation, durable JSON review job ledger records, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
@@ -72,8 +72,8 @@ The landed supervision slices are:
 The resulting operator loop is:
 
 1. Start or resume a bounded lane session with `run-loop --write`,
-   `agent-session start --lane main|review|merge --write`, `review session`, or
-   `merge-session`.
+   or manually claim with `main claim`, `review claim`, or `merge claim`, then
+   start runtime with `session start --lane main|review|merge --run <RUN_ID>`.
 2. Use `status` / `status-api` to inspect compact session state, attach command,
    log path, and evidence source without treating a running session as
    completed work.
@@ -112,7 +112,7 @@ Project v2 issues:
 2. Harden GitHub tracker writes.
    - Current explicit commands can set ProjectV2 status by option ID,
      create/update one marker workpad comment, create follow-up issues, add
-     issues to the configured project, claim/clear Review Agent fields, and
+     issues to the configured project, claim Main/Review/Merge lane fields, and
      route manual review pass/reject outcomes.
    - Mutating commands require `--write`.
    - Same-state status updates are treated as no-ops before mutation.
@@ -129,6 +129,10 @@ Project v2 issues:
    - Live GitHub `run-loop --write` requires unassigned issue execution to be
      explicitly allowed, and otherwise compares issue assignees against the
      current `gh` login or selected profile login before claim.
+   - Live write-mode claim, session, run-loop, review-loop, and merge-loop
+     commands require the canonical launch checkout to be attached to latest
+     `main`; detached HEAD, non-`main`, or stale `main` states block with
+     operator guidance instead of mutating git.
    - `run-loop` reuses tracker claim helpers to claim only `Todo` / `Rework`,
      resume active `In Progress`, and stop/replan on externally changed states.
    - Main-agent dispatch treats structured tracker blockers as authoritative,
@@ -491,8 +495,7 @@ local `tmux` backend for supervised lane execution, while prompt bodies remain
 the real Jade Symphony dogfood operating contracts. `run-loop --write` records
 attachable tmux session metadata, writes `session-registry.json` under the
 configured artifact root, and keeps the issue active until real implementation
-evidence is available for the existing handoff path. `agent-session`,
-`review session`, and `merge-session` use the same registry and lane prompt
-contracts for manual recovery. `review session` does not write the
-`Review Agent` claim. The registry is operator evidence for terminal sessions
-only; it does not replace Project state.
+evidence is available for the existing handoff path. Manual recovery uses lane
+claim commands first, then `session start --run <RUN_ID>` with the same registry
+and lane prompt contracts. The registry is operator evidence for terminal
+sessions only; it does not replace Project state.

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -146,11 +146,12 @@ export GEMINI_CLI_TRUST_WORKSPACE=true
 target/debug/jade-symphony review loop workflows/jade-symphony.md --max-iterations 1 --write
 ```
 
-For supervised manual review terminals, use
-`review session WORKFLOW '#issue' --write` on an `Agent Review` issue. It starts
-the lane-specific review prompt in tmux and writes attach/log evidence without
-writing the `Review Agent` claim or moving the issue to `Human Review`. Use
-`review claim` or the configured `review loop` for claim ownership.
+For supervised manual review terminals, first use
+`review claim WORKFLOW '#issue' --worker <worker> --write` on an `Agent Review`
+issue, then start the runtime with `session start WORKFLOW '#issue' --lane
+review --run <RUN_ID> --write`. Session startup validates the existing Review
+Agent claim and writes attach/log evidence without moving the issue to
+`Human Review`.
 
 If Gemini cannot start, the review workpad should name the configured command,
 whether worker `PATH` could resolve it, the required operator action, and the
@@ -301,14 +302,16 @@ loop tick. Merge work uses the `Merging Agent` Project field and can process
 multiple guarded merge slots in one bounded loop.
 Lane claim fields are latest-run audit pointers, not append-only logs. New
 values use `v=1 lane=<main|review|merge> actor=<codex|gemini|claude|human>
-source=<loop|manual|goal> issue=#N run=<id> state=<active|done|stale|failed|superseded>
-thread=<codex-link|unknown> registry=run/<id>`. Keep full paths and terminal
-logs in the session registry or workpad, and update terminal completed work to
-`state=done` instead of clearing useful claim evidence by default.
-For supervised merge terminals, use `merge-session WORKFLOW '#issue' --write`
-on a `Merging` issue. It uses the shared `agent-session` lane path to claim the
-`Merging Agent` field, start the merge prompt in tmux, and write attach/log
-evidence without merging the PR or closing the issue.
+worker=<worker> source=<loop|manual|goal> issue=#N run=<id>
+state=<active|done|stale|failed|superseded> thread=<codex-link|unknown>
+registry=run/<id>`. Keep full paths and terminal logs in the session registry
+or workpad, and update terminal completed work to `state=done` instead of
+clearing useful claim evidence by default.
+For supervised merge terminals, use `merge claim WORKFLOW '#issue' --worker
+<worker> --write` on a `Merging` issue, then `session start WORKFLOW '#issue'
+--lane merge --run <RUN_ID> --write`. Session startup validates the `Merging
+Agent` field and writes attach/log evidence without merging the PR or closing
+the issue.
 
 Operator commands also print compact `Latest:` lines for the current lane,
 issue, category, action, actor, workspace/branch when known, and next expected

--- a/src/lane_claim.rs
+++ b/src/lane_claim.rs
@@ -41,6 +41,8 @@ pub enum LaneClaimState {
 pub struct LaneClaim {
     pub lane: LaneClaimLane,
     pub actor: LaneClaimActor,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker: Option<String>,
     pub source: LaneClaimSource,
     pub issue: String,
     pub run: String,
@@ -136,6 +138,7 @@ impl LaneClaim {
         Self {
             lane,
             actor,
+            worker: None,
             source,
             issue: issue.to_string(),
             registry: format!("run/{run}"),
@@ -152,19 +155,32 @@ impl LaneClaim {
         }
     }
 
+    pub fn with_worker(&self, worker: impl Into<String>) -> Self {
+        let worker = worker.into();
+        Self {
+            worker: (!worker.trim().is_empty()).then(|| worker.trim().to_string()),
+            ..self.clone()
+        }
+    }
+
     pub fn render(&self) -> String {
-        [
+        let mut tokens = vec![
             "v=1".to_string(),
             format!("lane={}", self.lane.as_str()),
             format!("actor={}", self.actor.as_str()),
+        ];
+        if let Some(worker) = self.worker.as_deref() {
+            tokens.push(format!("worker={worker}"));
+        }
+        tokens.extend([
             format!("source={}", self.source.as_str()),
             format!("issue={}", self.issue),
             format!("run={}", self.run),
             format!("state={}", self.state.as_str()),
             format!("thread={}", self.thread),
             format!("registry={}", self.registry),
-        ]
-        .join(" ")
+        ]);
+        tokens.join(" ")
     }
 
     pub fn parse(input: &str) -> Result<Self, LaneClaimParseError> {
@@ -187,6 +203,7 @@ impl LaneClaim {
         Ok(Self {
             lane: parse_lane(required(&values, "lane")?)?,
             actor: parse_actor(required(&values, "actor")?)?,
+            worker: values.get("worker").map(|value| value.to_string()),
             source: parse_source(required(&values, "source")?)?,
             issue: required(&values, "issue")?.to_string(),
             run: required(&values, "run")?.to_string(),
@@ -304,6 +321,22 @@ mod tests {
 
         let rendered = claim.render();
         assert!(rendered.starts_with("v=1 lane=main actor=codex source=loop issue=#244"));
+        assert_eq!(LaneClaim::parse(&rendered).unwrap(), claim);
+    }
+
+    #[test]
+    fn renders_and_parses_worker_identity_when_present() {
+        let claim = LaneClaim::active(
+            "#265",
+            LaneClaimLane::Main,
+            LaneClaimActor::Codex,
+            LaneClaimSource::Manual,
+            1_778_904_900_123,
+        )
+        .with_worker("codex-manual-main");
+
+        let rendered = claim.render();
+        assert!(rendered.contains(" worker=codex-manual-main "));
         assert_eq!(LaneClaim::parse(&rendered).unwrap(), claim);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             worker,
             write,
         } => review_claim(workflow_path, issue_ref, worker, write),
+        Command::LaneClaim {
+            workflow_path,
+            issue_ref,
+            lane,
+            worker,
+            source,
+            write,
+        } => lane_claim_command(workflow_path, issue_ref, lane, worker, source, write),
         Command::ReviewClearClaim {
             workflow_path,
             issue_ref,
@@ -242,20 +250,38 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             workflow_path,
             issue_ref,
             write,
-        } => review_session(workflow_path, issue_ref, write),
+        } => {
+            legacy_agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Review, write)
+        }
         Command::ReviewFreshness { input } => review_freshness(input),
         Command::ReviewLoop { options } => review_loop(options),
         Command::MergeSession {
             workflow_path,
             issue_ref,
             write,
-        } => agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Merge, write),
+        } => {
+            legacy_agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Merge, write)
+        }
         Command::AgentSessionStart {
             workflow_path,
             issue_ref,
             lane,
+            run_id,
             write,
-        } => agent_session_start(workflow_path, issue_ref, lane, write),
+        } => agent_session_start(workflow_path, issue_ref, lane, run_id, write),
+        Command::SessionStart {
+            workflow_path,
+            issue_ref,
+            lane,
+            run_id,
+            write,
+        } => agent_session_start(workflow_path, issue_ref, lane, Some(run_id), write),
+        Command::SessionList { workflow_path } => agent_session_list(workflow_path),
+        Command::SessionAttach {
+            workflow_path,
+            session,
+            exec,
+        } => agent_session_attach(workflow_path, session, exec),
         Command::AgentSessionList { workflow_path } => agent_session_list(workflow_path),
         Command::AgentSessionAttach {
             workflow_path,
@@ -1370,7 +1396,8 @@ fn review_claim(
         },
         LaneClaimSource::Manual,
         project_text_field(&issue, "Review Agent").as_deref(),
-    );
+    )
+    .with_worker(&worker);
     let claim_value = claim.render();
     if !write {
         println!(
@@ -1403,6 +1430,165 @@ fn review_claim(
         issue.identifier, claim.run
     );
     Ok(())
+}
+
+fn lane_claim_command(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    lane: AgentSessionLaneArg,
+    worker: String,
+    source: CliLaneClaimSource,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if worker.trim().is_empty() {
+        return Err("lane claim requires a non-empty --worker".into());
+    }
+
+    let config = load_config(&workflow_path)?;
+    if write {
+        enforce_canonical_checkout_before_write(&config, &format!("{} claim", lane.label()))?;
+    }
+
+    let adapter = adapter_from_config(&config);
+    let issue = adapter
+        .get_issue(&issue_ref)?
+        .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
+    validate_lane_claim_state(&issue, lane)?;
+
+    let existing_value = project_text_field(&issue, lane.claim_field());
+    let claim = lane_claim_for_manual_worker(
+        &issue,
+        lane,
+        actor_from_worker(&worker),
+        source.into(),
+        worker.trim(),
+        existing_value.as_deref(),
+    )?;
+    let claim_value = claim.render();
+
+    if !write {
+        println!(
+            "{}_claim_dry_run action=claim_field issue_ref={} field={:?} run={} value={claim_value}",
+            lane.label(),
+            issue.identifier,
+            lane.claim_field(),
+            claim.run
+        );
+        return Ok(());
+    }
+
+    adapter.set_project_field(
+        &issue.identifier,
+        &ProjectFieldAssignment {
+            name: lane.claim_field().into(),
+            value: claim_value.clone(),
+        },
+    )?;
+    let command_name = format!("{} claim", lane.label());
+    append_tracker_mutation_audit(
+        &config,
+        TrackerMutationAudit {
+            command: &command_name,
+            mutation_type: "claim_field",
+            issue_ref: Some(&issue.identifier),
+            target: Some(format!("{}={claim_value}", lane.claim_field())),
+            from_state: Some(issue.state.clone()),
+            to_state: None,
+            reason: "manual lane worker claim",
+        },
+    );
+    println!(
+        "{}_claim=ok issue_ref={} field={:?} worker={} run={} value={claim_value}",
+        lane.label(),
+        issue.identifier,
+        lane.claim_field(),
+        worker.trim(),
+        claim.run
+    );
+    Ok(())
+}
+
+fn validate_lane_claim_state(
+    issue: &TrackerIssue,
+    lane: AgentSessionLaneArg,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let normalized = issue.normalized_state();
+    let valid = match lane {
+        AgentSessionLaneArg::Main => matches!(normalized.as_str(), "todo" | "in progress"),
+        AgentSessionLaneArg::Review => normalized == "agent review",
+        AgentSessionLaneArg::Merge => normalized == "merging",
+    };
+    if valid {
+        return Ok(());
+    }
+
+    Err(format!(
+        "{} claim cannot claim {}; {} is currently {}",
+        lane.label(),
+        issue.identifier,
+        issue.identifier,
+        issue.state
+    )
+    .into())
+}
+
+fn actor_from_worker(worker: &str) -> LaneClaimActor {
+    let normalized = worker.to_ascii_lowercase();
+    if normalized.contains("gemini") {
+        LaneClaimActor::Gemini
+    } else if normalized.contains("claude") {
+        LaneClaimActor::Claude
+    } else if normalized.contains("human") {
+        LaneClaimActor::Human
+    } else {
+        LaneClaimActor::Codex
+    }
+}
+
+fn lane_claim_for_manual_worker(
+    issue: &TrackerIssue,
+    lane: AgentSessionLaneArg,
+    actor: LaneClaimActor,
+    source: LaneClaimSource,
+    worker: &str,
+    existing: Option<&str>,
+) -> Result<LaneClaim, Box<dyn std::error::Error>> {
+    if let Some(existing) = existing {
+        if let Ok(claim) = LaneClaim::parse(existing) {
+            if claim.lane == lane.claim_lane()
+                && claim.issue == issue.identifier
+                && claim.state == LaneClaimState::Active
+            {
+                if claim.worker.as_deref() == Some(worker) {
+                    return Ok(claim);
+                }
+                return Err(format!(
+                    "{} already has an active {} claim owned by {} run={}",
+                    issue.identifier,
+                    lane.label(),
+                    claim.worker.as_deref().unwrap_or(claim.actor.as_str()),
+                    claim.run
+                )
+                .into());
+            }
+        } else if !existing.trim().is_empty() {
+            return Err(format!(
+                "{} already has an unparseable {} claim: {existing}",
+                issue.identifier,
+                lane.claim_field()
+            )
+            .into());
+        }
+    }
+
+    Ok(LaneClaim::active(
+        &issue.identifier,
+        lane.claim_lane(),
+        actor,
+        source,
+        current_time_ms(),
+    )
+    .with_worker(worker))
 }
 
 fn review_clear_claim(
@@ -2120,7 +2306,8 @@ fn merge_once_tick(
         LaneClaimActor::Codex,
         LaneClaimSource::Loop,
         project_text_field(&issue, WorkerLane::Merging.claim_field()).as_deref(),
-    );
+    )
+    .with_worker(&worker_id);
     write_lane_claim_field(
         &config,
         adapter.as_ref(),
@@ -2431,6 +2618,7 @@ fn review_claim_for_issue(issue: &TrackerIssue, worker_key: &str) -> LaneClaim {
         LaneClaimSource::Loop,
         project_text_field(issue, "Review Agent").as_deref(),
     )
+    .with_worker(worker_key)
 }
 
 fn print_review_claim_field_dry_run(issue: &TrackerIssue, worker_key: &str) {
@@ -2580,36 +2768,17 @@ fn agent_session_start(
     workflow_path: PathBuf,
     issue_ref: String,
     lane: AgentSessionLaneArg,
+    run_id: Option<String>,
     write: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    agent_session_start_inner(workflow_path, issue_ref, lane, write, true)
-}
-
-fn review_session(
-    workflow_path: PathBuf,
-    issue_ref: String,
-    write: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    agent_session_start_inner(
-        workflow_path,
-        issue_ref,
-        AgentSessionLaneArg::Review,
-        write,
-        false,
-    )
-}
-
-fn agent_session_start_inner(
-    workflow_path: PathBuf,
-    issue_ref: String,
-    lane: AgentSessionLaneArg,
-    write: bool,
-    write_claim: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+    let run_id = run_id.ok_or("session start requires explicit --run <RUN_ID>")?;
     let workflow = WorkflowDefinition::load(&workflow_path)?;
     let config = RuntimeConfig::from_workflow(&workflow, &workflow_path)?;
     config.validate()?;
     validate_tmux_session_config(&config)?;
+    if write {
+        enforce_canonical_checkout_before_write(&config, "session start")?;
+    }
 
     let adapter = adapter_from_config(&config);
     let issue = adapter
@@ -2617,66 +2786,19 @@ fn agent_session_start_inner(
         .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
     let workspace_key = agent_session_workspace_key(&config, &issue, lane)?;
     let prompt_path = rendered_lane_prompt_artifact_path(&config, &issue, lane, 1);
-    let claim = write_claim.then(|| {
-        lane_claim_for_issue(
-            &issue,
-            lane.claim_lane(),
-            LaneClaimActor::Codex,
-            LaneClaimSource::Manual,
-            None,
-        )
-    });
-    let claim_value = claim.as_ref().map(LaneClaim::render);
+    let claim = matching_lane_claim_for_session(&issue, lane, &run_id)?;
+    let claim_value = claim.render();
 
     if !write {
-        if let Some(claim_value) = claim_value.as_deref() {
-            println!(
-                "agent_session_dry_run action=claim_field issue={} field={:?} value={:?}",
-                issue.identifier,
-                lane.claim_field(),
-                claim_value
-            );
-        } else {
-            println!(
-                "agent_session_dry_run action=skip_claim_field issue={} field={:?}",
-                issue.identifier,
-                lane.claim_field()
-            );
-        }
         println!(
-            "agent_session_dry_run action=start issue={} lane={} run={} backend=tmux workspace_key={} prompt_artifact={}",
+            "session_dry_run action=start issue={} lane={} run={} backend=tmux workspace_key={} prompt_artifact={}",
             issue.identifier,
             lane.label(),
-            claim
-                .as_ref()
-                .map(|claim| claim.run.as_str())
-                .unwrap_or("unclaimed-session"),
+            claim.run,
             workspace_key,
             prompt_path.display()
         );
         return Ok(());
-    }
-
-    if let Some(claim_value) = claim_value.as_deref() {
-        adapter.set_project_field(
-            &issue.identifier,
-            &ProjectFieldAssignment {
-                name: lane.claim_field().into(),
-                value: claim_value.into(),
-            },
-        )?;
-        append_tracker_mutation_audit(
-            &config,
-            TrackerMutationAudit {
-                command: "agent-session",
-                mutation_type: "claim_field",
-                issue_ref: Some(&issue.identifier),
-                target: Some(format!("{}={claim_value}", lane.claim_field())),
-                from_state: Some(issue.state.clone()),
-                to_state: None,
-                reason: "manual tmux lane session claim",
-            },
-        );
     }
 
     let workspace = prepare_workspace(&config.workspace.root, &workspace_key, &config.hooks)?;
@@ -2685,7 +2807,7 @@ fn agent_session_start_inner(
         workflow.prompt_for_lane(lane.workflow_lane()),
         &issue,
         None,
-        claim.as_ref(),
+        Some(&claim),
     )?;
     let backend = TmuxBackend;
     let mut prepared = backend.prepare(workspace.path.clone(), prompt, &config)?;
@@ -2697,15 +2819,13 @@ fn agent_session_start_inner(
     prepared.issue_identifier = Some(issue.identifier.clone());
     prepared.issue_title = Some(issue.title.clone());
     prepared.lane = Some(lane.label().into());
-    if let Some(claim) = claim.as_ref() {
-        prepared.run_id = Some(claim.run.clone());
-        prepared
-            .env
-            .insert("JADE_SYMPHONY_RUN_ID".into(), claim.run.clone());
-        prepared
-            .env
-            .insert("JADE_SYMPHONY_CLAIM".into(), claim.render());
-    }
+    prepared.run_id = Some(claim.run.clone());
+    prepared
+        .env
+        .insert("JADE_SYMPHONY_RUN_ID".into(), claim.run.clone());
+    prepared
+        .env
+        .insert("JADE_SYMPHONY_CLAIM".into(), claim.render());
     prepared.attempt = 1;
     prepared.branch_name = current_git_branch(&workspace.path).ok().flatten();
     let events = backend.run(prepared)?;
@@ -2718,16 +2838,14 @@ fn agent_session_start_inner(
         &workspace.path,
         &summary,
         &prompt_path,
-        claim_value
-            .as_deref()
-            .unwrap_or("not written by review session"),
+        &claim_value,
         &git_identity,
     );
     adapter.upsert_workpad(&issue.identifier, &workpad)?;
     append_tracker_mutation_audit(
         &config,
         TrackerMutationAudit {
-            command: "agent-session",
+            command: "session start",
             mutation_type: "workpad_write",
             issue_ref: Some(&issue.identifier),
             target: summary.session_id.clone(),
@@ -2738,13 +2856,10 @@ fn agent_session_start_inner(
     );
 
     println!(
-        "agent_session_action=started issue={} lane={} run={} backend={} session={} pending_session={} workspace={} prompt_artifact={}",
+        "session_action=started issue={} lane={} run={} backend={} session={} pending_session={} workspace={} prompt_artifact={}",
         issue.identifier,
         lane.label(),
-        claim
-            .as_ref()
-            .map(|claim| claim.run.as_str())
-            .unwrap_or("unclaimed-session"),
+        claim.run,
         summary.backend,
         summary.session_id.as_deref().unwrap_or("n/a"),
         summary.pending_session,
@@ -2758,6 +2873,75 @@ fn agent_session_start_inner(
         println!("log_path={}", log_path.display());
     }
     Ok(())
+}
+
+fn legacy_agent_session_start(
+    _workflow_path: PathBuf,
+    _issue_ref: String,
+    lane: AgentSessionLaneArg,
+    _write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    Err(format!(
+        "{}-session and agent-session are hidden legacy entrypoints; use `{} claim` first, then `session start --lane {} --run <RUN_ID>`",
+        lane.label(),
+        lane.label(),
+        lane.label()
+    )
+    .into())
+}
+
+fn matching_lane_claim_for_session(
+    issue: &TrackerIssue,
+    lane: AgentSessionLaneArg,
+    run_id: &str,
+) -> Result<LaneClaim, Box<dyn std::error::Error>> {
+    let claim_value = project_text_field(issue, lane.claim_field()).ok_or_else(|| {
+        format!(
+            "session start requires an existing {} claim for {}",
+            lane.claim_field(),
+            issue.identifier
+        )
+    })?;
+    let claim = LaneClaim::parse(&claim_value)?;
+    if claim.lane != lane.claim_lane() {
+        return Err(format!(
+            "session start lane mismatch for {}; claim lane={} requested lane={}",
+            issue.identifier,
+            claim.lane.as_str(),
+            lane.label()
+        )
+        .into());
+    }
+    if claim.issue != issue.identifier {
+        return Err(format!(
+            "session start issue mismatch for {}; claim points at {}",
+            issue.identifier, claim.issue
+        )
+        .into());
+    }
+    if claim.run != run_id {
+        return Err(format!(
+            "session start run mismatch for {}; claim run={} requested run={run_id}",
+            issue.identifier, claim.run
+        )
+        .into());
+    }
+    if claim.state != LaneClaimState::Active {
+        return Err(format!(
+            "session start requires an active claim; {} claim state={}",
+            issue.identifier,
+            claim.state.as_str()
+        )
+        .into());
+    }
+    if claim.worker.as_deref().unwrap_or("").trim().is_empty() {
+        return Err(format!(
+            "session start requires a structured worker= claim for {} run={}",
+            issue.identifier, claim.run
+        )
+        .into());
+    }
+    Ok(claim)
 }
 
 fn agent_session_list(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
@@ -2826,13 +3010,13 @@ fn agent_session_attach(
 
 fn validate_tmux_session_config(config: &RuntimeConfig) -> Result<(), Box<dyn std::error::Error>> {
     if config.tmux.command.trim().is_empty() {
-        return Err("tmux.command must not be empty for agent-session".into());
+        return Err("tmux.command must not be empty for session start".into());
     }
     if config.tmux.agent_command.trim().is_empty() {
-        return Err("tmux.agent_command must not be empty for agent-session".into());
+        return Err("tmux.agent_command must not be empty for session start".into());
     }
     if config.tmux.session_prefix.trim().is_empty() {
-        return Err("tmux.session_prefix must not be empty for agent-session".into());
+        return Err("tmux.session_prefix must not be empty for session start".into());
     }
     Ok(())
 }
@@ -3177,7 +3361,8 @@ fn project_state(options: ProjectStateOptions) -> Result<(), Box<dyn std::error:
     let adapter = adapter_from_config(&config);
     match adapter.list_dispatchable_issues() {
         Ok(issues) => {
-            let integration_gaps = adapter.integration_gaps();
+            let mut integration_gaps = adapter.integration_gaps();
+            append_canonical_checkout_gap(&config, &mut integration_gaps);
             if options.display == DisplayMode::Tui {
                 println!("{}", render_project_state_panel(&issues, &integration_gaps));
                 return Ok(());
@@ -3343,6 +3528,7 @@ fn doctor(options: DoctorOptions) -> Result<(), Box<dyn std::error::Error>> {
     let adapter = adapter_from_config(&config);
     let issues = adapter.fetch_issues_by_states(&all_mapped_tracker_states(&config))?;
     let mut integration_gaps = adapter.integration_gaps();
+    append_canonical_checkout_gap(&config, &mut integration_gaps);
     let runtime_state = match load_runtime_state(&config) {
         Ok(state) => state,
         Err(error) => {
@@ -5516,7 +5702,8 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
                     LaneClaimActor::Codex,
                     LaneClaimSource::Loop,
                     project_text_field(candidate, WorkerLane::Main.claim_field()).as_deref(),
-                );
+                )
+                .with_worker(&worker_id);
                 write_lane_claim_field(
                     &config,
                     adapter.as_ref(),
@@ -5650,7 +5837,8 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
             LaneClaimActor::Codex,
             LaneClaimSource::Loop,
             project_text_field(&latest, WorkerLane::Main.claim_field()).as_deref(),
-        );
+        )
+        .with_worker(&worker_id);
         if matches!(claim_action, RunLoopClaimAction::Resume) {
             if let RuntimeOwnershipDecision::Mismatched { reason, .. } =
                 runtime_ownership_decision(latest.description.as_deref(), &ownership)
@@ -6629,6 +6817,110 @@ fn run_loop_assignee_ownership_decision(
 
 fn live_github_tracker(config: &RuntimeConfig) -> bool {
     config.tracker.kind == "github_project_v2" && config.tracker.fixture_path.is_none()
+}
+
+fn append_canonical_checkout_gap(config: &RuntimeConfig, gaps: &mut Vec<String>) {
+    if !live_github_tracker(config) {
+        return;
+    }
+    let Ok(current_dir) = std::env::current_dir() else {
+        gaps.push("canonical_checkout_blocked: current directory is unavailable".into());
+        return;
+    };
+    if let Some(reason) = canonical_checkout_report(&current_dir).blocker() {
+        gaps.push(format!("canonical_checkout_blocked: {reason}"));
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CanonicalCheckoutReport {
+    Ready,
+    Blocked { reason: String },
+}
+
+impl CanonicalCheckoutReport {
+    fn blocker(&self) -> Option<&str> {
+        match self {
+            Self::Ready => None,
+            Self::Blocked { reason } => Some(reason.as_str()),
+        }
+    }
+}
+
+fn canonical_checkout_report(path: &Path) -> CanonicalCheckoutReport {
+    let branch = match git_stdout(path, &["branch", "--show-current"]) {
+        Ok(branch) if !branch.trim().is_empty() => branch.trim().to_string(),
+        Ok(_) => {
+            return CanonicalCheckoutReport::Blocked {
+                reason: "HEAD is detached".into(),
+            }
+        }
+        Err(error) => {
+            return CanonicalCheckoutReport::Blocked {
+                reason: format!("git branch check failed: {error}"),
+            }
+        }
+    };
+    if branch != "main" {
+        return CanonicalCheckoutReport::Blocked {
+            reason: format!("current branch is {branch:?}, expected \"main\""),
+        };
+    }
+
+    if let Err(error) = git_status(path, &["fetch", "--quiet", "origin", "main"]) {
+        return CanonicalCheckoutReport::Blocked {
+            reason: format!("git fetch origin main failed: {error}"),
+        };
+    }
+
+    let head = match git_stdout(path, &["rev-parse", "HEAD"]) {
+        Ok(value) => value.trim().to_string(),
+        Err(error) => {
+            return CanonicalCheckoutReport::Blocked {
+                reason: format!("cannot read HEAD: {error}"),
+            }
+        }
+    };
+    let origin_main = match git_stdout(path, &["rev-parse", "origin/main"]) {
+        Ok(value) => value.trim().to_string(),
+        Err(error) => {
+            return CanonicalCheckoutReport::Blocked {
+                reason: format!("cannot read origin/main: {error}"),
+            }
+        }
+    };
+    if head != origin_main {
+        return CanonicalCheckoutReport::Blocked {
+            reason: "local main does not exactly match origin/main".into(),
+        };
+    }
+
+    CanonicalCheckoutReport::Ready
+}
+
+fn git_stdout(path: &Path, args: &[&str]) -> Result<String, String> {
+    let output = ProcessCommand::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .map_err(|error| error.to_string())?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!(
+                "git {:?} exited with status {:?}",
+                args,
+                output.status.code()
+            )
+        } else {
+            stderr
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn git_status(path: &Path, args: &[&str]) -> Result<(), String> {
+    git_stdout(path, args).map(|_| ())
 }
 
 fn normalized_login(value: &str) -> String {
@@ -7788,6 +8080,14 @@ enum Command {
         worker: String,
         write: bool,
     },
+    LaneClaim {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        lane: AgentSessionLaneArg,
+        worker: String,
+        source: CliLaneClaimSource,
+        write: bool,
+    },
     ReviewClearClaim {
         workflow_path: PathBuf,
         issue_ref: String,
@@ -7826,7 +8126,23 @@ enum Command {
         workflow_path: PathBuf,
         issue_ref: String,
         lane: AgentSessionLaneArg,
+        run_id: Option<String>,
         write: bool,
+    },
+    SessionStart {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        lane: AgentSessionLaneArg,
+        run_id: String,
+        write: bool,
+    },
+    SessionList {
+        workflow_path: PathBuf,
+    },
+    SessionAttach {
+        workflow_path: PathBuf,
+        session: String,
+        exec: bool,
     },
     AgentSessionList {
         workflow_path: PathBuf,
@@ -8000,6 +8316,19 @@ impl Command {
     }
 }
 
+fn lane_command(lane: AgentSessionLaneArg, args: LaneCommandArgs) -> Result<Command, String> {
+    match args.command {
+        LaneCommand::Claim(claim) => Ok(Command::LaneClaim {
+            workflow_path: claim.workflow_path,
+            issue_ref: claim.issue_ref,
+            lane,
+            worker: claim.worker,
+            source: claim.source,
+            write: claim.write,
+        }),
+    }
+}
+
 #[derive(Debug, Parser)]
 #[command(
     name = "jade-symphony",
@@ -8049,7 +8378,13 @@ enum CliCommand {
     MergeOnce(MergeOnceArgs),
     #[command(name = "merge-loop")]
     MergeLoop(MergeLoopArgs),
-    #[command(name = "merge-session")]
+    #[command(name = "main")]
+    Main(LaneCommandArgs),
+    #[command(name = "merge")]
+    Merge(LaneCommandArgs),
+    #[command(name = "session")]
+    Session(SessionArgs),
+    #[command(name = "merge-session", hide = true)]
     MergeSession(LaneSessionAliasArgs),
     #[command(name = "set-state")]
     SetState(SetStateArgs),
@@ -8079,7 +8414,7 @@ enum CliCommand {
     ReviewFreshness(ReviewFreshnessArgs),
     #[command(name = "review-loop", hide = true)]
     ReviewLoop(ReviewLoopArgs),
-    #[command(name = "agent-session")]
+    #[command(name = "agent-session", hide = true)]
     AgentSession(AgentSessionArgs),
     Gate(GateArgs),
     #[command(name = "gate-apply")]
@@ -8336,6 +8671,49 @@ struct MergeLoopArgs {
 }
 
 #[derive(Debug, Args)]
+struct LaneCommandArgs {
+    #[command(subcommand)]
+    command: LaneCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum LaneCommand {
+    Claim(LaneClaimArgs),
+}
+
+#[derive(Debug, Args)]
+struct LaneClaimArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long)]
+    worker: String,
+    #[arg(long, value_enum, default_value_t = CliLaneClaimSource::Manual)]
+    source: CliLaneClaimSource,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliLaneClaimSource {
+    Manual,
+    Loop,
+    Goal,
+}
+
+impl From<CliLaneClaimSource> for LaneClaimSource {
+    fn from(value: CliLaneClaimSource) -> Self {
+        match value {
+            CliLaneClaimSource::Manual => Self::Manual,
+            CliLaneClaimSource::Loop => Self::Loop,
+            CliLaneClaimSource::Goal => Self::Goal,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
 struct AgentSessionArgs {
     #[command(subcommand)]
     command: AgentSessionCommand,
@@ -8355,6 +8733,36 @@ struct AgentSessionStartArgs {
     issue_ref: String,
     #[arg(long, value_enum, default_value = "main")]
     lane: AgentSessionLaneArg,
+    #[arg(long = "run")]
+    run_id: Option<String>,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct SessionArgs {
+    #[command(subcommand)]
+    command: SessionCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum SessionCommand {
+    Start(SessionStartArgs),
+    List(AgentSessionListArgs),
+    Attach(AgentSessionAttachArgs),
+}
+
+#[derive(Debug, Args)]
+struct SessionStartArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long, value_enum)]
+    lane: AgentSessionLaneArg,
+    #[arg(long = "run")]
+    run_id: String,
     #[arg(long)]
     write: bool,
     #[arg(long = "dry-run")]
@@ -8585,7 +8993,7 @@ struct ReviewArgs {
 enum ReviewCommandArgs {
     Fake(ReviewFakeArgs),
     Once(ReviewOnceArgs),
-    Claim(ReviewClaimArgs),
+    Claim(LaneClaimArgs),
     Pass(ReviewEvidenceArgs),
     Reject(ReviewRejectArgs),
     Session(LaneSessionAliasArgs),
@@ -8909,6 +9317,25 @@ impl TryFrom<Cli> for Command {
                             },
                         })
                     }
+                    CliCommand::Main(args) => lane_command(AgentSessionLaneArg::Main, args),
+                    CliCommand::Merge(args) => lane_command(AgentSessionLaneArg::Merge, args),
+                    CliCommand::Session(args) => match args.command {
+                        SessionCommand::Start(start) => Ok(Self::SessionStart {
+                            workflow_path: start.workflow_path,
+                            issue_ref: start.issue_ref,
+                            lane: start.lane,
+                            run_id: start.run_id,
+                            write: start.write,
+                        }),
+                        SessionCommand::List(list) => Ok(Self::SessionList {
+                            workflow_path: list.workflow_path,
+                        }),
+                        SessionCommand::Attach(attach) => Ok(Self::SessionAttach {
+                            workflow_path: attach.workflow_path,
+                            session: attach.session,
+                            exec: attach.exec,
+                        }),
+                    },
                     CliCommand::MergeSession(args) => Ok(Self::MergeSession {
                         workflow_path: args.workflow_path,
                         issue_ref: args.issue_ref,
@@ -8950,9 +9377,12 @@ impl TryFrom<Cli> for Command {
                     CliCommand::ReviewOnce(args) => {
                         command_from_review_args(ReviewCommandArgs::Once(args))
                     }
-                    CliCommand::ReviewClaim(args) => {
-                        command_from_review_args(ReviewCommandArgs::Claim(args))
-                    }
+                    CliCommand::ReviewClaim(args) => Ok(Self::ReviewClaim {
+                        workflow_path: args.workflow_path,
+                        issue_ref: args.issue_ref,
+                        worker: args.worker,
+                        write: args.write,
+                    }),
                     CliCommand::ReviewClearClaim(args) => Ok(Self::ReviewClearClaim {
                         workflow_path: args.workflow_path,
                         issue_ref: args.issue_ref,
@@ -8978,6 +9408,7 @@ impl TryFrom<Cli> for Command {
                             workflow_path: start.workflow_path,
                             issue_ref: start.issue_ref,
                             lane: start.lane,
+                            run_id: start.run_id,
                             write: start.write,
                         }),
                         AgentSessionCommand::List(list) => Ok(Self::AgentSessionList {
@@ -9137,10 +9568,12 @@ fn command_from_review_args(command: ReviewCommandArgs) -> Result<Command, Strin
             issue_ref: args.issue_ref,
             write: args.write,
         }),
-        ReviewCommandArgs::Claim(args) => Ok(Command::ReviewClaim {
+        ReviewCommandArgs::Claim(args) => Ok(Command::LaneClaim {
             workflow_path: args.workflow_path,
             issue_ref: args.issue_ref,
+            lane: AgentSessionLaneArg::Review,
             worker: args.worker,
+            source: args.source,
             write: args.write,
         }),
         ReviewCommandArgs::Pass(args) => Ok(Command::ReviewPass {
@@ -9291,6 +9724,100 @@ mod tests {
 
     fn parse(args: &[&str]) -> Command {
         Command::parse(args.iter().map(|arg| arg.to_string()).collect()).unwrap()
+    }
+
+    fn git_ok(path: &Path, args: &[&str]) {
+        let output = ProcessCommand::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|error| panic!("failed to run git {args:?}: {error}"));
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout={}\nstderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn canonical_git_repo() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let temp = tempfile::tempdir().unwrap();
+        let remote = temp.path().join("origin.git");
+        let repo = temp.path().join("repo");
+        git_ok(
+            temp.path(),
+            &["init", "--bare", "--initial-branch=main", "origin.git"],
+        );
+        git_ok(temp.path(), &["init", "--initial-branch=main", "repo"]);
+        git_ok(&repo, &["config", "user.email", "jade@example.invalid"]);
+        git_ok(&repo, &["config", "user.name", "Jade Symphony"]);
+        std::fs::write(repo.join("README.md"), "main\n").unwrap();
+        git_ok(&repo, &["add", "README.md"]);
+        git_ok(&repo, &["commit", "-m", "initial"]);
+        git_ok(
+            &repo,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        git_ok(&repo, &["push", "-u", "origin", "main"]);
+        (temp, repo, remote)
+    }
+
+    #[test]
+    fn canonical_checkout_report_accepts_latest_main() {
+        let (_temp, repo, _remote) = canonical_git_repo();
+
+        assert_eq!(
+            canonical_checkout_report(&repo),
+            CanonicalCheckoutReport::Ready
+        );
+    }
+
+    #[test]
+    fn canonical_checkout_report_blocks_detached_head() {
+        let (_temp, repo, _remote) = canonical_git_repo();
+        git_ok(&repo, &["checkout", "--detach", "HEAD"]);
+
+        let report = canonical_checkout_report(&repo);
+        assert!(matches!(
+            report,
+            CanonicalCheckoutReport::Blocked { ref reason } if reason.contains("detached")
+        ));
+    }
+
+    #[test]
+    fn canonical_checkout_report_blocks_non_main_branch() {
+        let (_temp, repo, _remote) = canonical_git_repo();
+        git_ok(&repo, &["checkout", "-b", "feature/test"]);
+
+        let report = canonical_checkout_report(&repo);
+        assert!(matches!(
+            report,
+            CanonicalCheckoutReport::Blocked { ref reason } if reason.contains("current branch")
+        ));
+    }
+
+    #[test]
+    fn canonical_checkout_report_blocks_main_behind_origin_main() {
+        let (temp, repo, remote) = canonical_git_repo();
+        let other = temp.path().join("other");
+        git_ok(
+            temp.path(),
+            &["clone", remote.to_str().unwrap(), other.to_str().unwrap()],
+        );
+        git_ok(&other, &["config", "user.email", "jade@example.invalid"]);
+        git_ok(&other, &["config", "user.name", "Jade Symphony"]);
+        std::fs::write(other.join("CHANGELOG.md"), "change\n").unwrap();
+        git_ok(&other, &["add", "CHANGELOG.md"]);
+        git_ok(&other, &["commit", "-m", "advance main"]);
+        git_ok(&other, &["push", "origin", "main"]);
+
+        let report = canonical_checkout_report(&repo);
+        assert!(matches!(
+            report,
+            CanonicalCheckoutReport::Blocked { ref reason }
+                if reason.contains("local main does not exactly match origin/main")
+        ));
     }
 
     #[test]
@@ -10089,6 +10616,7 @@ mod tests {
                 workflow_path: PathBuf::from("workflows/jade-symphony.md"),
                 issue_ref: "#220".into(),
                 lane: AgentSessionLaneArg::Review,
+                run_id: None,
                 write: true,
             }
         );
@@ -10135,6 +10663,79 @@ mod tests {
                 workflow_path: PathBuf::from("workflows/jade-symphony.md"),
                 issue_ref: "#227".into(),
                 write: true,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_lane_claim_command_groups() {
+        assert_eq!(
+            parse(&[
+                "main",
+                "claim",
+                "workflows/jade-symphony.md",
+                "#265",
+                "--worker",
+                "codex-manual-main",
+                "--source",
+                "manual",
+                "--write"
+            ]),
+            Command::LaneClaim {
+                workflow_path: PathBuf::from("workflows/jade-symphony.md"),
+                issue_ref: "#265".into(),
+                lane: AgentSessionLaneArg::Main,
+                worker: "codex-manual-main".into(),
+                source: CliLaneClaimSource::Manual,
+                write: true,
+            }
+        );
+        assert_eq!(
+            parse(&[
+                "review",
+                "claim",
+                "workflows/jade-symphony.md",
+                "#265",
+                "--worker",
+                "gemini-manual-review"
+            ]),
+            Command::LaneClaim {
+                workflow_path: PathBuf::from("workflows/jade-symphony.md"),
+                issue_ref: "#265".into(),
+                lane: AgentSessionLaneArg::Review,
+                worker: "gemini-manual-review".into(),
+                source: CliLaneClaimSource::Manual,
+                write: false,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_unified_session_commands() {
+        assert_eq!(
+            parse(&[
+                "session",
+                "start",
+                "workflows/jade-symphony.md",
+                "#265",
+                "--lane",
+                "main",
+                "--run",
+                "20260517T0909Z-issue265-main-manual",
+                "--write"
+            ]),
+            Command::SessionStart {
+                workflow_path: PathBuf::from("workflows/jade-symphony.md"),
+                issue_ref: "#265".into(),
+                lane: AgentSessionLaneArg::Main,
+                run_id: "20260517T0909Z-issue265-main-manual".into(),
+                write: true,
+            }
+        );
+        assert_eq!(
+            parse(&["session", "list", "workflows/jade-symphony.md"]),
+            Command::SessionList {
+                workflow_path: PathBuf::from("workflows/jade-symphony.md"),
             }
         );
     }
@@ -10458,10 +11059,12 @@ mod tests {
                 "Gemini A",
                 "--write"
             ]),
-            Command::ReviewClaim {
+            Command::LaneClaim {
                 workflow_path: PathBuf::from("examples/github-project-workflow.md"),
                 issue_ref: "#235".into(),
+                lane: AgentSessionLaneArg::Review,
                 worker: "Gemini A".into(),
+                source: CliLaneClaimSource::Manual,
                 write: true
             }
         );

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -13,10 +13,9 @@ cargo run -- forge validate --workflow workflows/jade-symphony.md --status Todo 
 cargo run -- forge create --workflow workflows/jade-symphony.md --status Todo --title "<title>" --body-file /private/tmp/issue.md --assignee Alive24 --write
 cargo run -- review loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- merge-once workflows/jade-symphony.md --write
-cargo run -- review session workflows/jade-symphony.md '#123' --write
-cargo run -- merge-session workflows/jade-symphony.md '#123' --write
-cargo run -- agent-session start workflows/jade-symphony.md '#220' --lane review --write
-cargo run -- agent-session list workflows/jade-symphony.md
+cargo run -- main claim workflows/jade-symphony.md '#123' --worker codex-manual-main --write
+cargo run -- session start workflows/jade-symphony.md '#123' --lane main --run <RUN_ID> --write
+cargo run -- session list workflows/jade-symphony.md
 ```
 
 Main Agent execution uses the local `tmux` backend. A bounded write tick creates
@@ -25,15 +24,12 @@ log path, persists a session registry record, and leaves the issue active until
 real implementation evidence is available for the normal handoff path. Status
 commands classify registered tmux sessions from bounded pane/log evidence while
 keeping full scrollback out of routine output.
-The `agent-session` command is the manual tmux recovery path for all lanes:
-`main`, `review`, and `merge` each render their own lane prompt, claim the
-matching Project field, and leave workflow state unchanged until the lane's
-normal evidence path is ready.
-`review session` starts a review runtime/session and writes attach/log evidence
-without writing the `Review Agent` claim; claim ownership stays with
-`review claim` or the configured `review loop`. `merge-session` remains the
-merge-lane shortcut for session recovery. Neither shortcut approves reviews,
-merges PRs, or closes issues.
+Manual tmux recovery is a two-step path. Use `main claim`, `review claim`, or
+`merge claim` to write only the matching Project claim field and print the
+structured `run=`. Then use `session start --lane ... --run ...` to render the
+lane prompt and start the tmux runtime. Session commands validate the existing
+claim and write attach/log evidence without approving reviews, merging PRs, or
+closing issues.
 
 Lane prompt files:
 

--- a/workflows/prompts/main-agent.md
+++ b/workflows/prompts/main-agent.md
@@ -48,6 +48,9 @@ question, but do not edit files under
    implementation. Direct `gh issue view` / `gh pr view` is acceptable for raw
    issue and PR content, but do not use raw Project GraphQL or the Project UI
    for normal Project state reads or mutations.
+   Manual lane ownership must use `main claim ... --worker <worker> --write`;
+   session startup must use `session start ... --lane main --run <RUN_ID>`.
+   Session startup validates the claim and must not write Project claim fields.
 2. Confirm the issue is still executable with the Issue Quality Gate. If the
    issue is not executable, leave a precise workpad note, move it to
    `Need to Clarify`, and stop this issue. The gate must include explicit
@@ -130,6 +133,8 @@ throughout execution. Record:
 
 - Base the issue branch on the current `origin/main` unless the issue says
   otherwise.
+- The canonical harness checkout must stay on latest `main`; dogfood branches
+  belong in separate issue worktrees.
 - Use a branch name that includes the issue number.
 - Keep one issue per branch and one branch per PR.
 - Do not rewrite or revert unrelated user changes.

--- a/workflows/prompts/merge-agent.md
+++ b/workflows/prompts/merge-agent.md
@@ -24,6 +24,9 @@ context, but raw Project GraphQL or Project UI changes are break-glass only.
 ## Merge Contract
 
 - Confirm the issue is in `Merging` before attempting to land.
+- Claim `Merging Agent` through `merge claim ... --worker <worker> --write`
+  before starting manual merge work, then start runtime through `session start
+  --lane merge --run <RUN_ID>` only after the matching claim exists.
 - Confirm exactly one reliable PR target exists.
 - Preserve the assigned structured claim `run=` in merge evidence, workpad
   notes, and final summaries.

--- a/workflows/prompts/review-agent.md
+++ b/workflows/prompts/review-agent.md
@@ -24,8 +24,11 @@ context, but raw Project GraphQL or Project UI changes are break-glass only.
 ## Review Contract
 
 - Confirm the issue is in `Agent Review` before starting review.
-- Claim `Review Agent` through `review claim` or the configured `review loop`
+- Claim `Review Agent` through `review claim ... --worker <worker> --write`
+  or the configured `review-loop`
   before starting manual or automated review work.
+- Start manual review sessions through `session start --lane review --run
+  <RUN_ID>` only after the matching Project claim exists.
 - Preserve the assigned structured claim `run=` in review evidence, workpad
   notes, and any handoff summary.
 - `review session` may start or inspect a review runtime/session, but it does


### PR DESCRIPTION
## Summary
- add grouped `main/review/merge claim` commands that write only lane claim fields with `worker=` and `run=`
- add grouped `session start/list/attach`; `session start` requires an existing active matching claim and no longer writes Project claim fields
- block live write-mode claim/session/loop commands unless the canonical checkout is attached to latest `main`
- update operator docs and lane prompts for worker/run/session separation

## Verification
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- --help`
- `cargo run -- main claim examples/dry-run-workflow.md '#1' --worker codex-fixture-main --dry-run`
- `cargo run -- review claim examples/review-fixture-workflow.md '#41' --worker gemini-fixture-review --dry-run`
- `cargo run -- merge claim examples/merge-fixture-workflow.md '#9101' --worker codex-fixture-merge --dry-run`
- `cargo run -- session start workflows/jade-symphony.md '#265' --lane main --run 20260517T0909Z-issue265-main-manual --dry-run`
- `cargo run -- main claim workflows/jade-symphony.md '#265' --worker codex-manual-main --write` from the issue worktree, which blocked before mutation because the checkout was not `main`
- `cargo run -- project-state workflows/jade-symphony.md`, which still worked and reported `canonical_checkout_blocked`

Closes #265
