### PR TITLE
Support live context forge validation

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -252,7 +252,7 @@ cargo run -- project inspect workflows/jade-symphony.md '#123'
 
 | Command | Purpose | Boundary |
 | --- | --- | --- |
-| `forge validate` | Validate a body file or existing issue for `Backlog` or `Todo`. | Read-only; `Todo` uses the full Issue Quality Gate, `Backlog` uses the lighter seed gate. |
+| `forge validate` | Validate a body file, an existing issue, or candidate title/body content against live issue context for `Backlog` or `Todo`. | Read-only; `Todo` uses the full Issue Quality Gate, `Backlog` uses the lighter seed gate; output separates candidate contract gaps from live context gaps. |
 | `forge create` | Create a Project-backed issue in `Backlog` or `Todo`. | Dry-run by default unless `--write` is supplied; initializes the Project item to the requested status and verifies readback; live `Todo` creation requires `--assignee`. |
 | `forge promote` | Promote one existing Backlog issue in place by editing title/body, writing a structured Promotion Note comment, then moving it to `Todo`. | Dry-run by default unless `--write` is supplied; requires structured note inputs, keeps the `Todo` status mutation last, and reports the checkpoint where any failure stopped. |
 | `forge rework` | Revise one live `Human Review` issue into an explicit `Rework` contract. | Dry-run by default unless `--write` is supplied; requires a replacement title/body, evidence file, and operator confirmation; rejects active lane claims and keeps the `Rework` status mutation last. |
@@ -262,12 +262,19 @@ Examples:
 ```bash
 cargo run -- forge validate --workflow workflows/jade-symphony.md --status Backlog --title "Backlog seed" --body-file /tmp/issue.md
 cargo run -- forge validate --workflow workflows/jade-symphony.md --status Todo --title "Executable issue" --body-file /tmp/issue.md
+cargo run -- forge validate --workflow workflows/jade-symphony.md --issue '#293' --status Todo --title "Candidate promoted title" --body-file /tmp/candidate.md
 cargo run -- forge create --workflow workflows/jade-symphony.md --status Backlog --title "Backlog: follow-up title" --body-file /tmp/issue.md --dry-run
 cargo run -- forge create --workflow workflows/jade-symphony.md --status Todo --title "Follow-up title" --body-file /tmp/issue.md --assignee Alive24 --write
 cargo run -- forge promote '#241' --workflow workflows/jade-symphony.md --title "Executable title" --body-file /tmp/issue.md --operator-confirmation "promote it" --decision "Use the CLI-owned promotion note template." --scope-change "Backlog seed is now an executable Todo issue." --dependency-context "Dependencies: none; related context is non-blocking." --readback-summary "Operator confirmed the dry-run preview before write." --dry-run
 cargo run -- forge promote '#241' --workflow examples/promote-fixture-workflow.md --title "Harden Issue Forge Reflect promotion fixture" --body-file examples/fixtures/promoted-issue.md --operator-confirmation "promote it" --decision "Keep the promotion in place." --scope-change "Backlog seed becomes an executable Todo issue." --dependency-context "Dependencies: none." --readback-summary "Dry-run preview verified before write." --dry-run
 cargo run -- forge rework '#282' --workflow workflows/jade-symphony.md --title "Rework: revised execution contract" --body-file /tmp/rework-body.md --evidence-file /tmp/rework-evidence.md --operator-confirmation "route Human Review back to Rework" --dry-run
 ```
+
+Use `forge validate --issue '#123'` without overrides to validate the current
+live issue body. Add `--title` plus `--body` or `--body-file` when validating a
+candidate replacement contract against the live issue's assignee and Project
+context. `forge promote --dry-run` uses the same validation output categories,
+then adds the promotion-note preview and promotion-specific checks.
 
 `forge promote` owns the Promotion Note requirement. The command refuses missing
 or empty `--operator-confirmation`, `--decision`, `--scope-change`, and

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -310,15 +310,18 @@ Project v2 issues:
 10. Issue Forge tracker completion.
    - `forge validate` can validate body files or existing issues for `Backlog`
      or `Todo`, using the seed gate for Backlog and the full Issue Quality Gate
