### PR TITLE
Tolerate session registry status drift

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -162,6 +162,9 @@ joining the terminal unless `--exec` is provided.
 durable session registry. `doctor` flags stale, failed, orphaned, usage-limited,
 or runtime/session mismatch cases, while `clean audit` classifies the registry,
 rendered prompts, tmux logs, and individual sessions without deleting them.
+Unknown persisted registry status values are tolerated on read: they classify
+as `unknown`, keep the raw status value in diagnostics, and are not migrated,
+repaired, or rewritten by normal read-only commands.
 
 ## Workspace Discovery
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -113,6 +113,10 @@ and log tails, and reports a conservative session classification such as
 `failed`, `completed`, `stale`, or `unknown`. The status surface includes only
 compact evidence snippets plus attach/log locations; attach manually when raw
 scrollback is needed.
+Persisted session registry statuses that are not recognized by the current
+binary are read as `unknown` without rewriting or dropping the record. Status
+and doctor diagnostics preserve the raw drifted value so operators can inspect
+the evidence without running a repair or migration first.
 `doctor` reads the same registry and reports stale, orphaned, or attention
 requiring sessions next to tracker/runtime findings. `clean audit` treats the
 session registry, rendered prompts, and tmux logs as recovery evidence, and only

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1016,8 +1016,8 @@ fn audit_session_consistency(
                 AuditSeverity::Warning,
                 "tmux_session_needs_operator_attention",
                 &format!(
-                    "Registered tmux session `{}` is `{}` from {} evidence.",
-                    session.session_id, session.status, session.evidence_source
+                    "Registered tmux session `{}` is `{}` from {} evidence: {}.",
+                    session.session_id, session.status, session.evidence_source, session.evidence
                 ),
                 "Use the recorded attach command or log path to decide whether to resume, retry, or route the issue with evidence.",
             ));
@@ -1403,6 +1403,29 @@ mod tests {
         let report = audit_project_issues(&[issue]);
 
         assert!(report.is_clean());
+    }
+
+    #[test]
+    fn reports_raw_unknown_session_status_drift() {
+        let mut drifted = session(Some("#202"), "unknown");
+        drifted.evidence = "unknown persisted session status recorded_legacy".into();
+        let context = ProjectDoctorContext {
+            runtime_state: None,
+            sessions: vec![drifted],
+            now_ms: 20_000,
+            stale_after_ms: 10_000,
+        };
+        let report =
+            audit_project_issues_with_context(&[issue("#202", "In Progress")], Some(&context));
+
+        let violation = report
+            .violations
+            .iter()
+            .find(|violation| violation.code == "tmux_session_needs_operator_attention")
+            .unwrap();
+        assert!(violation
+            .message
+            .contains("unknown persisted session status recorded_legacy"));
     }
 
     #[test]

--- a/src/issue_workspace.rs
+++ b/src/issue_workspace.rs
@@ -682,6 +682,34 @@ mod tests {
     }
 
     #[test]
+    fn workspace_discovery_tolerates_unrelated_unknown_persisted_status() {
+        let mut unrelated = session("/tmp/issue-999");
+        unrelated.issue_id = Some("I_999".into());
+        unrelated.issue_identifier = Some("#999".into());
+        unrelated.status = SessionStatus::UnknownPersisted("recorded_legacy".into());
+        let report = discover_issue_workspaces_from_parts(
+            &issue(),
+            &[unrelated, session("/tmp/issue-253")],
+            &[GitWorktree {
+                path: PathBuf::from("/tmp/issue-253"),
+                head: Some("def".into()),
+                branch: Some("feature/issue-253-worktree-discovery".into()),
+                prunable: None,
+            }],
+            "<!-- jade-symphony-workpad -->",
+        );
+
+        assert!(report
+            .candidates
+            .iter()
+            .any(|candidate| candidate.path == Path::new("/tmp/issue-253")));
+        assert!(!report
+            .candidates
+            .iter()
+            .any(|candidate| candidate.path == Path::new("/tmp/issue-999")));
+    }
+
+    #[test]
     fn validates_adoption_against_repo_worktree_and_issue_branch() {
         let candidate = validate_workspace_adoption(
             &issue(),

--- a/src/session_registry.rs
+++ b/src/session_registry.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 use crate::config::RuntimeConfig;
@@ -49,8 +49,7 @@ pub struct AgentSessionRecord {
     pub updated_at_ms: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionStatus {
     Starting,
     Running,
@@ -63,6 +62,7 @@ pub enum SessionStatus {
     Recorded,
     Stale,
     Unknown,
+    UnknownPersisted(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -93,8 +93,58 @@ impl SessionStatus {
             Self::Completed => "completed",
             Self::Recorded => "recorded",
             Self::Stale => "stale",
-            Self::Unknown => "unknown",
+            Self::Unknown | Self::UnknownPersisted(_) => "unknown",
         }
+    }
+
+    pub fn raw_persisted_unknown(&self) -> Option<&str> {
+        match self {
+            Self::UnknownPersisted(raw) => Some(raw.as_str()),
+            _ => None,
+        }
+    }
+
+    fn from_persisted_str(value: &str) -> Self {
+        match value {
+            "starting" => Self::Starting,
+            "running" => Self::Running,
+            "waiting_for_trust" => Self::WaitingForTrust,
+            "waiting_for_approval" => Self::WaitingForApproval,
+            "waiting_for_human_input" => Self::WaitingForHumanInput,
+            "usage_limited" => Self::UsageLimited,
+            "failed" => Self::Failed,
+            "completed" => Self::Completed,
+            "recorded" => Self::Recorded,
+            "stale" => Self::Stale,
+            "unknown" => Self::Unknown,
+            other => Self::UnknownPersisted(other.to_string()),
+        }
+    }
+
+    fn persisted_str(&self) -> &str {
+        match self {
+            Self::UnknownPersisted(raw) => raw.as_str(),
+            _ => self.as_str(),
+        }
+    }
+}
+
+impl Serialize for SessionStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.persisted_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for SessionStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Self::from_persisted_str(&value))
     }
 }
 
@@ -278,10 +328,16 @@ pub fn classify_session_record(
         };
     }
 
