### PR TITLE
Add Jade Symphony Human Review skill

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -354,9 +354,12 @@ operator confirmation before writing. Use `--skip-codex`, `--skip-gemini`,
 the active local skill files with the repo-owned dated suite.
 
 The suite packages Issue Forge, Issue Forge Reflect, Manual Main, Manual Review,
-Manual Merge, and a Doctor/Fix stub. `forge reflect` remains a skill behavior,
-not a Jade Symphony CLI subcommand. `forge create`, `forge promote`, and
-`forge validate` remain deterministic CLI executor surfaces.
+Human Review, Manual Merge, and a Doctor/Fix stub. Human Review is an
+operator-owned briefing and UAT decision skill: it records a structured decision
+note and routes to `Merging`, `Rework`, or `Need Human Input` only after
+explicit operator confirmation. `forge reflect` remains a skill behavior, not a
+Jade Symphony CLI subcommand. `forge create`, `forge promote`, and `forge
+validate` remain deterministic CLI executor surfaces.
 
 ## Merge Lane
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -208,8 +208,10 @@ The packaged skills preserve the same lane boundaries as the Jade Symphony CLI:
 Issue Forge and Reflect handle conversation, draft shaping, and promotion
 discussion; the CLI owns `forge create`, `forge promote`, and `forge validate`.
 Manual Main stops at `Agent Review`; Manual Review owns evidence-backed review
-routing; Manual Merge owns approved merge-lane work. Automatic doctor
-install-health checks remain future work for #256.
+routing; Human Review briefs the operator for UAT and final acceptance but waits
+for explicit confirmation before any state change; Manual Merge owns approved
+merge-lane work. Automatic doctor install-health checks remain future work for
+#256.
 
 ## Inspect And Resume
 

--- a/skills/jade-symphony/README.md
+++ b/skills/jade-symphony/README.md
@@ -50,8 +50,13 @@ operator confirmation before writing.
 - `jade-symphony-issue-forge-reflect`
 - `jade-symphony-manual-main`
 - `jade-symphony-manual-review`
+- `jade-symphony-human-review`
 - `jade-symphony-manual-merge`
 - `jade-symphony-doctor`
+
+Human Review briefs the operator after Review Agent pass evidence, guides
+operator-owned UAT, records a structured decision note, and routes only after
+explicit confirmation. Accepted Human Review goes to `Merging`, not `Done`.
 
 The Doctor skill is a stub slot for operator triage and install-health checks.
 Full automatic doctor install-health repair remains out of scope for this

--- a/skills/jade-symphony/manifest.toml
+++ b/skills/jade-symphony/manifest.toml
@@ -29,6 +29,12 @@ targets = ["codex", "gemini"]
 summary = "Manual Review Agent lane for evidence-backed review and Human Review routing."
 
 [[skills]]
+name = "jade-symphony-human-review"
+path = "suite/jade-symphony-human-review"
+targets = ["codex", "gemini"]
+summary = "Human Review briefing flow for operator-owned UAT, decision notes, and confirmed routing."
+
+[[skills]]
 name = "jade-symphony-manual-merge"
 path = "suite/jade-symphony-manual-merge"
 targets = ["codex", "gemini"]