-     for Todo.
+     for Todo. It also supports `--issue` plus candidate `--title` and
+     `--body`/`--body-file` overrides so a dry validation can reuse live issue
+     assignee and Project context while checking replacement contract text.
+     Validation output separates candidate-side gaps from live-context gaps.
    - `forge create` creates tracker issues, always inserts them into the
      configured Project, supports `--status Backlog|Todo`, and accepts repeatable
      `--project-field NAME=VALUE` assignments.
    - `forge promote` reads a Backlog issue, validates an explicit replacement
-     title/body with the Todo gate, requires structured Promotion Note inputs,
-     edits the same issue in place, writes the Promotion Note comment, sets
-     Project status to `Todo` as the final mutation, and then performs read-only
-     status readback verification.
+     title/body with the same Todo validation categories, requires structured
+     Promotion Note inputs, edits the same issue in place, writes the Promotion
+     Note comment, sets Project status to `Todo` as the final mutation, and then
+     performs read-only status readback verification.
    - Reflection, discussion, and repair are skill-owned workflows, not
      Jade Symphony CLI subcommands.
    - Remaining work: text/number/date field writes and richer Project selection

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -295,6 +295,13 @@ mutation, `set-state`, or `forge promote` for this normal path. Missing linked
 PRs or missing local worktrees are downstream Main Agent recovery work after the
 issue is in `Rework`.
 
+When the operator wants to preflight a candidate body for an existing issue
+without running the promotion command, use `forge validate --issue '#123'
+--status Todo --title "<candidate title>" --body-file <path>`. That mode is
+read-only: it validates the candidate title/body while reusing live assignee and
+Project context from the issue, and reports candidate contract gaps separately
+from live-context gaps.
+
 Use `debug` when you need one read-only operator report before a supervised
 dogfood, repair, review, or merge session. It summarizes the current Project
 queue, doctor health, smoke readiness, runtime/session state, cleanup/audit

