### PR TITLE
#272: Clarify parent/subissue topology fixture verification

### DIFF
--- a/docs/parent-subissue-topology.md
+++ b/docs/parent-subissue-topology.md
@@ -131,3 +131,20 @@ Later doctor checks should flag these examples:
 
 Issue #273 should turn these into doctor invariants. Issue #274 should teach
 lane flows how to use the parent integration branch during live execution.
+
+## Dry Fixture Verification
+
+The credential-free topology fixture lives at:
+
+```text
+examples/fixtures/parent-subissue-topology.json
+```
+
+Run its focused verification with:
+
+```bash
+cargo test --test parent_subissue_topology
+```
+
+That test validates the happy path, unsafe topology examples, and the
+documentation boundaries above without changing live lane behavior.

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,7 +49,7 @@ memory-backed. They do not mutate live GitHub Project v2 state.
 
 | Fixture | Purpose | Verification |
 | --- | --- | --- |
-| `fixtures/parent-subissue-topology.json` | Dry parent/subissue integration branch topology examples for the documented `#243` parent flow. | `cargo test parent_subissue_topology` |
+| `fixtures/parent-subissue-topology.json` | Dry parent/subissue integration branch topology examples for the documented `#243` parent flow. | `cargo test --test parent_subissue_topology` |
 
 ## Fixture Data
 

--- a/tests/parent_subissue_topology.rs
+++ b/tests/parent_subissue_topology.rs
@@ -74,7 +74,11 @@ fn fixture_covers_unsafe_topologies_for_later_doctor_checks() {
         .expect("fixture should include unsafe topology examples");
     let names: Vec<_> = unsafe_topologies
         .iter()
-        .map(|topology| topology["name"].as_str().expect("unsafe example should have a name"))
+        .map(|topology| {
+            topology["name"]
+                .as_str()
+                .expect("unsafe example should have a name")
+        })
         .collect();
 
     for required in [
@@ -91,7 +95,9 @@ fn fixture_covers_unsafe_topologies_for_later_doctor_checks() {
 
     for topology in unsafe_topologies {
         assert!(
-            topology["violates"].as_str().is_some_and(|value| !value.is_empty()),
+            topology["violates"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty()),
             "unsafe examples should explain the violated rule"
         );
         assert!(
@@ -113,7 +119,8 @@ fn documentation_states_the_non_competing_sources_and_boundaries() {
         "The parent issue remains the final Human Review unit",
         "The Main Agent still stops at `Agent Review`",
         "Issue #273 should turn these into doctor invariants",
-        "Issue #274 should teach lane flows how to use the parent integration branch",
+        "Issue #274 should teach",
+        "the parent integration branch during live execution",
     ] {
         assert!(
             doc.contains(required),


### PR DESCRIPTION
Closes #272

## Summary

- Document the exact dry fixture verification command for the parent/subissue topology fixture.
- Correct the examples README so the integration test actually runs instead of filtering every topology test out.
- Make the topology doc boundary checks robust to Markdown line wrapping.

## Verification

- `cargo fmt --check`
- `cargo test --test parent_subissue_topology`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Notes

- This PR is intentionally docs/fixture/test only and does not change live lane behavior.
- `origin/main` already contains the initial topology document, fixture, and tests; this PR repairs the verification entrypoint and preserves a reviewable #272 handoff.
