### PR TITLE
#273: Add parent/subissue topology doctor checks

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -193,6 +193,13 @@ for an operator-selected existing worktree; it must not be used as a shortcut
 for `gh pr checkout` in the canonical checkout. `doctor` warns when multiple
 strong candidates exist for one active issue.
 
+For native parent/subissue flows, `doctor` also checks the read-only integration
+branch topology from GitHub native parent/subissue links plus Jade-owned branch
+and merge evidence. It reports blockers for subissue PRs targeting `main`,
+missing or ambiguous parent integration branch evidence, `Done` subissues
+without parent-branch merge evidence, and parent `Human Review` before native
+subissues are complete.
+
 ## Tracker Writes
 
 These commands can mutate live tracker state and require `--write`.

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -291,9 +291,12 @@ Project v2 issues:
      claim alone is not evidence. `doctor --interactive` and
      `doctor repair ISSUE` provide non-destructive repair guidance, while
      explicit-write repair can move uncertain work to `Need Human Input` after
-     writing workpad evidence. `doctor --auto-fix --write` is limited to clearly
-     safe repairs such as invalid `Human Review` issues without independent
-     Review Agent pass evidence.
+     writing workpad evidence. Native parent/subissue topology diagnostics are
+     read-only and flag unsafe parent integration branch evidence, subissue PR
+     targets, subissue `Done` merge evidence, and premature parent
+     `Human Review`. `doctor --auto-fix --write` is limited to clearly safe
+     repairs such as invalid `Human Review` issues without independent Review
+     Agent pass evidence.
 
 9. Integration profile.
    - Credential-gated GitHub Project v2 smoke test.

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -249,7 +249,11 @@ break-glass recovery paths.
 For parent tracking issues with native GitHub subissues, use
 `docs/parent-subissue-topology.md` as the design source. Native sub-issue links
 define hierarchy, subissue PRs target the parent integration branch by default,
-and the parent issue remains the final Human Review unit.
+and the parent issue remains the final Human Review unit. `doctor` now reports
+read-only topology blockers for native subissue PRs targeting `main`, missing or
+ambiguous parent integration branch evidence, `Done` subissues without merge
+evidence into the parent branch, and parent `Human Review` before all native
+subissues are `Done` and merged.
 
 ## Issue Forge Reflect
 

--- a/docs/parent-subissue-topology.md
+++ b/docs/parent-subissue-topology.md
@@ -132,6 +132,28 @@ Later doctor checks should flag these examples:
 Issue #273 should turn these into doctor invariants. Issue #274 should teach
 lane flows how to use the parent integration branch during live execution.
 
+## Doctor Diagnostics
+
+`doctor` is diagnostic-only for parent/subissue topology. It reads GitHub native
+parent and subissue links as hierarchy authority, then uses parent issue body or
+workpad branch evidence, linked PR base/merge state, and branch-name hints as
+supplemental execution evidence.
+
+Blocker findings cover unsafe execution states:
+
+- native subissue PRs targeting `main` instead of the parent integration branch;
+- missing or ambiguous parent integration branch evidence on a native parent;
+- `Done` subissues without linked PR or workpad evidence showing merge into the
+  parent integration branch;
+- parent issues in `Human Review` before every native subissue is `Done` and
+  merged into the parent integration branch.
+
+Warning findings cover repairable metadata inconsistencies, such as body-only
+parent membership or a subissue PR target that disagrees with the parent branch
+without directly targeting `main`. Doctor does not repair these states, retarget
+PRs, edit native GitHub relationships, move Project statuses, or replace the
+#274 lane-flow work.
+
 ## Dry Fixture Verification
 
 The credential-free topology fixture lives at:

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -176,6 +176,8 @@ pub fn audit_project_issues_with_context(
         }
     }
 
+    audit_parent_subissue_topology(issues, &mut violations);
+
     if let Some(context) = context {
         audit_session_consistency(issues, context, &mut violations);
     }
@@ -399,6 +401,400 @@ fn has_dirty_or_conflicted_pr(issue: &TrackerIssue) -> bool {
             state == "dirty" || state == "blocked" || state == "behind" || state == "conflicted"
         })
         .unwrap_or(false)