--- a/src/main.rs
+++ b/src/main.rs
@@ -1506,12 +1506,17 @@ fn forge_validate(
             .get_issue(&issue_ref)?
             .ok_or_else(|| format!("issue not found: {issue_ref}"))?;
         let status = status.unwrap_or_else(|| forge_status_from_issue(&config, &issue));
-        (
-            status,
-            issue.title,
-            issue.description.unwrap_or_default(),
-            issue.assignees,
-        )
+        let title = if title.trim().is_empty() {
+            issue.title.clone()
+        } else {
+            title
+        };
+        let markdown = if markdown.trim().is_empty() {
+            issue.description.clone().unwrap_or_default()
+        } else {
+            markdown
+        };
+        (status, title, markdown, issue.assignees)
     } else {
         let assignees = issue_contract_assignees(&markdown);
         (
@@ -1555,6 +1560,29 @@ fn forge_validation_report(
             validate_forge_create_report_with_assignees(title, markdown, config, intended_assignees)
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ForgeMissingCategories {
+    candidate_missing: Vec<String>,
+    live_context_missing: Vec<String>,
+}
+
+fn forge_missing_categories(report: &ForgeValidationReport) -> ForgeMissingCategories {
+    let (live_context_missing, candidate_missing): (Vec<_>, Vec<_>) = report
+        .decision
+        .missing
+        .iter()
+        .cloned()
+        .partition(|missing| is_live_context_missing(missing));
+    ForgeMissingCategories {
+        candidate_missing,
+        live_context_missing,
+    }
+}
+
+fn is_live_context_missing(missing: &str) -> bool {
+    matches!(missing, "live GitHub issue assignee")
 }
 
 fn validate_backlog_seed(title: &str, markdown: &str) -> ForgeValidationReport {
@@ -10754,20 +10782,11 @@ impl TryFrom<Cli> for Command {
                         }),
                         ForgeCommandArgs::Validate(args) => {
                             if let Some(issue_ref) = args.issue_ref {
-                                if args.title.is_some()
-                                    || args.markdown.body.is_some()
-                                    || args.markdown.body_file.is_some()
-                                {
-                                    return Err(
-                                        "forge validate --issue cannot be combined with --title, --body, or --body-file"
-                                            .into(),
-                                    );
-                                }
                                 Ok(Self::ForgeValidate {
                                     workflow_path: args.workflow,
                                     status: args.status,
-                                    title: String::new(),
-                                    markdown: String::new(),
+                                    title: args.title.unwrap_or_default(),
+                                    markdown: read_optional_forge_markdown_arg(args.markdown)?,
                                     issue_ref: Some(issue_ref),
                                 })
                             } else {
@@ -10852,6 +10871,16 @@ fn read_forge_markdown_arg(args: ForgeMarkdownArgs) -> Result<String, String> {
         (None, Some(path)) => std::fs::read_to_string(&path)
             .map_err(|error| format!("failed to read {}: {error}", path.display())),
         _ => Err(usage()),
+    }
+}
+
+fn read_optional_forge_markdown_arg(args: ForgeMarkdownArgs) -> Result<String, String> {
+    match (args.body, args.body_file) {
+        (Some(value), None) => Ok(value),
+        (None, Some(path)) => std::fs::read_to_string(&path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display())),
+        (None, None) => Ok(String::new()),
+        (Some(_), Some(_)) => Err(usage()),
     }
 }
 
@@ -10978,18 +11007,35 @@ fn promotion_note_input(args: PromotionNoteArgs) -> Result<PromotionNoteInput, S
 }
 
 fn print_forge_validation(report: &ForgeValidationReport) {
+    let categories = forge_missing_categories(report);
     println!("title={}", report.title);
     println!("gate={:?}", report.decision.kind);
     println!("dispatchable={}", report.decision.is_dispatchable());
     if !report.decision.missing.is_empty() {
         println!("missing={}", report.decision.missing.join(", "));
     }
+    println!(
+        "candidate_missing={}",
+        missing_category_value(&categories.candidate_missing)
+    );
+    println!(
+        "live_context_missing={}",
+        missing_category_value(&categories.live_context_missing)
+    );
     if !report.decision.assumptions.is_empty() {
         println!("assumptions={}", report.decision.assumptions.join("; "));
     }
     if let Some(question) = &report.question {
         println!("question={}", question.question);
         println!("why={}", question.why_it_matters);
+    }
+}
+
+fn missing_category_value(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".into()
+    } else {
+        values.join(", ")
     }
 }
 
@@ -14677,6 +14723,45 @@ mod tests {
     }
 
     #[test]
+    fn parses_forge_validate_issue_with_candidate_body_flags() {
+        let temp = tempfile::tempdir().unwrap();
+        let body_path = temp.path().join("candidate.md");
+        std::fs::write(&body_path, forge_contract()).unwrap();
+
+        let command = Command::parse(vec![
+            "forge".into(),
+            "validate".into(),
+            "--workflow".into(),
+            "examples/github-project-workflow.md".into(),
+            "--issue".into(),
+            "#293".into(),
+            "--status".into(),
+            "todo".into(),
+            "--title".into(),
+            "Candidate promoted title".into(),
+            "--body-file".into(),
+            body_path.display().to_string(),
+        ])
+        .unwrap();
+
+        let Command::ForgeValidate {
+            status,
+            title,
+            markdown,
+            issue_ref,
+            ..
+        } = command
+        else {
+            panic!("expected forge validate command");
+        };
+
+        assert_eq!(status, Some(ForgeStatusArg::Todo));
+        assert_eq!(title, "Candidate promoted title");
+        assert!(markdown.contains("## Issue Goal"));
+        assert_eq!(issue_ref.as_deref(), Some("#293"));
+    }
+
+    #[test]
     fn rejects_removed_flat_forge_commands() {
         let error = Command::parse(vec![
             "forge-create".into(),
@@ -14733,6 +14818,63 @@ mod tests {
         .unwrap();
 
         assert!(report.decision.is_dispatchable());
+    }
+
+    #[test]
+    fn forge_validate_candidate_context_uses_live_issue_assignee() {
+        let config = live_github_config(false);
+        let assignees = vec!["Alive24".to_string()];
+        let report = forge_validation_report(
+            ForgeStatusArg::Todo,
+            "Candidate promoted title",
+            &forge_contract(),
+            &config,
+            &assignees,
+        )
+        .unwrap();
+        let categories = forge_missing_categories(&report);
+
+        assert!(report.decision.is_dispatchable());
+        assert!(categories.candidate_missing.is_empty());
+        assert!(categories.live_context_missing.is_empty());
+    }
+
+    #[test]
+    fn forge_validate_candidate_context_reports_unassigned_live_issue() {
+        let config = live_github_config(false);
+        let report = forge_validation_report(
+            ForgeStatusArg::Todo,
+            "Candidate promoted title",
+            &forge_contract(),
+            &config,
+            &[],
+        )
+        .unwrap();
+        let categories = forge_missing_categories(&report);
+
+        assert_eq!(
+            categories.live_context_missing,
+            vec!["live GitHub issue assignee".to_string()]
+        );
+        assert!(categories.candidate_missing.is_empty());
+    }
+
+    #[test]
+    fn forge_validate_candidate_context_reports_candidate_gaps_separately() {
+        let config = live_github_config(false);
+        let assignees = vec!["Alive24".to_string()];
+        let report = forge_validation_report(
+            ForgeStatusArg::Todo,
+            "Thin issue",
+            "make forge better",
+            &config,
+            &assignees,
+        )
+        .unwrap();
+        let categories = forge_missing_categories(&report);
+
+        assert!(!categories.candidate_missing.is_empty());
+        assert!(categories.live_context_missing.is_empty());
     }
 
     #[test]

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -10,6 +10,7 @@ Use it for live Project #9 operations:
 ```bash
 cargo run -- main loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- forge validate --workflow workflows/jade-symphony.md --status Todo --title "<title>" --body-file /private/tmp/issue.md
+cargo run -- forge validate --workflow workflows/jade-symphony.md --issue '#123' --status Todo --title "<candidate title>" --body-file /private/tmp/candidate.md
 cargo run -- forge create --workflow workflows/jade-symphony.md --status Todo --title "<title>" --body-file /private/tmp/issue.md --assignee Alive24 --write
 cargo run -- review loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- merge once workflows/jade-symphony.md --write


### PR DESCRIPTION
## Summary

Closes #294.

- Allows `forge validate --issue` to accept candidate `--title` plus `--body` or `--body-file` overrides while reusing live issue assignee and Project context.
- Prints `candidate_missing` and `live_context_missing` alongside the existing validation summary, and reuses those categories in `forge promote --dry-run` output.
- Updates operator docs and workflow examples for the live-context candidate validation path.

## Verification

- `cargo fmt --check`
- `cargo test forge_validate`
- `cargo run -- forge validate --workflow workflows/jade-symphony.md --issue '#294' --status Todo --title 'Candidate promoted title' --body-file /private/tmp/jade-symphony-issue-294-candidate.md`
- `cargo run -- forge validate --workflow workflows/jade-symphony.md --status Todo --title 'Candidate promoted title' --body-file /private/tmp/jade-symphony-issue-294-candidate.md`
- `cargo run -- forge validate --workflow workflows/jade-symphony.md --status Backlog --title 'Backlog seed' --body-file /private/tmp/jade-symphony-issue-294-candidate.md`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- validate workflows/jade-symphony.md`
- `cargo run -- forge promote '#241' --workflow examples/promote-fixture-workflow.md --title 'Harden Issue Forge Reflect promotion fixture' --body-file examples/fixtures/promoted-issue.md --operator-confirmation 'promote it' --decision 'Keep the promotion in place.' --scope-change 'Backlog seed becomes an executable Todo issue.' --dependency-context 'Dependencies: none.' --readback-summary 'Dry-run preview verified before write.' --dry-run`

## Notes

- `cargo run -- set-state workflows/jade-symphony.md '#294' 'In Progress' --write` was attempted after the Main Agent claim and initial workpad, but the tracker rejected `In Progress` as an unsupported normalized state for this workflow. The issue remains lane-owned through the Main Agent claim and workpad evidence.
- `workspace show workflows/jade-symphony.md '#294'` was blocked by the known session-registry serialization gap (`unknown variant recorded`), so the issue worktree was created manually from the clean canonical checkout.
