### PR TITLE
Centralize GitHub access policy

### DIFF
--- a/.codex/skills/jade-symphony-doctor/SKILL.md
+++ b/.codex/skills/jade-symphony-doctor/SKILL.md
@@ -70,7 +70,7 @@ evidence preserved before the mutation.
 Run or equivalent-check these before recommending repair:
 
 ```bash
-cargo run -- project-state workflows/jade-symphony.md
+cargo run -- project state workflows/jade-symphony.md
 cargo run -- doctor workflows/jade-symphony.md
 cargo run -- debug workflows/jade-symphony.md
 ```
@@ -78,14 +78,14 @@ cargo run -- debug workflows/jade-symphony.md
 For an operator-selected issue:
 
 ```bash
-cargo run -- project-issue workflows/jade-symphony.md '#258' --json
+cargo run -- project issue workflows/jade-symphony.md '#258' --json
 cargo run -- doctor workflows/jade-symphony.md repair '#258'
 ```
 
 If the issue appears to be implementation-claimable, also run:
 
 ```bash
-cargo run -- gate workflows/jade-symphony.md '#258'
+cargo run -- forge validate --workflow workflows/jade-symphony.md --issue '#258'
 ```
 
 If worktree or session evidence is ambiguous, add the narrowest relevant reads:
@@ -96,9 +96,10 @@ cargo run -- agent-session list workflows/jade-symphony.md
 git worktree list --porcelain
 ```
 
-Use `gh issue view` and `gh pr view` only for ordinary issue/PR content. Do not
-use raw Project reads for status, claim fields, blockers, or linked PR state in
-normal flow.
+Use `gh issue view` and `gh pr view` only for ordinary issue/PR content when
+the CLI lacks the needed content read, and record the CLI gap when the result
+changes the repair recommendation. Do not use raw Project reads for status,
+claim fields, blockers, workpads, or linked PR state in normal flow.
 
 ## Classification
 
@@ -109,7 +110,7 @@ when they change the recommended next step.
   credentials, destructive approval, missing sample data, or a choice that the
   issue contract did not authorize.
 - `missing_pr_linkage`: a lane handoff or merge needs a Project-visible linked
-  PR, but `project-issue` does not expose the expected PR.
+  PR, but `project issue` does not expose the expected PR.
 - `draft_pr_handoff`: the linked PR exists but is draft before an Agent Review
   handoff.
 - `stale_lane_claim`: `Main Agent`, `Review Agent`, or `Merging Agent` points to
@@ -141,8 +142,8 @@ GitHub issue comment through the configured workpad/comment path.
 - Secondary classifications: `stale_lane_claim`
 - Diagnosis: ...
 - Evidence read:
-  - `cargo run -- project-state workflows/jade-symphony.md`: ...
-  - `cargo run -- project-issue workflows/jade-symphony.md '#258' --json`: ...
+  - `cargo run -- project state workflows/jade-symphony.md`: ...
+  - `cargo run -- project issue workflows/jade-symphony.md '#258' --json`: ...
   - `cargo run -- doctor workflows/jade-symphony.md repair '#258'`: ...
 - Recommended next step: ...
 - Repair actions requiring explicit confirmation:
@@ -188,7 +189,7 @@ Out of scope for Doctor v1:
 - automatic Project mutation.
 - full local skill integrity checking from #256.
 - full dated installable skill suite packaging from #242.
-- replacing `doctor`, `project-state`, or `project-issue`.
+- replacing `doctor`, `project state`, or `project issue`.
 
 ## Handoff
 

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -11,10 +11,13 @@ workflow path when `JADE_SYMPHONY_WORKFLOW` is set, or when
 
 For normal dogfood, Jade Symphony CLI is the authority for GitHub Project v2
 workflow reads and mutations. Direct `gh issue view` / `gh pr view` is still
-acceptable for raw issue or PR content, but Project status, Project fields,
-relationships, claim locks, workpads, and state transitions should go through
-the commands in this reference. Manual Project UI or raw Project GraphQL changes
-are break-glass recovery actions, not the standard path.
+acceptable for raw issue or PR content when the CLI lacks the needed content
+read, but Project status, Project fields, relationships, claim locks, workpads,
+linked-PR handoff checks, and state transitions should go through the commands
+in this reference. Manual Project UI or raw Project GraphQL changes are
+break-glass recovery actions, not the standard path. See
+`docs/github-access-policy.md` for the current raw GitHub inventory and
+REST-first / GraphQL-required boundaries.
 
 The canonical `workflows/jade-symphony.md` file is a workflow index/config. It
 references lane-specific prompts in `workflows/prompts/` so Main, Review, and

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -91,17 +91,19 @@ These must exist before Jade Symphony can safely dogfood against real GitHub
 Project v2 issues:
 
 1. Harden read-only GitHub Project v2 adapter.
-   - Keep loading ProjectV2 items through `gh api graphql` or replace it with a
-     direct HTTP client behind the same adapter.
+   - Keep loading ProjectV2 items through the centralized GitHub access helper
+     in `src/tracker.rs`; it may call `gh api graphql` or a future direct HTTP
+     client, but callers should not open-code Project queries.
    - Use `project state` as the canonical dogfood diagnostic before claim or
      merge work; failed reads print a classified blocker instead of looking like
      an empty queue.
    - Use `project issue` for per-issue Project status, fields, claim locks,
      blockers, and linked PRs. Direct `gh issue view` / `gh pr view` is still
-     allowed for raw issue and PR context, but not for normal Project state
-     reads.
-   - Retry transient network and rate-limit failures, and fail partial Project
-     payloads loudly when required item fields are missing.
+     allowed for raw issue and PR context when the CLI lacks an equivalent
+     content read, but not for normal Project state reads.
+   - Retry transient network and rate-limit failures, classify GraphQL resource
+     limits separately, and fail partial Project payloads loudly when required
+     item fields are missing.
    - Filter to real GitHub Issues, not draft items or PR items.
    - Resolve configured status field and option IDs.
    - Normalize issue body, labels, assignees, linked PRs, project fields, and

--- a/docs/github-access-policy.md
+++ b/docs/github-access-policy.md
@@ -1,0 +1,50 @@
+# GitHub Access Policy
+
+Jade Symphony CLI is the authority for workflow-critical GitHub access. Project
+state, Project fields, relationships, claim locks, workpads, workflow status,
+and linked-PR handoff checks must go through CLI commands or shared tracker
+helpers.
+
+## Access Rules
+
+- Prefer REST-backed `gh api` reads when REST exposes the required issue, PR, or
+  repository fact.
+- Use ProjectV2 GraphQL only for Project item reads, Project fields, Project
+  mutations, issue/comment mutations that require node IDs, and GitHub surfaces
+  that REST cannot provide in the required shape.
+- Keep ProjectV2 GraphQL shallow: small page sizes, explicit field selection,
+  split metadata from item-page queries, and paginate with cursors.
+- Route GitHub CLI execution through `GithubCliAccess` in `src/tracker.rs` so
+  retry, JSON parsing, auth, rate-limit, resource-limit, partial-response, and
+  missing-capability diagnostics stay consistent.
+- Raw `gh issue view` or `gh pr view` is allowed for read-only diagnostics when
+  the CLI lacks the needed content read. Record it as a CLI gap in workpad or
+  report evidence when it affects workflow decisions.
+- Raw `gh project`, Project GraphQL, or Project UI writes are break-glass only.
+  Record the missing CLI surface and preserve evidence before any such repair.
+
+## Current Inventory
+
+| Surface | Current usage | Classification | Target |
+| --- | --- | --- | --- |
+| `src/tracker.rs` ProjectV2 queries and mutations | `gh api graphql` through tracker helper methods | Must stay behind CLI helper | Centralized in `GithubCliAccess`; keep small pages and explicit fields. |
+| `src/tracker.rs` native blocker reads | REST `gh api repos/{owner}/{repo}/issues/.../dependencies/blocked_by` | Preferred REST read | Keep REST-first helper path. |
+| `src/tracker.rs` issue edits and assignment | `gh issue edit` from CLI commands | CLI-owned mutation helper | Route through `GithubCliAccess::run_status` for consistent diagnostics. |
+| `src/tracker.rs` workpad comments, issue creation, PR linkage comment, issue close | GraphQL mutations | GraphQL required or currently node-id-shaped | Keep inside CLI; do not expose raw operator commands. |
+| `src/main.rs` lane prompt warnings and Project mutation audit | Operator-facing guard text | Must stay CLI-first | Keep warning text aligned with this policy. |
+| `src/git_handoff.rs` PR read commands | `gh pr view` for handoff evidence | Allowed helper-level PR read | Keep behind CLI helper surface; avoid operator raw Project reads. |
+| `.codex/skills/` | Doctor/Main/Review/Merge manual workflows mention raw `gh` fallbacks | Allowed only as labeled CLI-gap diagnostics | Prefer grouped CLI commands and require workpad/report evidence for fallbacks. |
+| `docs/cli-command-reference.md`, `docs/operator-dogfood.md`, `docs/operator-doctor.md` | Operator guidance for CLI vs raw GitHub access | Policy documentation | Keep raw reads diagnostic and Project writes break-glass. |
+| `workflows/prompts/*.md` | Lane authority contracts | Workflow-critical | Route Project facts and mutations through Jade Symphony CLI. |
+
+## Missing Or Deferred CLI Surfaces
+
+- Ordinary raw issue/PR body and comment reads still rely on `gh issue view` or
+  `gh pr view` in some manual diagnostics. That is an allowed CLI gap until a
+  dedicated content-read command exists.
+- PR diff inspection is outside the Project state machine. Review and Merge may
+  use ordinary Git/GitHub PR reads when local checkout or review context needs
+  them, but linked-PR state and draft/ready gates must be verified through CLI
+  readback.
+- ProjectV2 still requires GraphQL for item fields and mutations. This policy
+  optimizes and centralizes GraphQL; it does not remove it.

--- a/docs/operator-doctor.md
+++ b/docs/operator-doctor.md
@@ -87,8 +87,12 @@ gh issue view 258 --repo Alive24/jade-symphony
 gh pr view 123 --repo Alive24/jade-symphony --json number,isDraft,url,state
 ```
 
-Do not use raw Project reads for status, claim locks, dependency relationships,
-or linked PR state in normal Doctor flow.
+Use those raw reads only as diagnostic content fallbacks when the CLI lacks the
+needed issue or PR content surface, and record the CLI gap when the result
+changes the repair recommendation. Do not use raw Project reads for status,
+claim locks, dependency relationships, workpads, or linked PR state in normal
+Doctor flow. See `docs/github-access-policy.md` for the current inventory and
+fallback classification.
 
 ## Classification
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -238,8 +238,8 @@ healthy read prints `project_state_access=ok`, `trusted=true`, the issue count,
 and a state summary, plus a read-only `canonical_checkout` cleanliness line for
 the launch checkout. A failed read prints `project_state_access=blocked`,
 `trusted=false`, and a `failure_kind` such as `auth`, `network`, `rate_limit`,
-`schema`, `partial_response`, or `payload`; treat that as a blocker, not as an
-empty queue.
+`resource_limit`, `schema`, `partial_response`, `payload`, or
+`missing_capability`; treat that as a blocker, not as an empty queue.
 
 The canonical checkout is only the harness launch directory. Do not use it as a
 Main, Review, or Merge issue worktree, and do not leave runtime state, logs,
@@ -252,9 +252,12 @@ the operator moves them to an issue worktree or artifact location.
 Use `project issue` for per-issue Project status, Project fields, blocker
 relationships, claim locks, and linked PRs. Raw `gh issue view` and `gh pr view`
 remain acceptable for ordinary issue/PR body text, comments, and diff context,
-but normal dogfood should not read or mutate Project fields, status, claim locks,
-or relationships through raw Project GraphQL or the Project UI. Those are
-break-glass recovery paths.
+when the CLI does not expose the needed content read; record that as a CLI gap
+when it affects a workflow decision. Normal dogfood should not read or mutate
+Project fields, status, claim locks, relationships, workpads, or linked-PR
+handoff state through raw Project GraphQL or the Project UI. Those are
+break-glass recovery paths. The current inventory and classification live in
+`docs/github-access-policy.md`.
 
 For parent tracking issues with native GitHub subissues, use
 `docs/parent-subissue-topology.md` as the design source. Native sub-issue links
@@ -291,9 +294,9 @@ it validates the source issue is `Human Review`, rejects active lane claims,
 records a diagnostic workpad if they are present, preserves terminal lane claims
 as audit pointers, replaces the issue content, writes Rework revision evidence
 to the workpad, and sets `Rework` as the final mutation. Do not use raw Project
-mutation, `set-state`, or `forge promote` for this normal path. Missing linked
-PRs or missing local worktrees are downstream Main Agent recovery work after the
-issue is in `Rework`.
+mutation, `project set-state`, or `forge promote` for this normal path. Missing
+linked PRs or missing local worktrees are downstream Main Agent recovery work
+after the issue is in `Rework`.
 
 Use `debug` when you need one read-only operator report before a supervised
 dogfood, repair, review, or merge session. It summarizes the current Project

--- a/src/main.rs
+++ b/src/main.rs
@@ -3358,7 +3358,7 @@ This Gemini process is running under Jade Symphony automatic `review loop` or `r
 Jade Symphony CLI has already claimed or will own any Review Agent claim, workpad write,\n\
 issue body update, and Project state transition outside this process.\n\n\
 Do not run mutating Jade Symphony or GitHub commands, including `review claim`, `review pass`,\n\
-`review reject`, `set-state`, `workpad`, `forge`, `gh issue edit`, `gh issue comment`, raw\n\
+`review reject`, `project set-state`, `project workpad`, `forge`, `gh issue edit`, `gh issue comment`, raw\n\
 Project GraphQL mutations, or Project UI changes. Do not activate or follow any manual review\n\
 skill that tells you to mutate Project state.\n\n\
 Return review evidence in stdout only. Start with exactly one line: `Review Result: PASS`,\n\

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -130,9 +130,11 @@ pub enum ProjectStateFailureKind {
     Auth,
     Network,
     RateLimit,
+    ResourceLimit,
     Schema,
     PartialResponse,
     Payload,
+    MissingCapability,
     Unknown,
 }
 
@@ -142,9 +144,11 @@ impl ProjectStateFailureKind {
             Self::Auth => "auth",
             Self::Network => "network",
             Self::RateLimit => "rate_limit",
+            Self::ResourceLimit => "resource_limit",
             Self::Schema => "schema",
             Self::PartialResponse => "partial_response",
             Self::Payload => "payload",
+            Self::MissingCapability => "missing_capability",
             Self::Unknown => "unknown",
         }
     }
@@ -157,7 +161,7 @@ pub fn classify_project_state_error(error: &TrackerError) -> ProjectStateFailure
         TrackerError::IntegrationUnavailable(message) => {
             classify_project_state_failure_message(message)
         }
-        TrackerError::NotImplemented(_) => ProjectStateFailureKind::Unknown,
+        TrackerError::NotImplemented(_) => ProjectStateFailureKind::MissingCapability,
     }
 }
 
@@ -169,6 +173,15 @@ pub fn classify_project_state_failure_message(message: &str) -> ProjectStateFail
         || normalized.contains("http 429")
     {
         ProjectStateFailureKind::RateLimit
+    } else if normalized.contains("resource limit")
+        || normalized.contains("resource limitation")
+        || normalized.contains("maximum node limit")
+        || normalized.contains("max node limit")
+        || normalized.contains("exceeds maximum")
+        || normalized.contains("query has complexity")
+        || normalized.contains("query is too complex")
+    {
+        ProjectStateFailureKind::ResourceLimit
     } else if normalized.contains("authentication")
         || normalized.contains("authenticate")
         || normalized.contains("auth login")
@@ -205,6 +218,12 @@ pub fn classify_project_state_failure_message(message: &str) -> ProjectStateFail
         || normalized.contains("invalid github api json")
     {
         ProjectStateFailureKind::Payload
+    } else if normalized.contains("does not support")
+        || normalized.contains("not implemented")
+        || normalized.contains("missing cli capability")
+        || normalized.contains("cli gap")
+    {
+        ProjectStateFailureKind::MissingCapability
     } else {
         ProjectStateFailureKind::Unknown
     }
@@ -880,23 +899,18 @@ impl GithubProjectV2GhClient {
             .ok_or_else(|| TrackerError::Payload("tracker.repo is required".into()))?;
 
         for assignee in assignees {
-            let output = Command::new("gh")
-                .args([
-                    "issue",
-                    "edit",
-                    &number.to_string(),
-                    "--repo",
-                    &format!("{owner}/{repo}"),
-                    "--add-assignee",
-                    assignee,
-                ])
-                .output()
-                .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
-            if !output.status.success() {
-                return Err(TrackerError::IntegrationUnavailable(
-                    String::from_utf8_lossy(&output.stderr).trim().to_string(),
-                ));
-            }
+            GithubCliAccess::run_status(
+                vec![
+                    "issue".into(),
+                    "edit".into(),
+                    number.to_string(),
+                    "--repo".into(),
+                    format!("{owner}/{repo}"),
+                    "--add-assignee".into(),
+                    assignee.clone(),
+                ],
+                "GitHub issue assignment",
+            )?;
         }
 
         Ok(())
@@ -938,26 +952,22 @@ impl GithubProjectV2GhClient {
             std::env::temp_dir().join(format!("jade-symphony-issue-body-{number}-{nonce}.md"));
         fs::write(&body_path, body)
             .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
-        let output = Command::new("gh")
-            .args([
-                "issue",
-                "edit",
-                &number.to_string(),
-                "--repo",
-                &format!("{owner}/{repo}"),
-                "--title",
-                title,
-                "--body-file",
-            ])
-            .arg(&body_path)
-            .output()
-            .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
+        let result = GithubCliAccess::run_status(
+            vec![
+                "issue".into(),
+                "edit".into(),
+                number.to_string(),
+                "--repo".into(),
+                format!("{owner}/{repo}"),
+                "--title".into(),
+                title.to_string(),
+                "--body-file".into(),
+                body_path.to_string_lossy().to_string(),
+            ],
+            "GitHub issue edit",
+        );
         let _ = fs::remove_file(&body_path);
-        if !output.status.success() {
-            return Err(TrackerError::IntegrationUnavailable(
-                String::from_utf8_lossy(&output.stderr).trim().to_string(),
-            ));
-        }
+        result?;
 
         Ok(())
     }
@@ -1156,10 +1166,8 @@ impl GithubProjectV2GhClient {
         issue_id: &str,
         marker: &str,
     ) -> Result<Vec<(String, String)>, TrackerError> {
-        let response = self.graphql(
-            GITHUB_ISSUE_COMMENTS_QUERY,
-            &[("issueId", issue_id.to_string())],
-        )?;
+        let query = github_issue_comments_query();
+        let response = self.graphql(&query, &[("issueId", issue_id.to_string())])?;
         Ok(response
             .pointer("/data/node/comments/nodes")
             .and_then(serde_json::Value::as_array)
@@ -1376,6 +1384,118 @@ fn gh_available() -> bool {
         .unwrap_or(false)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GithubCliApi {
+    Graphql,
+    RestJson,
+}
+
+impl GithubCliApi {
+    fn operation_label(self) -> &'static str {
+        match self {
+            Self::Graphql => "GitHub GraphQL operation",
+            Self::RestJson => "GitHub REST operation",
+        }
+    }
+
+    fn invalid_json_label(self) -> &'static str {
+        match self {
+            Self::Graphql => "invalid GitHub GraphQL JSON",
+            Self::RestJson => "invalid GitHub API JSON",
+        }
+    }
+
+    fn validate_response(self, response: &serde_json::Value) -> Result<(), TrackerError> {
+        if self == Self::Graphql {
+            if let Some(message) = graphql_error_message(response) {
+                return Err(TrackerError::IntegrationUnavailable(message));
+            }
+        }
+        Ok(())
+    }
+}
+
+struct GithubCliAccess;
+
+impl GithubCliAccess {
+    const MAX_ATTEMPTS: usize = 3;
+
+    fn run_json(api: GithubCliApi, args: Vec<String>) -> Result<serde_json::Value, TrackerError> {
+        let mut last_error = None;
+
+        for attempt in 1..=Self::MAX_ATTEMPTS {
+            match Self::run_json_once(api, &args) {
+                Ok(response) => return Ok(response),
+                Err(error) if project_state_error_is_retryable(&error) => {
+                    last_error = Some(error);
+                    if attempt < Self::MAX_ATTEMPTS {
+                        thread::sleep(project_state_retry_delay(attempt));
+                    } else {
+                        break;
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        let error = last_error.unwrap_or_else(|| {
+            TrackerError::IntegrationUnavailable(format!("{} failed", api.operation_label()))
+        });
+        let kind = classify_project_state_error(&error);
+        Err(TrackerError::IntegrationUnavailable(format!(
+            "{} failed after {} attempts kind={}: {error}",
+            api.operation_label(),
+            Self::MAX_ATTEMPTS,
+            kind.as_str()
+        )))
+    }
+
+    fn run_status(args: Vec<String>, operation: &str) -> Result<(), TrackerError> {
+        let output = Command::new("gh")
+            .args(args)
+            .output()
+            .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
+
+        if !output.status.success() {
+            let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let kind = classify_project_state_failure_message(&message);
+            return Err(TrackerError::IntegrationUnavailable(format!(
+                "{operation} failed kind={}: {message}",
+                kind.as_str()
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn run_json_once(
+        api: GithubCliApi,
+        args: &[String],
+    ) -> Result<serde_json::Value, TrackerError> {
+        let output = Command::new("gh")
+            .args(args)
+            .output()
+            .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
+
+        if !output.status.success() {
+            let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let kind = classify_project_state_failure_message(&message);
+            return Err(TrackerError::IntegrationUnavailable(format!(
+                "{} failed kind={}: {message}",
+                api.operation_label(),
+                kind.as_str()
+            )));
+        }
+
+        let response: serde_json::Value =
+            serde_json::from_slice(&output.stdout).map_err(|error| {
+                TrackerError::Payload(format!("{}: {error}", api.invalid_json_label()))
+            })?;
+        api.validate_response(&response)?;
+        Ok(response)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum GithubAuthMode {
     Fixture,
@@ -1443,99 +1563,11 @@ fn github_auth_gap(mode: GithubAuthMode) -> Option<String> {
 }
 
 fn run_gh_graphql(args: Vec<String>) -> Result<serde_json::Value, TrackerError> {
-    const MAX_ATTEMPTS: usize = 3;
-    let mut last_error = None;
-
-    for attempt in 1..=MAX_ATTEMPTS {
-        match run_gh_graphql_once(&args) {
-            Ok(response) => return Ok(response),
-            Err(error) if project_state_error_is_retryable(&error) => {
-                last_error = Some(error);
-                if attempt < MAX_ATTEMPTS {
-                    thread::sleep(project_state_retry_delay(attempt));
-                } else {
-                    break;
-                }
-            }
-            Err(error) => return Err(error),
-        }
-    }
-
-    let error = last_error.unwrap_or_else(|| {
-        TrackerError::IntegrationUnavailable("GitHub GraphQL operation failed".into())
-    });
-    let kind = classify_project_state_error(&error);
-    Err(TrackerError::IntegrationUnavailable(format!(
-        "GitHub GraphQL operation failed after {MAX_ATTEMPTS} attempts kind={}: {error}",
-        kind.as_str()
-    )))
-}
-
-fn run_gh_graphql_once(args: &[String]) -> Result<serde_json::Value, TrackerError> {
-    let output = Command::new("gh")
-        .args(args)
-        .output()
-        .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
-
-    if !output.status.success() {
-        return Err(TrackerError::IntegrationUnavailable(
-            String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        ));
-    }
-
-    let response: serde_json::Value = serde_json::from_slice(&output.stdout)
-        .map_err(|error| TrackerError::Payload(format!("invalid gh GraphQL JSON: {error}")))?;
-
-    if let Some(message) = graphql_error_message(&response) {
-        return Err(TrackerError::IntegrationUnavailable(message));
-    }
-
-    Ok(response)
+    GithubCliAccess::run_json(GithubCliApi::Graphql, args)
 }
 
 fn run_gh_api_json(args: Vec<String>) -> Result<serde_json::Value, TrackerError> {
-    const MAX_ATTEMPTS: usize = 3;
-    let mut last_error = None;
-
-    for attempt in 1..=MAX_ATTEMPTS {
-        match run_gh_api_json_once(&args) {
-            Ok(response) => return Ok(response),
-            Err(error) if project_state_error_is_retryable(&error) => {
-                last_error = Some(error);
-                if attempt < MAX_ATTEMPTS {
-                    thread::sleep(project_state_retry_delay(attempt));
-                } else {
-                    break;
-                }
-            }
-            Err(error) => return Err(error),
-        }
-    }
-
-    let error = last_error.unwrap_or_else(|| {
-        TrackerError::IntegrationUnavailable("GitHub API operation failed".into())
-    });
-    let kind = classify_project_state_error(&error);
-    Err(TrackerError::IntegrationUnavailable(format!(
-        "GitHub API operation failed after {MAX_ATTEMPTS} attempts kind={}: {error}",
-        kind.as_str()
-    )))
-}
-
-fn run_gh_api_json_once(args: &[String]) -> Result<serde_json::Value, TrackerError> {
-    let output = Command::new("gh")
-        .args(args)
-        .output()
-        .map_err(|error| TrackerError::IntegrationUnavailable(error.to_string()))?;
-
-    if !output.status.success() {
-        return Err(TrackerError::IntegrationUnavailable(
-            String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        ));
-    }
-
-    serde_json::from_slice(&output.stdout)
-        .map_err(|error| TrackerError::Payload(format!("invalid gh API JSON: {error}")))
+    GithubCliAccess::run_json(GithubCliApi::RestJson, args)
 }
 
 fn project_state_error_is_retryable(error: &TrackerError) -> bool {
@@ -1553,20 +1585,29 @@ fn project_state_retry_delay(attempt: usize) -> Duration {
     })
 }
 
+const GITHUB_PROJECT_ITEM_PAGE_SIZE: usize = 25;
+const GITHUB_PROJECT_FIELD_VALUE_PAGE_SIZE: usize = 30;
+const GITHUB_PROJECT_LABEL_PAGE_SIZE: usize = 25;
+const GITHUB_PROJECT_ASSIGNEE_PAGE_SIZE: usize = 10;
+const GITHUB_PROJECT_LINKED_PR_PAGE_SIZE: usize = 10;
+const GITHUB_PROJECT_COMMENT_PAGE_SIZE: usize = 20;
+const GITHUB_PROJECT_METADATA_FIELD_PAGE_SIZE: usize = 50;
+const GITHUB_WORKPAD_COMMENT_PAGE_SIZE: usize = 50;
+
 fn github_project_query(owner_field: &str) -> String {
     format!(
         r#"
 query JadeSymphonyProject($owner: String!, $number: Int!, $cursor: String) {{
   {owner_field}(login: $owner) {{
     projectV2(number: $number) {{
-      items(first: 50, after: $cursor) {{
+      items(first: {GITHUB_PROJECT_ITEM_PAGE_SIZE}, after: $cursor) {{
         pageInfo {{
           hasNextPage
           endCursor
         }}
         nodes {{
           id
-          fieldValues(first: 50) {{
+          fieldValues(first: {GITHUB_PROJECT_FIELD_VALUE_PAGE_SIZE}) {{
             nodes {{
               ... on ProjectV2ItemFieldSingleSelectValue {{
                 name
@@ -1605,17 +1646,17 @@ query JadeSymphonyProject($owner: String!, $number: Int!, $cursor: String) {{
               state
               createdAt
               updatedAt
-              labels(first: 50) {{
+              labels(first: {GITHUB_PROJECT_LABEL_PAGE_SIZE}) {{
                 nodes {{
                   name
                 }}
               }}
-              assignees(first: 20) {{
+              assignees(first: {GITHUB_PROJECT_ASSIGNEE_PAGE_SIZE}) {{
                 nodes {{
                   login
                 }}
               }}
-              closedByPullRequestsReferences(first: 10) {{
+              closedByPullRequestsReferences(first: {GITHUB_PROJECT_LINKED_PR_PAGE_SIZE}) {{
                 nodes {{
                   id
                   number
@@ -1626,7 +1667,7 @@ query JadeSymphonyProject($owner: String!, $number: Int!, $cursor: String) {{
                   headRefName
                 }}
               }}
-              comments(first: 20) {{
+              comments(first: {GITHUB_PROJECT_COMMENT_PAGE_SIZE}) {{
                 nodes {{
                   body
                 }}
@@ -1649,7 +1690,7 @@ query JadeSymphonyProjectMetadata($owner: String!, $number: Int!) {{
   {owner_field}(login: $owner) {{
     projectV2(number: $number) {{
       id
-      fields(first: 100) {{
+      fields(first: {GITHUB_PROJECT_METADATA_FIELD_PAGE_SIZE}) {{
         nodes {{
           ... on ProjectV2FieldCommon {{
             id
@@ -1717,20 +1758,24 @@ mutation JadeSymphonyClearProjectField($projectId: ID!, $itemId: ID!, $fieldId: 
 }
 "#;
 
-const GITHUB_ISSUE_COMMENTS_QUERY: &str = r#"
-query JadeSymphonyIssueComments($issueId: ID!) {
-  node(id: $issueId) {
-    ... on Issue {
-      comments(first: 100) {
-        nodes {
+fn github_issue_comments_query() -> String {
+    format!(
+        r#"
+query JadeSymphonyIssueComments($issueId: ID!) {{
+  node(id: $issueId) {{
+    ... on Issue {{
+      comments(first: {GITHUB_WORKPAD_COMMENT_PAGE_SIZE}) {{
+        nodes {{
           id
           body
-        }
-      }
-    }
-  }
+        }}
+      }}
+    }}
+  }}
+}}
+"#
+    )
 }
-"#;
 
 const GITHUB_UPDATE_ISSUE_COMMENT_MUTATION: &str = r#"
 mutation JadeSymphonyUpdateIssueComment($commentId: ID!, $body: String!) {
@@ -4253,6 +4298,10 @@ Prompt
             ProjectStateFailureKind::RateLimit
         );
         assert_eq!(
+            classify_project_state_failure_message("GraphQL resource limit exceeded"),
+            ProjectStateFailureKind::ResourceLimit
+        );
+        assert_eq!(
             classify_project_state_failure_message("could not resolve host api.github.com"),
             ProjectStateFailureKind::Network
         );
@@ -4267,6 +4316,12 @@ Prompt
                 "partial ProjectV2 response missing status field \"Status\" for issue #7".into()
             )),
             ProjectStateFailureKind::PartialResponse
+        );
+        assert_eq!(
+            classify_project_state_error(&TrackerError::NotImplemented(
+                "missing CLI capability for raw issue content reads".into()
+            )),
+            ProjectStateFailureKind::MissingCapability
         );
     }
 

--- a/workflows/prompts/main-agent.md
+++ b/workflows/prompts/main-agent.md
@@ -45,9 +45,10 @@ question, but do not edit files under
 
 1. Refresh tracker state, Project fields, claim locks, linked PR state, local
    git state, and any existing issue workpad through Jade Symphony CLI before
-   implementation. Direct `gh issue view` / `gh pr view` is acceptable for raw
-   issue and PR content, but do not use raw Project GraphQL or the Project UI
-   for normal Project state reads or mutations.
+   implementation. Direct `gh issue view` / `gh pr view` is acceptable only as
+   a read-only CLI-gap diagnostic for raw issue and PR content; record the gap
+   when it affects workflow decisions. Do not use raw Project GraphQL or the
+   Project UI for normal Project state reads or mutations.
    Manual lane ownership must use `main claim ... --worker <worker> --write`;
    session startup must use `session start ... --lane main --run <RUN_ID>`.
    Session startup validates the claim and must not write Project claim fields.

--- a/workflows/prompts/merge-agent.md
+++ b/workflows/prompts/merge-agent.md
@@ -14,8 +14,9 @@ the linked PR, records evidence, merges only clean and authorized PRs, closes
 the issue when supported, and routes blockers with a clear workpad.
 
 Use Jade Symphony CLI for Project state, Project fields, claim locks, workpad
-updates, and merge routing. Direct GitHub PR reads are acceptable for raw PR
-context, but raw Project GraphQL or Project UI changes are break-glass only.
+updates, linked-PR state, and merge routing. Direct GitHub PR reads are
+acceptable for raw PR context only as read-only CLI-gap diagnostics, but raw
+Project GraphQL or Project UI changes are break-glass only.
 
 ## Current Issue Contract
 

--- a/workflows/prompts/review-agent.md
+++ b/workflows/prompts/review-agent.md
@@ -14,8 +14,9 @@ produce a review result. Do not implement unrelated code changes while acting as
 the Review Agent.
 
 Use Jade Symphony CLI for Project state, Project fields, claim locks, workpad
-updates, and review routing. Direct GitHub issue/PR reads are acceptable for raw
-context, but raw Project GraphQL or Project UI changes are break-glass only.
+updates, linked-PR state, and review routing. Direct GitHub issue/PR reads are
+acceptable only as read-only CLI-gap diagnostics for raw context, but raw
+Project GraphQL or Project UI changes are break-glass only.
 
 ## Current Issue Contract
 
@@ -28,8 +29,8 @@ context, but raw Project GraphQL or Project UI changes are break-glass only.
   `review claim ... --worker <worker> --write` before starting review work.
 - Automatic headless `review loop` owns its own Review Agent claim and final
   routing outside the Gemini process. In that mode, do not run `review claim`,
-  `review pass`, `review reject`, `set-state`, `workpad`, `gh issue edit`, or
-  other Project/issue mutation commands yourself.
+  `review pass`, `review reject`, `project set-state`, `project workpad`,
+  `gh issue edit`, or other Project/issue mutation commands yourself.
 - Start manual review sessions through `session start --lane review --run
   <RUN_ID>` only after the matching Project claim exists.
 - Gemini-backed `review loop` runs headlessly by default with stdin prompt


### PR DESCRIPTION
Closes #303

## Summary
- add a centralized GitHub access policy and raw gh inventory/classification
- route REST JSON, GraphQL JSON, and status-only gh calls through a shared tracker helper with resource-limit and missing-capability classification
- update dogfood docs, lane prompts, and repo-owned Doctor skill guidance to keep Project-aware facts/mutations behind Jade Symphony CLI surfaces

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo run -- project state workflows/jade-symphony.md
- cargo run -- project issue workflows/jade-symphony.md '#303' --json