### PR TITLE
Support quoted worker labels in lane claims

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -100,9 +100,12 @@ runtime/log/prompt/evidence/draft artifacts are moved to artifact quarantine
 with a warning; unclassified untracked files block for operator repair.
 New lane claims are written as single-line `v=1` key/value audit pointers, for
 example `v=1 lane=main actor=codex worker=codex-manual-main source=manual
-issue=#244 run=... state=active thread=unknown registry=run/...`. The Project
-field stores the compact pointer; the session registry and workpad store the
-durable paths, logs, and handoff evidence for the same `run=`.
+issue=#244 run=... state=active thread=unknown registry=run/...`. Worker display
+labels may contain spaces; the CLI stores those values with reversible quoting,
+such as `worker="Codex Manual Main"`, and validates the rendered pointer before
+writing Project fields. The Project field stores the compact pointer; the
+session registry and workpad store the durable paths, logs, and handoff evidence
+for the same `run=`.
 
 Manual claim and session control are separate operations. Claim commands write
 the lane claim Project field, create a matching `codex-app-manual` registry
@@ -110,7 +113,7 @@ record with status `recorded`, and do not change Project Status:
 
 ```bash
 cargo run -- main claim workflows/jade-symphony.md '#265' --worker codex-manual-main --write
-cargo run -- review claim workflows/jade-symphony.md '#265' --worker gemini-manual-review --write
+cargo run -- review claim workflows/jade-symphony.md '#265' --worker "Manual Gemini Review" --write
 cargo run -- merge claim workflows/jade-symphony.md '#265' --worker codex-manual-merge --write
 ```
 
@@ -324,7 +327,7 @@ changes.
 | `review fake` | Fixture/fake review transition helper. | Local testing path. |
 | `review once` | Run one configured review backend for one issue. | Direct backend command for one issue. |
 | `review loop` | Bounded review worker selection/reconciliation. | For `gemini-cli`, runs headless Gemini by default with stdin prompt transport, JSON output capture, configured model/tools, and durable review-job evidence. |
-| `review claim` | Claim one `Agent Review` item's `Review Agent` text field for manual/operator review. | Requires `--worker` and `--write`; refuses non-`Agent Review` issues and writes a structured claim pointer. |
+| `review claim` | Claim one `Agent Review` item's `Review Agent` text field for manual/operator review. | Requires `--worker` and `--write`; refuses non-`Agent Review` issues and writes a structured, round-trip-validated claim pointer. |
 | `review pass` | Record manual independent review pass evidence and move to `Human Review`. | Requires `--write`, a durable evidence file containing the exact current `Review Agent` claim, and preserves the field as terminal pass evidence. |
 | `review reject` | Record failed/inconclusive manual review evidence and route to `Agent Review`, `Rework`, or `Need Human Input`. | Refuses `Human Review`, requires exact claim evidence, and preserves the field as terminal reject/failed evidence. |
 | `review session` | Hidden legacy review session alias. | Does not write the `Review Agent` claim; use `review claim` or `review loop` for claim ownership. |

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -504,3 +504,8 @@ evidence is available for the existing handoff path. Manual recovery uses lane
 claim commands first, then `session start --run <RUN_ID>` with the same registry
 and lane prompt contracts. The registry is operator evidence for terminal
 sessions only; it does not replace Project state.
+Worker display labels supplied to `main claim`, `review claim`, or
+`merge claim` may contain spaces. Jade Symphony stores those labels with
+reversible quoting in the structured claim pointer, validates the rendered
+claim before Project mutation, and expects operators to use the CLI claim path
+instead of raw Project field edits for normal claim ownership.

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -158,7 +158,10 @@ printed `run=` without pretending a tmux pane exists. Then start the runtime
 with `session start WORKFLOW '#issue' --lane review --run <RUN_ID> --write`.
 Session startup validates the existing Review Agent claim and writes attach/log
 evidence without moving the issue to `Human Review`; this tmux path is an
-explicit manual fallback, not the automatic review-loop default.
+explicit manual fallback, not the automatic review-loop default. The worker
+value may be a display label such as `Manual Gemini Review`; use the claim
+command so Jade Symphony can quote, escape, and validate the stored pointer
+before Project mutation.
 
 If Gemini cannot start, the review workpad should name the configured command,
 whether worker `PATH` could resolve it, the required operator action, and the