--- a/skills/jade-symphony/suite/jade-symphony-human-review/SKILL.md
+++ b/skills/jade-symphony/suite/jade-symphony-human-review/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: jade-symphony-human-review
+description: Use when briefing a Jade Symphony operator for Human Review after independent Review Agent pass evidence, guiding UAT, recording a structured decision note, and routing only after explicit operator confirmation.
+metadata:
+  short-description: Jade Symphony Human Review briefing
+  suite-version: 2026.05.18
+---
+
+# Jade Symphony Human Review
+
+Use this skill when the operator wants help reviewing a Jade Symphony issue that
+has passed independent Review Agent checks and is waiting for Human Review.
+
+Human Review is the operator-owned final acceptance checkpoint before merge-lane
+work. It is not implementation work, it is not the independent Review Agent, and
+it is not merge execution.
+
+## Repository
+
+Default repository:
+
+```text
+Alive24/jade-symphony
+```
+
+Default local checkout:
+
+```bash
+/Volumes/Bohemialive/GitHub/jade-symphony
+```
+
+Canonical workflow:
+
+```bash
+workflows/jade-symphony.md
+```
+
+Canonical decision note template:
+
+```bash
+workflows/template/workpad/human-review.md
+```
+
+## Core Boundary
+
+- Do not modify implementation code.
+- Do not act as the independent Review Agent.
+- Do not merge PRs or act as the Merging Agent.
+- Do not move accepted work directly to `Done`.
+- Accepted Human Review routes to `Merging`.
+- Treat UAT checklist items as Human Review-owned unless the issue explicitly
+  says otherwise.
+- Never mutate Project state until the operator explicitly confirms the decision
+  after the briefing and UAT discussion.
+- Use Jade Symphony CLI for Project reads, workpad writes, and confirmed state
+  routing. Do not bypass it with raw Project mutations.
+
+## CLI Topology Transition
+
+Issue #284 is cleaning up Jade Symphony CLI topology. Prefer the intended grouped
+language in explanations:
+
+- `project state`
+- `project issue`
+- `project workpad`
+- `project set-state`
+
+During live use, if the current binary still exposes flat commands, use those
+commands and say so in the workpad note:
+
+```bash
+cargo run -- project-state workflows/jade-symphony.md
+cargo run -- project-issue workflows/jade-symphony.md '#<issue>' --json
+cargo run -- workpad workflows/jade-symphony.md '#<issue>' /path/to/human-review-note.md --write
+cargo run -- set-state workflows/jade-symphony.md '#<issue>' merging --write
+```
+
+Do not turn the topology transition into custom GitHub Project mutations.
+
+## Required Reads
+
+Before briefing the operator, read the decision surfaces:
+
+```bash
+cargo run -- project-issue workflows/jade-symphony.md '#<issue>' --json
+gh issue view <issue> --repo Alive24/jade-symphony --comments
+gh pr view <pr> --repo Alive24/jade-symphony --json number,title,state,url,isDraft,baseRefName,headRefName,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+Inspect the issue body and workpad for:
+
+- issue goal, scope, guardrails, and dependencies;
+- Expected Outcome, Completion Criteria, Functional Verification, UAT, and
+  Context Verification checkboxes;
+- Review Agent pass evidence and any explicitly unchecked review items;
+- linked PR identity, readiness, base branch, and check/review state;
+- missing evidence, stale assumptions, or blockers that should prevent approval.
+
+Do not drown the operator in raw JSON. Summarize the decision-relevant facts and
+include exact issue and PR references.
+
+## Brief The Operator
+
+Give a concise Human Review brief with:
+
+- what the issue was supposed to deliver;
+- what changed and where the PR is;
+- what the Review Agent already checked;
+- what remains human-owned, especially UAT;
+- any missing evidence, stale assumption, or risk;
+- available decisions and their target states.
+
+If the issue is not in `Human Review`, or if Review Agent pass evidence or a
+reliable linked PR is missing, stop before UAT and recommend the smallest safe
+route such as `Need Human Input`, `Agent Review`, or no state change.
+
+## Guide UAT
+
+Walk the operator through UAT items from the issue body.
+
+- Treat unchecked UAT items as human-owned.
+- Ask for concrete pass/fail/deferred notes when useful.
+- If UAT cannot be performed, record what is missing.
+- If UAT fails, recommend `Rework` with the smallest actionable finding.
+- Do not check UAT boxes based only on Review Agent evidence.
+
+## Prepare Decision Note
+
+Use `workflows/template/workpad/human-review.md` as the canonical note shape.
+Complete it with the specific issue, PR, reviewer, decision, evidence reviewed,
+UAT result, findings or missing evidence, and confirmation phrase.
+
+Supported decisions:
+
+- `Approve for Merging`: target state `Merging`.
+- `Request Rework`: target state `Rework`.
+- `Need Human Input`: target state `Need Human Input`.
+- `Defer`: target state unchanged, unless the operator explicitly asks for a
+  workpad-only defer note.
+
+The note must distinguish Review Agent-owned evidence from Human Review-owned
+UAT and acceptance. A Review Agent pass is input to Human Review, not a
+substitute for Human Review.
+
+## Confirm Before Mutating
+
+Ask the operator for explicit confirmation before writing the decision note or
+changing state. Examples:
+
+- `confirm approve to Merging`
+- `confirm request Rework`
+- `confirm Need Human Input`
+- `defer, do not change state`
+
+Do not infer confirmation from discussion, enthusiasm, or a partial UAT answer.
+
+## Route With CLI
+
+After explicit confirmation, write the completed decision note through the Jade
+Symphony workpad surface first. Then, if the decision requires a state change,
+set state as the final mutation.
+
+Current flat-command examples:
+
+```bash
+cargo run -- workpad workflows/jade-symphony.md '#<issue>' /path/to/human-review-note.md --write
+cargo run -- set-state workflows/jade-symphony.md '#<issue>' merging --write
+cargo run -- set-state workflows/jade-symphony.md '#<issue>' rework --write
+cargo run -- set-state workflows/jade-symphony.md '#<issue>' need_human_input --write
+```
+
+After the state mutation, only read back:
+
+```bash
+cargo run -- project-issue workflows/jade-symphony.md '#<issue>' --json
+cargo run -- project-state workflows/jade-symphony.md
+```
+
+Do not continue reviewing, implementing, or merging after the state change.
+
+## Decision Mapping
+
+- Approve for merge-lane work -> `Merging`.
+- Confirmed implementation change needed -> `Rework`.
+- Missing human decision, credential, external context, or destructive approval
+  -> `Need Human Input`.
+- Evidence incomplete but no routing decision yet -> no state change, or a
+  workpad-only defer note if the operator explicitly wants it.
+
+## Quality Bar
+
+A good Human Review response leaves the operator with:
+
+- the issue and PR identity;
+- a short evidence summary;
+- a clear UAT result or UAT blocker;
+- the Review Agent evidence boundary;
+- a recommendation and supported alternatives;
+- the exact state transition that will happen only after confirmation.

--- a/skills/jade-symphony/suite/jade-symphony-human-review/agents/openai.yaml
+++ b/skills/jade-symphony/suite/jade-symphony-human-review/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Jade Symphony Human Review
+short_description: Brief the operator for Jade Symphony Human Review, guide UAT, and route only after explicit confirmation.
+default_prompt: Brief one Jade Symphony Human Review issue, inspect Review Agent evidence and PR state, guide operator-owned UAT, prepare a Human Review Decision Note, and wait for explicit confirmation before any state change.

--- a/tests/skill_suite.rs
+++ b/tests/skill_suite.rs
@@ -1,0 +1,33 @@
+use std::fs;
+use std::path::Path;
+
+fn repo_file(path: &str) -> String {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join(path))
+        .unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+}
+
+#[test]
+fn skill_suite_lists_human_review_skill() {
+    let manifest = repo_file("skills/jade-symphony/manifest.toml");
+    let readme = repo_file("skills/jade-symphony/README.md");
+    let skill = repo_file("skills/jade-symphony/suite/jade-symphony-human-review/SKILL.md");
+
+    assert!(manifest.contains("name = \"jade-symphony-human-review\""));
+    assert!(manifest.contains("path = \"suite/jade-symphony-human-review\""));
+    assert!(readme.contains("`jade-symphony-human-review`"));
+    assert!(skill.contains("Accepted Human Review routes to `Merging`"));
+    assert!(skill.contains("Never mutate Project state until the operator explicitly confirms"));
+}
+
+#[test]
+fn human_review_template_supports_all_decisions() {
+    let template = repo_file("workflows/template/workpad/human-review.md");
+
+    assert!(template.starts_with("<!-- jade-symphony-workpad -->"));
+    assert!(template.contains("## Human Review Decision Note"));
+    assert!(template.contains("Approve for Merging"));
+    assert!(template.contains("Request Rework"));
+    assert!(template.contains("Need Human Input"));
+    assert!(template.contains("Defer"));
+    assert!(template.contains("Target state after explicit confirmation"));
+}

--- a/tests/skill_suite.rs
+++ b/tests/skill_suite.rs
@@ -26,6 +26,7 @@ fn human_review_template_supports_all_decisions() {
     assert!(template.starts_with("<!-- jade-symphony-workpad -->"));
     assert!(template.contains("## Human Review Decision Note"));
     assert!(template.contains("Approve for Merging"));
+    assert!(template.contains("Decision timestamp: <YYYY-MM-DD HH:MM timezone>"));
     assert!(template.contains("Request Rework"));
     assert!(template.contains("Need Human Input"));
     assert!(template.contains("Defer"));

--- a/workflows/template/workpad/human-review.md
+++ b/workflows/template/workpad/human-review.md
@@ -4,6 +4,7 @@
 - Issue: #<issue>
 - PR: #<pr> <url>
 - Human reviewer: <operator or unknown>
+- Decision timestamp: <YYYY-MM-DD HH:MM timezone>
 - Decision: Approve for Merging | Request Rework | Need Human Input | Defer
 - Target state after explicit confirmation: Merging | Rework | Need Human Input | unchanged
 

--- a/workflows/template/workpad/human-review.md
+++ b/workflows/template/workpad/human-review.md
@@ -1,0 +1,30 @@
+<!-- jade-symphony-workpad -->
+## Human Review Decision Note
+
+- Issue: #<issue>
+- PR: #<pr> <url>
+- Human reviewer: <operator or unknown>
+- Decision: Approve for Merging | Request Rework | Need Human Input | Defer
+- Target state after explicit confirmation: Merging | Rework | Need Human Input | unchanged
+
+### Evidence Reviewed
+
+- Issue body and checklist:
+- Workpad evidence:
+- Review Agent evidence:
+- PR state/checks:
+- UAT evidence:
+
+### UAT Result
+
+- Pass/fail/deferred:
+- Notes:
+
+### Findings Or Missing Evidence
+
+- ...
+
+### Operator Confirmation
+
+- Confirmation phrase:
+- Confirmed at:


### PR DESCRIPTION
## Summary

- add the repo-owned `jade-symphony-human-review` skill with explicit Human Review, UAT, decision-note, and confirmed-routing boundaries
- add the canonical `workflows/template/workpad/human-review.md` decision note template
- register the skill in the suite manifest/README, document discoverability, and add skill-suite coverage

Closes #292

## Verification

- `node scripts/install-jade-symphony-skills.js --dry-run --skip-gemini --codex-dir /tmp/jade-symphony-skill-preview`
- `cargo fmt --check`
- `cargo test --test skill_suite`
- `cargo test`

Note: the first full `cargo test` run hit a transient timeout in `review::tests::gemini_backend_closes_prompt_stdin_after_launch`; that exact test passed on rerun, and the subsequent full `cargo test` passed cleanly.