+    let evidence = if let Some(raw) = record.status.raw_persisted_unknown() {
+        format!("unknown persisted session status {raw}")
+    } else {
+        format!("registry status {}", record.status.as_str())
+    };
+
     SessionStatusProbe {
         status: record.status.clone(),
         source: SessionStatusSource::Registry,
-        evidence: format!("registry status {}", record.status.as_str()),
+        evidence,
     }
 }
 
@@ -553,6 +609,54 @@ mod tests {
 
         assert_eq!(loaded.sessions.len(), 1);
         assert_eq!(loaded.sessions[0].updated_at_ms, 20);
+    }
+
+    #[test]
+    fn loads_unknown_persisted_status_as_unknown_with_raw_diagnostic() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(SESSION_REGISTRY_FILE);
+        let mut value = serde_json::to_value(SessionRegistry {
+            sessions: vec![fixture_record()],
+        })
+        .unwrap();
+        value["sessions"][0]["status"] = serde_json::Value::String("recorded_legacy".into());
+        fs::write(&path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+
+        let loaded = load_session_registry(&path).unwrap();
+        let record = &loaded.sessions[0];
+        let probe = classify_session_record(record, None, None, 2_000, 10_000);
+
+        assert_eq!(record.status.as_str(), "unknown");
+        assert_eq!(
+            record.status.raw_persisted_unknown(),
+            Some("recorded_legacy")
+        );
+        assert_eq!(probe.status.as_str(), "unknown");
+        assert_eq!(
+            probe.evidence,
+            "unknown persisted session status recorded_legacy"
+        );
+    }
+
+    #[test]
+    fn saving_another_record_preserves_unknown_persisted_status_value() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(SESSION_REGISTRY_FILE);
+        let mut value = serde_json::to_value(SessionRegistry {
+            sessions: vec![fixture_record()],
+        })
+        .unwrap();
+        value["sessions"][0]["status"] = serde_json::Value::String("recorded_legacy".into());
+        fs::write(&path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
+        let mut second = fixture_record();
+        second.session_name = "jade-main-299-attempt-1-second".into();
+        second.issue_identifier = Some("#299".into());
+
+        save_session_record(&path, second).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+
+        assert!(content.contains(r#""status": "recorded_legacy""#));
+        assert!(content.contains(r#""status": "running""#));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Tolerate unknown persisted session registry status strings by reading them as `unknown` while preserving the raw value.
- Surface raw unknown-status drift in session diagnostics used by status/doctor flows.
- Add regression coverage for registry load/save preservation, workspace discovery resilience, and doctor diagnostic output.
- Document the no-repair/no-migration boundary for unknown registry statuses.

Closes #298

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -- workspace show workflows/jade-symphony.md '#298'`
- `cargo run -- project issue --json workflows/jade-symphony.md '#298'`

## Handoff Notes

- Unknown persisted statuses classify as `unknown` for read behavior.
- `UnknownPersisted(raw)` serializes back to the raw value, so normal save paths do not migrate or rewrite unrelated drifted records.
- Main Agent stops at Agent Review after linked-PR readback confirms this PR is visible and ready.