@@ -390,7 +393,9 @@ worker=<worker> source=<loop|manual|goal> issue=#N run=<id>
 state=<active|done|stale|failed|superseded> thread=<codex-link|unknown>
 registry=run/<id>`. Keep full paths and terminal logs in the session registry
 or workpad, and update terminal completed work to `state=done` instead of
-clearing useful claim evidence by default.
+clearing useful claim evidence by default. Display labels with spaces are stored
+with reversible quoting, for example `worker="Codex Manual Main"`; raw Project
+field edits are a break-glass repair path, not normal claim ownership.
 For supervised merge terminals, use `merge claim WORKFLOW '#issue' --worker
 <worker> --write` on a `Merging` issue; the claim records truthful non-tmux
 manual evidence for the `run=`. Then use `session start WORKFLOW '#issue'

--- a/docs/supervised-live-dogfood.md
+++ b/docs/supervised-live-dogfood.md
@@ -191,6 +191,8 @@ Expected outcomes:
 - manual review claims use `review claim`, and terminal manual review routing
   validates the exact evidence claim before preserving the `Review Agent` field
   as a terminal structured audit pointer;
+- worker display labels such as `Manual Gemini Review` are stored through
+  CLI-owned quoting/escaping; avoid raw Project edits for normal claim repair;
 - passed independent review may move the issue to `Human Review`;
 - confirmed findings move the issue to `Rework`;
 - completed but inconclusive automatic review moves to `Rework` with a missing