+}
+
+fn audit_parent_subissue_topology(
+    issues: &[TrackerIssue],
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    for issue in issues {
+        audit_body_only_parent_hierarchy(issue, violations);
+    }
+
+    for parent in issues {
+        if parent.normalized_state() == "done" {
+            continue;
+        }
+        let subissue_refs = native_subissue_refs(parent, issues);
+        if subissue_refs.is_empty() {
+            continue;
+        }
+
+        let parent_branches = parent_integration_branch_candidates(parent);
+        match parent_branches.as_slice() {
+            [] => violations.push(violation(
+                parent,
+                AuditSeverity::Blocker,
+                "parent_topology_missing_integration_branch",
+                "Parent issue has native subissues but no parent integration branch evidence.",
+                "Record the parent integration branch in the parent issue body or Jade Symphony workpad before subissue PRs advance.",
+            )),
+            [_] => {}
+            branches => violations.push(violation(
+                parent,
+                AuditSeverity::Blocker,
+                "parent_topology_ambiguous_integration_branch",
+                &format!(
+                    "Parent issue has multiple parent integration branch candidates: {}.",
+                    branches.join(", ")
+                ),
+                "Choose one parent integration branch and supersede stale branch evidence before Human Review or Merge.",
+            )),
+        }
+
+        let Some(parent_branch) = parent_branches.first() else {
+            continue;
+        };
+        if parent_branches.len() > 1 {
+            continue;
+        }
+
+        audit_parent_human_review_gate(parent, &subissue_refs, issues, parent_branch, violations);
+    }
+
+    for subissue in issues {
+        let Some(parent_ref) = native_parent_ref(subissue) else {
+            continue;
+        };
+        let Some(parent) = find_issue_by_ref(issues, &parent_ref) else {
+            continue;
+        };
+        if parent.normalized_state() == "done" {
+            continue;
+        }
+        let parent_branches = parent_integration_branch_candidates(parent);
+        let Some(parent_branch) = parent_branches.first() else {
+            continue;
+        };
+        if parent_branches.len() > 1 {
+            continue;
+        }
+
+        audit_subissue_pr_target(subissue, parent_branch, violations);
+        audit_subissue_done_merge_evidence(subissue, parent_branch, violations);
+    }
+}
+
+fn audit_body_only_parent_hierarchy(
+    issue: &TrackerIssue,
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    if native_parent_ref(issue).is_some() {
+        return;
+    }
+    if issue.normalized_state() == "done" {
+        return;
+    }
+    let Some(description) = issue.description.as_deref() else {
+        return;
+    };
+    let mut supplemental_parent_refs = supplemental_parent_refs(description);
+    supplemental_parent_refs.retain(|issue_ref| !issue_refs_match(issue_ref, &issue.identifier));
+    if supplemental_parent_refs.is_empty() {
+        return;
+    }
+
+    violations.push(violation(
+        issue,
+        AuditSeverity::Warning,
+        "body_only_parent_hierarchy",
+        &format!(
+            "Issue claims parent membership in text without a GitHub native parent link: {}.",
+            supplemental_parent_refs.join(", ")
+        ),
+        "Create or repair the GitHub native sub-issue relationship, or record an explicit topology exception before relying on parent/subissue flow.",
+    ));
+}
+
+fn audit_subissue_pr_target(
+    subissue: &TrackerIssue,
+    parent_branch: &str,
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    if has_parent_topology_exception(subissue) {
+        return;
+    }
+
+    for pr in &subissue.linked_pull_requests {
+        let Some(base) = pr.base_ref_name.as_deref() else {
+            continue;
+        };
+        if base == "main" {
+            violations.push(violation(
+                subissue,
+                AuditSeverity::Blocker,
+                "subissue_pr_targets_main",
+                "Native subissue PR targets `main` instead of the parent integration branch.",
+                &format!(
+                    "Retarget the subissue PR to `{parent_branch}` or record an explicit parent topology exception in the issue workpad and PR body."
+                ),
+            ));
+        } else if base != parent_branch {
+            violations.push(violation(
+                subissue,
+                AuditSeverity::Warning,
+                "subissue_pr_target_mismatch",
+                &format!(
+                    "Native subissue PR targets `{base}` instead of parent branch `{parent_branch}`."
+                ),
+                "Inspect the linked PR base branch and parent integration branch evidence before handoff or merge.",
+            ));
+        }
+    }
+}
+
+fn audit_subissue_done_merge_evidence(
+    subissue: &TrackerIssue,
+    parent_branch: &str,
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    if subissue.normalized_state() != "done" || has_parent_topology_exception(subissue) {
+        return;
+    }
+    if has_merged_into_parent_branch_evidence(subissue, parent_branch) {
+        return;
+    }
+
+    violations.push(violation(
+        subissue,
+        AuditSeverity::Blocker,
+        "subissue_done_missing_parent_merge",
+        "Subissue is Done without evidence that its PR merged into the parent integration branch.",
+        &format!(
+            "Keep the subissue out of Done until linked PR evidence or workpad merge evidence shows it merged into `{parent_branch}`."
+        ),
+    ));
+}
+
+fn audit_parent_human_review_gate(
+    parent: &TrackerIssue,
+    subissue_refs: &[String],
+    issues: &[TrackerIssue],
+    parent_branch: &str,
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    if parent.normalized_state() != "human review" {
+        return;
+    }
+
+    for subissue_ref in subissue_refs {
+        let Some(subissue) = find_issue_by_ref(issues, subissue_ref) else {
+            violations.push(violation(
+                parent,
+                AuditSeverity::Blocker,
+                "parent_human_review_missing_subissue",
+                &format!(
+                    "Parent issue is in Human Review but native subissue `{subissue_ref}` is missing from the Project read."
+                ),
+                "Refresh Project membership or add the native subissue to the Project before parent Human Review proceeds.",
+            ));
+            continue;
+        };
+
+        if subissue.normalized_state() != "done" {
+            violations.push(violation(
+                parent,
+                AuditSeverity::Blocker,
+                "parent_human_review_subissue_not_done",
+                &format!(
+                    "Parent issue is in Human Review while native subissue `{}` is `{}`.",
+                    subissue.identifier, subissue.state
+                ),
+                "Return the parent issue before Human Review until every native subissue is Done and merged into the parent branch.",
+            ));
+        } else if !has_merged_into_parent_branch_evidence(subissue, parent_branch)
+            && !has_parent_topology_exception(subissue)
+        {
+            violations.push(violation(
+                parent,
+                AuditSeverity::Blocker,
+                "parent_human_review_subissue_missing_merge",
+                &format!(
+                    "Parent issue is in Human Review but native subissue `{}` lacks merge evidence into `{parent_branch}`.",
+                    subissue.identifier
+                ),
+                "Record or repair subissue merge evidence before parent Human Review proceeds.",
+            ));
+        }
+    }
+}
+
+fn native_parent_ref(issue: &TrackerIssue) -> Option<String> {
+    issue
+        .project_fields
+        .get("GitHub Native Parent")
+        .and_then(issue_ref_from_value)
+}
+
+fn native_subissue_refs(parent: &TrackerIssue, issues: &[TrackerIssue]) -> Vec<String> {
+    let mut refs = Vec::new();
+    if let Some(values) = parent
+        .project_fields
+        .get("GitHub Native Subissues")
+        .and_then(serde_json::Value::as_array)
+    {
+        for value in values {
+            if let Some(issue_ref) = issue_ref_from_value(value) {
+                push_unique(&mut refs, issue_ref);
+            }
+        }
+    }
+
+    for issue in issues {
+        if native_parent_ref(issue)
+            .is_some_and(|issue_ref| issue_refs_match(&issue_ref, &parent.identifier))
+        {
+            push_unique(&mut refs, issue.identifier.clone());
+        }
+    }
+
+    refs
+}
+
+fn issue_ref_from_value(value: &serde_json::Value) -> Option<String> {
+    value
+        .get("identifier")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .or_else(|| value.as_str().map(str::to_string))
+        .or_else(|| {
+            value
+                .get("number")
+                .and_then(serde_json::Value::as_u64)
+                .map(|number| format!("#{number}"))
+        })
+}
+
+fn parent_integration_branch_candidates(issue: &TrackerIssue) -> Vec<String> {
+    let mut branches = Vec::new();
+    for value in issue.project_fields.values() {
+        collect_integration_branches_from_value(value, &mut branches);
+    }
+    if let Some(description) = issue.description.as_deref() {
+        collect_integration_branches(description, &mut branches);
+    }
+    if let Some(branch) = issue
+        .branch_name
+        .as_deref()
+        .filter(|branch| branch.starts_with("integration/"))
+    {
+        push_unique(&mut branches, branch.to_string());
+    }
+    for pr in &issue.linked_pull_requests {
+        if let Some(head) = pr
+            .head_ref_name
+            .as_deref()
+            .filter(|branch| branch.starts_with("integration/"))
+        {
+            push_unique(&mut branches, head.to_string());
+        }
+    }
+    branches
+}
+
+fn collect_integration_branches_from_value(value: &serde_json::Value, branches: &mut Vec<String>) {
+    match value {
+        serde_json::Value::String(text) => collect_integration_branches(text, branches),
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_integration_branches_from_value(value, branches);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for value in map.values() {
+                collect_integration_branches_from_value(value, branches);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_integration_branches(text: &str, branches: &mut Vec<String>) {
+    for token in text.split(|character: char| {
+        character.is_whitespace()
+            || matches!(
+                character,
+                '`' | '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | ',' | ';'
+            )
+    }) {
+        let branch = token.trim_matches(|character: char| {
+            matches!(character, '.' | ':' | '`' | '"' | '\'' | ')' | ']' | '}')
+        });
+        if branch.starts_with("integration/issue-") {
+            push_unique(branches, branch.to_string());
+        }
+    }
+}
+
+fn supplemental_parent_refs(description: &str) -> Vec<String> {
+    let mut refs = Vec::new();
+    for line in description.lines() {
+        let lower = line.to_lowercase();
+        let explicit_subissue_parent_claim = lower.contains("subissue under parent")
+            || lower.contains("subissue seed under parent")
+            || lower.contains("native parent")
+            || lower.contains("native_parent")
+            || lower.contains("claimed_parent")
+            || (lower.contains("related parent issue") && lower.contains("subissue"));
+        if !explicit_subissue_parent_claim {
+            continue;
+        }
+        collect_issue_refs(line, &mut refs);
+    }
+    refs
+}
+
+fn collect_issue_refs(text: &str, refs: &mut Vec<String>) {
+    let bytes = text.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'#' {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        index += 1;
+        let digits_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+        if index > digits_start {
+            push_unique(refs, text[start..index].to_string());
+        }
+    }
+}
+
+fn has_parent_topology_exception(issue: &TrackerIssue) -> bool {
+    issue.description.as_deref().is_some_and(|description| {
+        let text = description.to_lowercase();
+        text.contains("parent topology exception")
+            || text.contains("parent integration branch exception")
+            || text.contains("not part of the parent integration branch")
+    }) || string_project_field(issue, "parent_topology_exception")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+        || bool_project_field(issue, "parent_topology_exception_recorded")
+}
+
+fn has_merged_into_parent_branch_evidence(issue: &TrackerIssue, parent_branch: &str) -> bool {
+    issue.linked_pull_requests.iter().any(|pr| {
+        pr.base_ref_name.as_deref() == Some(parent_branch)
+            && pr
+                .state
+                .as_deref()
+                .is_some_and(|state| normalize_state(state) == "merged")
+    }) || issue.description.as_deref().is_some_and(|description| {
+        let text = description.to_lowercase();
+        text.contains(&parent_branch.to_lowercase())
+            && text.contains("merged")
+            && (text.contains("merge evidence") || text.contains("pr "))
+    })
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
 }
 
 fn audit_runtime_consistency(
@@ -886,6 +1282,40 @@ mod tests {
         }
     }
 
+    fn linked_pr_to(url: &str, state: &str, base: &str) -> LinkedPullRequest {
+        let mut pr = linked_pr(url, state);
+        pr.base_ref_name = Some(base.into());
+        pr
+    }
+
+    fn with_native_parent(mut issue: TrackerIssue, parent: &str) -> TrackerIssue {
+        issue.project_fields.insert(
+            "GitHub Native Parent".into(),
+            serde_json::json!({ "identifier": parent }),
+        );
+        issue
+    }
+
+    fn with_native_subissues(mut issue: TrackerIssue, subissues: &[&str]) -> TrackerIssue {
+        issue.project_fields.insert(
+            "GitHub Native Subissues".into(),
+            serde_json::Value::Array(
+                subissues
+                    .iter()
+                    .map(|issue_ref| serde_json::json!({ "identifier": issue_ref }))
+                    .collect(),
+            ),
+        );
+        issue
+    }
+
+    fn with_parent_branch(mut issue: TrackerIssue, branch: &str) -> TrackerIssue {
+        issue.description = Some(format!(
+            "## Parent Topology\n\nParent integration branch: `{branch}`"
+        ));
+        issue
+    }
+
     fn runtime_context(identifier: &str, updated_at_ms: u64) -> ProjectDoctorContext {
         let mut runtime_state = RuntimeState::active(
             crate::runtime_state::RuntimeIssueState {
@@ -989,6 +1419,137 @@ mod tests {
         let report = audit_project_issues(&[issue]);
 
         assert!(report.is_clean());
+    }
+
+    #[test]
+    fn accepts_happy_parent_subissue_topology() {
+        let parent_branch = "integration/issue-243-parent-subissue-orchestration";
+        let mut parent = with_parent_branch(
+            with_native_subissues(issue("#243", "Human Review"), &["#272", "#273"]),
+            parent_branch,
+        );
+        parent.description = Some(format!(
+            "Parent integration branch: `{parent_branch}`\nReview pass evidence: `recorded`"
+        ));
+        let mut subissue_one = with_native_parent(issue("#272", "Done"), "#243");
+        subissue_one.linked_pull_requests.push(linked_pr_to(
+            "https://github.com/Alive24/jade-symphony/pull/272",
+            "MERGED",
+            parent_branch,
+        ));
+        let mut subissue_two = with_native_parent(issue("#273", "Done"), "#243");
+        subissue_two.linked_pull_requests.push(linked_pr_to(
+            "https://github.com/Alive24/jade-symphony/pull/273",
+            "MERGED",
+            parent_branch,
+        ));
+
+        let report = audit_project_issues(&[parent, subissue_one, subissue_two]);
+
+        assert!(report.is_clean());
+    }
+
+    #[test]
+    fn reports_subissue_pr_targeting_main() {
+        let parent_branch = "integration/issue-243-parent-subissue-orchestration";
+        let parent = with_parent_branch(
+            with_native_subissues(issue("#243", "Todo"), &["#273"]),
+            parent_branch,
+        );
+        let mut subissue = with_native_parent(issue("#273", "Agent Review"), "#243");
+        subissue.linked_pull_requests.push(linked_pr_to(
+            "https://github.com/Alive24/jade-symphony/pull/273",
+            "OPEN",
+            "main",
+        ));
+
+        let report = audit_project_issues(&[parent, subissue]);
+
+        assert!(report
+            .violations
+            .iter()
+            .any(|violation| violation.code == "subissue_pr_targets_main"
+                && violation.severity == AuditSeverity::Blocker));
+    }
+
+    #[test]
+    fn reports_missing_parent_integration_branch_evidence() {
+        let parent = with_native_subissues(issue("#243", "Todo"), &["#273"]);
+        let subissue = with_native_parent(issue("#273", "Todo"), "#243");
+
+        let report = audit_project_issues(&[parent, subissue]);
+
+        assert!(report.violations.iter().any(|violation| {
+            violation.code == "parent_topology_missing_integration_branch"
+                && violation.severity == AuditSeverity::Blocker
+        }));
+    }
+
+    #[test]
+    fn reports_done_subissue_without_parent_merge_evidence() {
+        let parent_branch = "integration/issue-243-parent-subissue-orchestration";
+        let parent = with_parent_branch(
+            with_native_subissues(issue("#243", "Todo"), &["#272"]),
+            parent_branch,
+        );
+        let mut subissue = with_native_parent(issue("#272", "Done"), "#243");
+        subissue.linked_pull_requests.push(linked_pr_to(
+            "https://github.com/Alive24/jade-symphony/pull/272",
+            "OPEN",
+            parent_branch,
+        ));
+
+        let report = audit_project_issues(&[parent, subissue]);
+
+        assert!(report.violations.iter().any(|violation| {
+            violation.code == "subissue_done_missing_parent_merge"
+                && violation.severity == AuditSeverity::Blocker
+        }));
+    }
+
+    #[test]
+    fn reports_parent_human_review_before_subissues_done() {
+        let parent_branch = "integration/issue-243-parent-subissue-orchestration";
+        let mut parent = with_parent_branch(
+            with_native_subissues(issue("#243", "Human Review"), &["#272", "#273"]),
+            parent_branch,
+        );
+        parent.description = Some(format!(
+            "Parent integration branch: `{parent_branch}`\nReview pass evidence: `recorded`"
+        ));
+        let mut done_subissue = with_native_parent(issue("#272", "Done"), "#243");
+        done_subissue.linked_pull_requests.push(linked_pr_to(
+            "https://github.com/Alive24/jade-symphony/pull/272",
+            "MERGED",
+            parent_branch,
+        ));
+        let mut active_subissue = with_native_parent(issue("#273", "Agent Review"), "#243");
+        active_subissue.linked_pull_requests.push(linked_pr_to(
+            "https://github.com/Alive24/jade-symphony/pull/273",
+            "MERGED",
+            parent_branch,
+        ));
+
+        let report = audit_project_issues(&[parent, done_subissue, active_subissue]);
+
+        assert!(report.violations.iter().any(|violation| {
+            violation.code == "parent_human_review_subissue_not_done"
+                && violation.severity == AuditSeverity::Blocker
+        }));
+    }
+
+    #[test]
+    fn reports_body_only_parent_hierarchy_as_warning() {
+        let mut subissue = issue("#274", "Todo");
+        subissue.description =
+            Some("Related Parent Issue or Context: subissue under parent issue #243.".into());
+
+        let report = audit_project_issues(&[subissue]);
+
+        assert!(report.violations.iter().any(|violation| {
+            violation.code == "body_only_parent_hierarchy"
+                && violation.severity == AuditSeverity::Warning
+        }));
     }
 
     #[test]

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -1,6 +1,4 @@
-use std::collections::BTreeMap;
-#[cfg(test)]
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::process::Command;
 use std::thread;
@@ -1626,7 +1624,19 @@ query JadeSymphonyProject($owner: String!, $number: Int!, $cursor: String) {{
                   headRefName
                 }}
               }}
-              comments(first: 20) {{
+              parent {{
+                id
+                number
+                state
+              }}
+              subIssues(first: 20) {{
+                nodes {{
+                  id
+                  number
+                  state
+                }}
+              }}
+              comments(last: 50) {{
                 nodes {{
                   body
                 }}
@@ -2203,7 +2213,25 @@ fn issue_from_project_item(
             serde_json::Value::String(issue_state.to_string()),
         );
     }
+    if let Some(parent) = native_issue_ref(content.get("parent")) {
+        project_fields.insert("GitHub Native Parent".into(), parent);
+    }
+    let native_subissues = native_issue_refs(content.pointer("/subIssues/nodes"));
+    if !native_subissues.is_empty() {
+        project_fields.insert(
+            "GitHub Native Subissues".into(),
+            serde_json::Value::Array(native_subissues),
+        );
+    }
     let blocked_by = blocker_refs_from_project_fields(&project_fields);
+    let linked_pull_requests = merge_linked_pull_requests(
+        pull_requests_from_issue(content),
+        linked_pull_requests_from_workpads(
+            &comment_bodies(content.pointer("/comments/nodes")),
+            config.tracker.owner.as_deref(),
+            config.tracker.repo.as_deref(),
+        ),
+    );
 
     Ok(Some(TrackerIssue {
         tracker_kind: "github_project_v2".into(),
@@ -2239,7 +2267,7 @@ fn issue_from_project_item(
         assignees: string_nodes(content.pointer("/assignees/nodes"), "login"),
         priority: project_fields.get("Priority").and_then(json_number_to_i64),
         branch_name: None,
-        linked_pull_requests: pull_requests_from_issue(content),
+        linked_pull_requests,
         blocked_by,
         project_fields,
         created_at: content
@@ -2251,6 +2279,25 @@ fn issue_from_project_item(
             .and_then(serde_json::Value::as_str)
             .map(ToOwned::to_owned),
     }))
+}
+
+fn native_issue_ref(issue: Option<&serde_json::Value>) -> Option<serde_json::Value> {
+    let issue = issue?;
+    let number = issue.get("number").and_then(serde_json::Value::as_u64)?;
+    Some(serde_json::json!({
+        "id": issue.get("id").and_then(serde_json::Value::as_str),
+        "identifier": format!("#{number}"),
+        "state": issue.get("state").and_then(serde_json::Value::as_str),
+    }))
+}
+
+fn native_issue_refs(nodes: Option<&serde_json::Value>) -> Vec<serde_json::Value> {
+    nodes
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|node| native_issue_ref(Some(node)))
+        .collect()
 }
 
 fn github_issue_description_with_workpad(
@@ -2470,6 +2517,16 @@ fn string_nodes(nodes: Option<&serde_json::Value>, field: &str) -> Vec<String> {
         .collect()
 }
 
+fn comment_bodies(nodes: Option<&serde_json::Value>) -> Vec<String> {
+    nodes
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|node| node.get("body").and_then(serde_json::Value::as_str))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
 fn pull_requests_from_issue(issue: &serde_json::Value) -> Vec<LinkedPullRequest> {
     issue
         .pointer("/closedByPullRequestsReferences/nodes")
@@ -2504,8 +2561,11 @@ fn pull_requests_from_issue(issue: &serde_json::Value) -> Vec<LinkedPullRequest>
         .collect()
 }
 
-#[cfg(test)]
-fn linked_pull_requests_from_workpads(workpad_bodies: &[String]) -> Vec<LinkedPullRequest> {
+fn linked_pull_requests_from_workpads(
+    workpad_bodies: &[String],
+    owner: Option<&str>,
+    repo: Option<&str>,
+) -> Vec<LinkedPullRequest> {
     let mut seen = BTreeSet::new();
     let mut linked = Vec::new();
     for body in workpad_bodies {
@@ -2514,11 +2574,20 @@ fn linked_pull_requests_from_workpads(workpad_bodies: &[String]) -> Vec<LinkedPu
                 linked.push(linked_pull_request_from_url(&url));
             }
         }
+        for pr in linked_pull_request_comment_refs(body, owner, repo) {
+            let key = pr
+                .url
+                .clone()
+                .or_else(|| pr.number.map(|number| format!("#{number}")))
+                .unwrap_or_default();
+            if seen.insert(key) {
+                linked.push(pr);
+            }
+        }
     }
     linked
 }
 
-#[cfg(test)]
 fn merge_linked_pull_requests(
     existing: Vec<LinkedPullRequest>,
     discovered: Vec<LinkedPullRequest>,
@@ -2536,14 +2605,12 @@ fn merge_linked_pull_requests(
     merged
 }
 
-#[cfg(test)]
 fn github_pull_request_urls(text: &str) -> Vec<String> {
     text.split(|character: char| character.is_whitespace() || character == '<' || character == '>')
         .filter_map(clean_github_pull_request_url)
         .collect()
 }
 
-#[cfg(test)]
 fn clean_github_pull_request_url(raw: &str) -> Option<String> {
     let value = raw.trim_matches(|character: char| {
         matches!(
@@ -2566,7 +2633,6 @@ fn clean_github_pull_request_url(raw: &str) -> Option<String> {
         .then(|| base.to_string())
 }
 
-#[cfg(test)]
 fn linked_pull_request_from_url(url: &str) -> LinkedPullRequest {
     LinkedPullRequest {
         id: None,
@@ -2581,6 +2647,44 @@ fn linked_pull_request_from_url(url: &str) -> LinkedPullRequest {
         base_ref_name: None,
         head_ref_name: None,
     }
+}
+
+fn linked_pull_request_comment_refs(
+    text: &str,
+    owner: Option<&str>,
+    repo: Option<&str>,
+) -> Vec<LinkedPullRequest> {
+    text.lines()
+        .filter_map(|line| {
+            let (_, raw_ref) = line.split_once("Jade Symphony linked pull request:")?;
+            let raw_ref = raw_ref.trim();
+            if raw_ref.starts_with("http://github.com/")
+                || raw_ref.starts_with("https://github.com/")
+            {
+                return clean_github_pull_request_url(raw_ref)
+                    .map(|url| linked_pull_request_from_url(&url));
+            }
+            let number = raw_ref
+                .trim_start_matches('#')
+                .split(|character: char| !character.is_ascii_digit())
+                .next()
+                .and_then(|number| number.parse::<u64>().ok())?;
+            let url = owner
+                .zip(repo)
+                .map(|(owner, repo)| format!("https://github.com/{owner}/{repo}/pull/{number}"));
+            Some(LinkedPullRequest {
+                id: None,
+                number: Some(number),
+                url,
+                state: None,
+                is_draft: None,
+                merge_state_status: None,
+                review_decision: None,
+                base_ref_name: None,
+                head_ref_name: None,
+            })
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone)]
@@ -3553,6 +3657,22 @@ mod tests {
                                                     "id": "PR_1",
                                                     "number": 7,
                                                     "url": "https://github.com/Alive24/jade-symphony/pull/7",
+                                                    "state": "OPEN",
+                                                    "baseRefName": "integration/issue-41-parent",
+                                                    "headRefName": "feature/issue-42-implement-adapter"
+                                                }
+                                            ]
+                                        },
+                                        "parent": {
+                                            "id": "GHI_PARENT",
+                                            "number": 41,
+                                            "state": "OPEN"
+                                        },
+                                        "subIssues": {
+                                            "nodes": [
+                                                {
+                                                    "id": "GHI_CHILD",
+                                                    "number": 43,
                                                     "state": "OPEN"
                                                 }
                                             ]
@@ -3591,18 +3711,41 @@ mod tests {
             Some("OPEN")
         );
         assert_eq!(issues[0].linked_pull_requests[0].number, Some(7));
+        assert_eq!(
+            issues[0].linked_pull_requests[0].base_ref_name.as_deref(),
+            Some("integration/issue-41-parent")
+        );
+        assert_eq!(
+            issues[0]
+                .project_fields
+                .get("GitHub Native Parent")
+                .and_then(|value| value.get("identifier"))
+                .and_then(serde_json::Value::as_str),
+            Some("#41")
+        );
+        assert_eq!(
+            issues[0]
+                .project_fields
+                .get("GitHub Native Subissues")
+                .and_then(serde_json::Value::as_array)
+                .and_then(|values| values.first())
+                .and_then(|value| value.get("identifier"))
+                .and_then(serde_json::Value::as_str),
+            Some("#43")
+        );
     }
 
     #[test]
     fn discovers_pull_request_urls_from_workpad_text() {
         let bodies = vec![format!(
-            "{}\n- Live PR: `https://github.com/Alive24/jade-symphony/pull/98` (created: `true`)\n- Also see https://github.com/Alive24/jade-symphony/pull/100.",
+            "{}\n- Live PR: `https://github.com/Alive24/jade-symphony/pull/98` (created: `true`)\n- Also see https://github.com/Alive24/jade-symphony/pull/100.\nJade Symphony linked pull request: 101",
             "<!-- jade-symphony-workpad -->"
         )];
 
-        let prs = linked_pull_requests_from_workpads(&bodies);
+        let prs =
+            linked_pull_requests_from_workpads(&bodies, Some("Alive24"), Some("jade-symphony"));
 
-        assert_eq!(prs.len(), 2);
+        assert_eq!(prs.len(), 3);
         assert_eq!(
             prs[0].url.as_deref(),
             Some("https://github.com/Alive24/jade-symphony/pull/98")
@@ -3612,6 +3755,11 @@ mod tests {
         assert_eq!(
             prs[1].url.as_deref(),
             Some("https://github.com/Alive24/jade-symphony/pull/100")
+        );
+        assert_eq!(prs[2].number, Some(101));
+        assert_eq!(
+            prs[2].url.as_deref(),
+            Some("https://github.com/Alive24/jade-symphony/pull/101")
         );
     }
 


### PR DESCRIPTION
## Summary

- Read GitHub native `parent` / `subIssues` relationships into tracker Project evidence.
- Add read-only Doctor diagnostics for parent/subissue integration branch topology.
- Document Doctor metadata authority, severity rules, and non-mutating boundaries.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test doctor::tests::`
- `cargo test tracker::tests::parses_github_project_v2_issue_items`
- `cargo test --test parent_subissue_topology`
- `cargo test -- --test-threads=1`
- `cargo run -- doctor workflows/jade-symphony.md`

Note: a parallel `cargo test` run hit the existing timing-sensitive `review::tests::gemini_backend_closes_prompt_stdin_after_launch` timeout; the serial full-suite rerun passed.

Closes #273