--- a/src/lane_claim.rs
+++ b/src/lane_claim.rs
@@ -166,32 +166,26 @@ impl LaneClaim {
     pub fn render(&self) -> String {
         let mut tokens = vec![
             "v=1".to_string(),
-            format!("lane={}", self.lane.as_str()),
-            format!("actor={}", self.actor.as_str()),
+            claim_token("lane", self.lane.as_str()),
+            claim_token("actor", self.actor.as_str()),
         ];
         if let Some(worker) = self.worker.as_deref() {
-            tokens.push(format!("worker={worker}"));
+            tokens.push(claim_token("worker", worker));
         }
         tokens.extend([
-            format!("source={}", self.source.as_str()),
-            format!("issue={}", self.issue),
-            format!("run={}", self.run),
-            format!("state={}", self.state.as_str()),
-            format!("thread={}", self.thread),
-            format!("registry={}", self.registry),
+            claim_token("source", self.source.as_str()),
+            claim_token("issue", &self.issue),
+            claim_token("run", &self.run),
+            claim_token("state", self.state.as_str()),
+            claim_token("thread", &self.thread),
+            claim_token("registry", &self.registry),
         ]);
         tokens.join(" ")
     }
 
     pub fn parse(input: &str) -> Result<Self, LaneClaimParseError> {
         let mut values = BTreeMap::new();
-        for token in input.split_whitespace() {
-            let Some((key, value)) = token.split_once('=') else {
-                return Err(LaneClaimParseError::InvalidToken(token.into()));
-            };
-            if key.is_empty() || value.is_empty() {
-                return Err(LaneClaimParseError::InvalidToken(token.into()));
-            }
+        for (key, value) in parse_claim_tokens(input)? {
             values.insert(key, value);
         }
 
@@ -215,13 +209,162 @@ impl LaneClaim {
 }
 
 fn required<'a>(
-    values: &'a BTreeMap<&str, &str>,
+    values: &'a BTreeMap<String, String>,
     key: &'static str,
 ) -> Result<&'a str, LaneClaimParseError> {
     values
         .get(key)
-        .copied()
+        .map(String::as_str)
         .ok_or(LaneClaimParseError::MissingKey(key))
+}
+
+fn claim_token(key: &str, value: &str) -> String {
+    format!("{key}={}", render_claim_value(value))
+}
+
+fn render_claim_value(value: &str) -> String {
+    if value.is_empty()
+        || value
+            .chars()
+            .any(|character| character.is_whitespace() || matches!(character, '"' | '\\'))
+    {
+        let mut rendered = String::with_capacity(value.len() + 2);
+        rendered.push('"');
+        for character in value.chars() {
+            match character {
+                '\\' => rendered.push_str("\\\\"),
+                '"' => rendered.push_str("\\\""),
+                '\n' => rendered.push_str("\\n"),
+                '\r' => rendered.push_str("\\r"),
+                '\t' => rendered.push_str("\\t"),
+                other => rendered.push(other),
+            }
+        }
+        rendered.push('"');
+        rendered
+    } else {
+        value.to_string()
+    }
+}
+
+fn parse_claim_tokens(input: &str) -> Result<Vec<(String, String)>, LaneClaimParseError> {
+    let mut tokens = Vec::new();
+    let mut chars = input.char_indices().peekable();
+
+    while let Some((_, character)) = chars.peek().copied() {
+        if character.is_whitespace() {
+            chars.next();
+            continue;
+        }
+
+        let token_start = chars.peek().map(|(index, _)| *index).unwrap_or(input.len());
+        let mut key = String::new();
+        while let Some((_, character)) = chars.peek().copied() {
+            if character == '=' {
+                chars.next();
+                break;
+            }
+            if character.is_whitespace() {
+                return Err(invalid_token_from(input, token_start, chars.peek()));
+            }
+            key.push(character);
+            chars.next();
+        }
+
+        if key.is_empty() {
+            return Err(invalid_token_from(input, token_start, chars.peek()));
+        }
+
+        let Some((_, next)) = chars.peek().copied() else {
+            return Err(LaneClaimParseError::InvalidToken(key));
+        };
+
+        let value = if next == '"' {
+            chars.next();
+            parse_quoted_claim_value(input, token_start, &mut chars)?
+        } else {
+            parse_unquoted_claim_value(&mut chars)
+        };
+
+        if value.is_empty() {
+            return Err(LaneClaimParseError::InvalidToken(format!("{key}=")));
+        }
+
+        tokens.push((key, value));
+    }
+
+    Ok(tokens)
+}
+
+fn parse_quoted_claim_value(
+    input: &str,
+    token_start: usize,
+    chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+) -> Result<String, LaneClaimParseError> {
+    let mut value = String::new();
+    let mut closed = false;
+
+    while let Some((_, character)) = chars.next() {
+        match character {
+            '"' => {
+                closed = true;
+                break;
+            }
+            '\\' => {
+                let Some((_, escaped)) = chars.next() else {
+                    return Err(invalid_token_slice(input, token_start, input.len()));
+                };
+                match escaped {
+                    'n' => value.push('\n'),
+                    'r' => value.push('\r'),
+                    't' => value.push('\t'),
+                    '"' => value.push('"'),
+                    '\\' => value.push('\\'),
+                    other => value.push(other),
+                }
+            }
+            other => value.push(other),
+        }
+    }
+
+    if !closed {
+        return Err(invalid_token_slice(input, token_start, input.len()));
+    }
+
+    if let Some((_, character)) = chars.peek().copied() {
+        if !character.is_whitespace() {
+            return Err(invalid_token_from(input, token_start, chars.peek()));
+        }
+    }
+
+    Ok(value)
+}
+
+fn parse_unquoted_claim_value(
+    chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+) -> String {
+    let mut value = String::new();
+    while let Some((_, character)) = chars.peek().copied() {
+        if character.is_whitespace() {
+            break;
+        }
+        value.push(character);
+        chars.next();
+    }
+    value
+}
+
+fn invalid_token_from(
+    input: &str,
+    token_start: usize,
+    cursor: Option<&(usize, char)>,
+) -> LaneClaimParseError {
+    let token_end = cursor.map(|(index, _)| *index).unwrap_or(input.len());
+    invalid_token_slice(input, token_start, token_end)
+}
+
+fn invalid_token_slice(input: &str, token_start: usize, token_end: usize) -> LaneClaimParseError {
+    LaneClaimParseError::InvalidToken(input[token_start..token_end].into())
 }
 
 fn parse_lane(value: &str) -> Result<LaneClaimLane, LaneClaimParseError> {
@@ -338,6 +481,61 @@ mod tests {
         let rendered = claim.render();
         assert!(rendered.contains(" worker=codex-manual-main "));
         assert_eq!(LaneClaim::parse(&rendered).unwrap(), claim);
+    }
+
+    #[test]
+    fn renders_and_parses_quoted_worker_display_label() {
+        let claim = LaneClaim::active(
+            "#297",
+            LaneClaimLane::Main,
+            LaneClaimActor::Codex,
+            LaneClaimSource::Manual,
+            1_778_904_900_123,
+        )
+        .with_worker("Codex Manual Main");
+
+        let rendered = claim.render();
+
+        assert!(rendered.contains(" worker=\"Codex Manual Main\" "));
+        assert_eq!(LaneClaim::parse(&rendered).unwrap(), claim);
+    }
+
+    #[test]
+    fn renders_and_parses_escaped_worker_display_label() {
+        let claim = LaneClaim::active(
+            "#297",
+            LaneClaimLane::Review,
+            LaneClaimActor::Gemini,
+            LaneClaimSource::Manual,
+            1_778_904_900_123,
+        )
+        .with_worker("Manual \"Gemini\" Review\\A");
+
+        let rendered = claim.render();
+
+        assert!(rendered.contains(" worker=\"Manual \\\"Gemini\\\" Review\\\\A\" "));
+        assert_eq!(LaneClaim::parse(&rendered).unwrap(), claim);
+    }
+
+    #[test]
+    fn parses_existing_unquoted_claim_values() {
+        let claim = LaneClaim::parse(
+            "v=1 lane=main actor=codex worker=codex-manual-main source=manual issue=#297 run=20260518T0640Z-issue297-main-73cb state=active thread=unknown registry=run/20260518T0640Z-issue297-main-73cb",
+        )
+        .unwrap();
+
+        assert_eq!(claim.worker.as_deref(), Some("codex-manual-main"));
+        assert_eq!(claim.issue, "#297");
+    }
+
+    #[test]
+    fn rejects_unclosed_quoted_claim_value() {
+        let error = LaneClaim::parse(
+            "v=1 lane=main actor=codex worker=\"Codex Manual Main source=manual issue=#297 run=run state=active thread=unknown registry=run/run",
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, LaneClaimParseError::InvalidToken(_)));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1854,7 +1854,7 @@ fn review_claim(
         project_text_field(&issue, "Review Agent").as_deref(),
     )
     .with_worker(&worker);
-    let claim_value = claim.render();
+    let claim_value = render_parseable_lane_claim(&claim)?;
     if !write {
         println!(
             "review_claim_dry_run action=claim_field issue_ref={} field=\"Review Agent\" value={claim_value}",
@@ -1930,7 +1930,7 @@ fn lane_claim_command(
         worker.trim(),
         existing_value.as_deref(),
     )?;
-    let claim_value = claim.render();
+    let claim_value = render_parseable_lane_claim(&claim)?;
 
     if !write {
         println!(
@@ -2060,6 +2060,19 @@ fn lane_claim_for_manual_worker(
         current_time_ms(),
     )
     .with_worker(worker))
+}
+
+fn render_parseable_lane_claim(claim: &LaneClaim) -> Result<String, Box<dyn std::error::Error>> {
+    let value = claim.render();
+    let parsed = LaneClaim::parse(&value)
+        .map_err(|error| format!("rendered lane claim is not parseable: {error}; value={value}"))?;
+    if parsed != *claim {
+        return Err(format!(
+            "rendered lane claim did not round-trip; rendered={value} parsed={parsed:?} original={claim:?}"
+        )
+        .into());
+    }
+    Ok(value)
 }
 
 fn record_manual_lane_claim_evidence(
@@ -3258,7 +3271,7 @@ fn write_review_claim_field(
     worker_key: &str,
 ) -> Result<LaneClaim, Box<dyn std::error::Error>> {
     let claim = review_claim_for_issue(issue, worker_key);
-    let claim_value = claim.render();
+    let claim_value = render_parseable_lane_claim(&claim)?;
     adapter.set_project_field(
         &issue.identifier,
         &ProjectFieldAssignment {
@@ -7829,7 +7842,7 @@ fn write_lane_claim_field(
     claim: &LaneClaim,
     write: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let claim_value = claim.render();
+    let claim_value = render_parseable_lane_claim(claim)?;
     if !write {
         println!(
             "{}_pool_dry_run action=claim_field issue={} field={:?} value={:?}",
@@ -7878,7 +7891,7 @@ fn write_lane_claim_state(
     state: LaneClaimState,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let updated = claim.with_state(state);
-    let value = updated.render();
+    let value = render_parseable_lane_claim(&updated)?;
     adapter.set_project_field(
         &issue.identifier,
         &ProjectFieldAssignment {
@@ -12559,6 +12572,32 @@ mod tests {
                 write: true
             }
         );
+    }
+
+    #[test]
+    fn manual_lane_claim_with_display_worker_round_trips_to_session_start_validation() {
+        let mut issue = tracker_issue_with_ref("#297", "Support quoted worker labels", "Todo");
+        let claim = lane_claim_for_manual_worker(
+            &issue,
+            AgentSessionLaneArg::Main,
+            LaneClaimActor::Codex,
+            LaneClaimSource::Manual,
+            "Codex Manual Main",
+            None,
+        )
+        .unwrap();
+        let claim_value = render_parseable_lane_claim(&claim).unwrap();
+
+        assert!(claim_value.contains("worker=\"Codex Manual Main\""));
+        issue
+            .project_fields
+            .insert("Main Agent".into(), serde_json::Value::String(claim_value));
+
+        let parsed =
+            matching_lane_claim_for_session(&issue, AgentSessionLaneArg::Main, &claim.run).unwrap();
+
+        assert_eq!(parsed.worker.as_deref(), Some("Codex Manual Main"));
+        assert_eq!(parsed, claim);
     }
 
     #[test]

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -13,7 +13,7 @@ cargo run -- forge validate --workflow workflows/jade-symphony.md --status Todo 
 cargo run -- forge create --workflow workflows/jade-symphony.md --status Todo --title "<title>" --body-file /private/tmp/issue.md --assignee Alive24 --write
 cargo run -- review loop workflows/jade-symphony.md --max-iterations 1 --write
 cargo run -- merge once workflows/jade-symphony.md --write
-cargo run -- main claim workflows/jade-symphony.md '#123' --worker codex-manual-main --write
+cargo run -- main claim workflows/jade-symphony.md '#123' --worker "Codex Manual Main" --write
 cargo run -- session start workflows/jade-symphony.md '#123' --lane main --run <RUN_ID> --write
 cargo run -- session list workflows/jade-symphony.md
 ```
@@ -31,10 +31,12 @@ review handoff.
 Manual tmux recovery is a two-step path. Use `main claim`, `review claim`, or
 `merge claim` to write the matching Project claim field, print the structured
 `run=`, and record minimum non-tmux registry evidence for the manual Codex App
-claim. Then use `session start --lane ... --run ...` to render the lane prompt
-and start the tmux runtime when a supervised terminal is needed. Session
-commands validate the existing claim and write attach/log evidence without
-approving reviews, merging PRs, or closing issues.
+claim. Worker labels may be human-readable display labels with spaces; claim
+commands quote and validate those values before Project writes. Then use
+`session start --lane ... --run ...` to render the lane prompt and start the
+tmux runtime when a supervised terminal is needed. Session commands validate the
+existing claim and write attach/log evidence without approving reviews, merging
+PRs, or closing issues.
 
 Lane prompt files:
 

--- a/workflows/prompts/main-agent.md
+++ b/workflows/prompts/main-agent.md
@@ -49,7 +49,8 @@ question, but do not edit files under
    issue and PR content, but do not use raw Project GraphQL or the Project UI
    for normal Project state reads or mutations.
    Manual lane ownership must use `main claim ... --worker <worker> --write`;
-   session startup must use `session start ... --lane main --run <RUN_ID>`.
+   worker display labels with spaces are allowed through the CLI claim path.
+   Session startup must use `session start ... --lane main --run <RUN_ID>`.
    Session startup validates the claim and must not write Project claim fields.
 2. Confirm the issue is still executable with the Issue Quality Gate. If the
    issue is not executable, leave a precise workpad note, move it to

--- a/workflows/prompts/merge-agent.md
+++ b/workflows/prompts/merge-agent.md
@@ -25,7 +25,8 @@ context, but raw Project GraphQL or Project UI changes are break-glass only.
 
 - Confirm the issue is in `Merging` before attempting to land.
 - Claim `Merging Agent` through `merge claim ... --worker <worker> --write`
-  before starting manual merge work, then start runtime through `session start
+  before starting manual merge work. Worker display labels with spaces are
+  allowed through the CLI claim path. Then start runtime through `session start
   --lane merge --run <RUN_ID>` only after the matching claim exists.
 - Confirm exactly one reliable PR target exists.
 - Preserve the assigned structured claim `run=` in merge evidence, workpad

--- a/workflows/prompts/review-agent.md
+++ b/workflows/prompts/review-agent.md
@@ -26,6 +26,7 @@ context, but raw Project GraphQL or Project UI changes are break-glass only.
 - Confirm the issue is in `Agent Review` before starting review.
 - Manual review sessions must claim `Review Agent` through
   `review claim ... --worker <worker> --write` before starting review work.
+  Worker display labels with spaces are allowed through the CLI claim path.
 - Automatic headless `review loop` owns its own Review Agent claim and final
   routing outside the Gemini process. In that mode, do not run `review claim`,
   `review pass`, `review reject`, `set-state`, `workpad`, `gh issue edit`, or


### PR DESCRIPTION
## Summary

- add reversible quoting/escaping for structured lane claim values so worker display labels with spaces survive Project storage
- validate rendered lane claims by parsing them back before Project field writes
- document display-label support and raw Project edit boundaries across CLI/operator docs and lane prompts

## Verification

- `cargo test lane_claim -- --nocapture`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Closes #297
