### PR TITLE
#344: Fast-forward canonical checkout before write-mode lane operations

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -161,11 +161,16 @@ is reported separately from real active sessions; a Todo candidate is not
 `running` until a backend session or runtime record exists. `main loop`, `review
 loop`, and `merge once` print compact `Latest:` status bars in addition to their
 detailed line logs.
-`main loop --write`, `review loop --write`, and `merge loop --write` also
-enforce a clean canonical launch checkout before the first tracker mutation.
-Tracked dirty files block the lane; recognized untracked
-runtime/log/prompt/evidence/draft artifacts are moved to artifact quarantine
-with a warning; unclassified untracked files block for operator repair.
+Write-mode lane/control commands first run a guarded canonical checkout refresh
+before the first tracker mutation. From a clean attached `main` checkout, the
+CLI fetches the upstream branch and fast-forwards with `git merge --ff-only`
+when local `main` is only behind. Output includes
+`canonical_checkout_refresh=already_current`, `ff_only`, `would_ff_only`, or
+`blocked`, followed by the normal `canonical_checkout ...` safety line.
+Tracked dirty files, detached HEAD, non-`main` branches, missing upstreams,
+unclassified untracked files, and non-fast-forward updates block the lane.
+Recognized untracked runtime/log/prompt/evidence/draft artifacts are moved to
+artifact quarantine with a warning before write-mode git or tracker mutation.
 New lane claims are written as single-line `v=1` key/value audit pointers, for
 example `v=1 lane=main actor=codex worker=codex-manual-main source=manual
 issue=#244 run=... state=active thread=unknown registry=run/...`. Worker display
@@ -192,10 +197,12 @@ targeted child issue reads have had a chance to fill statuses omitted from the
 parent read. This is independent from tracker blocker relationships so native
 subissue changes cannot silently bypass parent dispatch safety.
 
-Live write-mode claim, session, and lane loop commands refuse to run unless the
-canonical checkout is attached to `main` and exactly matches `origin/main` after
-a fetch. They report the blocker and leave git untouched when HEAD is detached,
-the branch is not `main`, or local `main` is stale.
+Live write-mode claim, session, lane loop, review pass/reject, forge rework, and
+workspace ensure commands refuse to run unless the canonical checkout is a clean
+attached `main` checkout with a configured upstream. If local `main` is behind
+and can fast-forward, the CLI performs that canonical-only `ff-only` refresh
+before continuing. It never refreshes issue worktrees or PR branches in this
+path.
 
 PR relationship verification is a lane invariant, not just evidence text. A PR
 URL found in a workpad, issue comment, or local branch can help operators

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -136,9 +136,12 @@ Project v2 issues:
      explicitly allowed, and otherwise compares issue assignees against the
      current `gh` login or selected profile login before claim.
    - Live write-mode claim, session, main loop, review loop, and merge loop
-     commands require the canonical launch checkout to be attached to latest
-     `main`; detached HEAD, non-`main`, or stale `main` states block with
-     operator guidance instead of mutating git.
+     commands require the canonical launch checkout to be clean and attached to
+     `main`. When local `main` is only behind its configured upstream, the CLI
+     fetches and performs a canonical-only `git merge --ff-only` before tracker
+     mutation; dry-runs report `would_ff_only` without changing the checkout.
+     Detached HEAD, non-`main`, missing upstream, dirty/unclassified paths, and
+     non-fast-forward updates block with operator guidance.
    - `main loop` reuses tracker claim helpers to claim only `Todo` / `Rework`,
      resume active `In Progress`, and stop/replan on externally changed states.
    - Main-agent dispatch treats structured tracker blockers as authoritative,
@@ -164,7 +167,8 @@ Project v2 issues:
      `review reject` refuses `Human Review`; both commands require the exact
      current `Review Agent` claim in the evidence file and preserve the field
      as terminal audit evidence.
-   - Review mutating commands hard-stop unless the canonical checkout is clean
+   - Review mutating commands use the same canonical-only `ff-only` pre-write
+     refresh as other lane commands, then hard-stop unless the checkout is clean
      latest `main`; local PR inspection must happen through `workspace show`,
      `workspace adopt`, or `workspace ensure`, not by checking out PR branches
      in the canonical checkout.

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -361,10 +361,15 @@ comment/workpad streams, and rich linked-PR hydration.
 The canonical checkout is only the harness launch directory. Do not use it as a
 Main, Review, or Merge issue worktree, and do not leave runtime state, logs,
 prompts, drafts, or evidence there. `main loop --write`, `review loop --write`,
-and `merge loop --write` check the launch checkout before tracker mutation:
-tracked dirty files block the lane, recognized local artifacts are moved to the
-artifact quarantine with a warning, and unclassified untracked files block until
-the operator moves them to an issue worktree or artifact location.
+and `merge loop --write` refresh and check the launch checkout before tracker
+mutation. From a clean attached `main`, Jade Symphony fetches the configured
+upstream and performs a canonical-only `git merge --ff-only` when local `main`
+is only behind. The terminal output reports
+`canonical_checkout_refresh=already_current`, `ff_only`, `would_ff_only`, or
+`blocked`, then prints the canonical safety line. Tracked dirty files,
+detached HEAD, non-`main`, missing upstream, unclassified untracked files, and
+non-fast-forward updates block until the operator repairs the canonical checkout.
+Recognized local artifacts are moved to artifact quarantine with a warning.
 
 Use `project issue` for per-issue Project status, Project fields, blocker
 relationships, claim locks, rich issue body, workpad/timeline comments, native

--- a/skills/jade-symphony/suite/jade-symphony-human-review/SKILL.md
+++ b/skills/jade-symphony/suite/jade-symphony-human-review/SKILL.md
@@ -130,6 +130,10 @@ Before any PR-specific UAT, verify that the reviewed PR branch contains the
 latest `origin/main`. Run this only from the linked PR/issue worktree, never
 from the canonical `main` checkout.
 
+Jade Symphony write-mode lane commands may now fast-forward the canonical
+checkout before tracker mutation. That is separate control-surface
+synchronization and is not evidence that the reviewed PR branch is fresh.
+
 From the linked PR/issue worktree, run:
 
 ```bash

--- a/skills/jade-symphony/suite/jade-symphony-manual-main/SKILL.md
+++ b/skills/jade-symphony/suite/jade-symphony-manual-main/SKILL.md
@@ -81,6 +81,12 @@ Raw `gh issue view` and `gh pr view` are acceptable for ordinary issue and PR
 content. Raw Project field/status/claim reads or mutations are break-glass only;
 record the reason if they are needed.
 
+Write-mode lane/control commands may automatically refresh the canonical
+checkout when clean local `main` is only behind upstream. That `ff-only` sync is
+allowed control-surface progress. Implementation edits, PR branch freshness, and
+review/merge work still belong in the isolated issue or PR worktree, not in the
+canonical checkout.
+
 ## Selection
 
 Pick the issue only when all are true:

--- a/skills/jade-symphony/suite/jade-symphony-manual-merge/SKILL.md
+++ b/skills/jade-symphony/suite/jade-symphony-manual-merge/SKILL.md
@@ -117,6 +117,12 @@ by default, then continues normal merge selection. It must not adopt manual
 claims, and it must not route merge repair through `Rework`. Use `--no-recover`
 only for debugging or a deliberately conservative operator pass.
 
+Write-mode merge commands may automatically refresh the canonical checkout with
+a canonical-only `git merge --ff-only` when clean local `main` is behind its
+configured upstream. Treat that as control-surface synchronization only. It does
+not refresh PR branches or issue worktrees; those remain merge-lane freshness or
+conflict-repair work.
+
 ## Merging
 
 For `Merging` issues:

--- a/src/canonical_checkout.rs
+++ b/src/canonical_checkout.rs
@@ -36,6 +36,40 @@ impl CanonicalCheckoutReport {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CanonicalCheckoutRefreshMode {
+    Apply,
+    DryRun,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CanonicalCheckoutRefreshAction {
+    AlreadyCurrent,
+    FfOnly,
+    WouldFfOnly,
+}
+
+impl CanonicalCheckoutRefreshAction {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AlreadyCurrent => "already_current",
+            Self::FfOnly => "ff_only",
+            Self::WouldFfOnly => "would_ff_only",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CanonicalCheckoutRefreshReport {
+    pub action: CanonicalCheckoutRefreshAction,
+    pub root: PathBuf,
+    pub upstream: String,
+    pub head_before: String,
+    pub upstream_head: String,
+    pub head_after: String,
+    pub checkout: CanonicalCheckoutReport,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CanonicalUntrackedPath {
     pub path: PathBuf,
@@ -96,6 +130,46 @@ pub enum CanonicalCheckoutError {
         upstream: String,
         upstream_head: String,
     },
+    #[error("canonical checkout refresh is blocked: local `main` in {root} has no upstream. Configure it to track `origin/main` before running a live write lane.")]
+    MissingUpstream { root: PathBuf },
+    #[error("canonical checkout refresh is blocked: {root} is under workflow workspace root {workspace_root}. Run write-mode lane/control commands from the canonical checkout, not an issue worktree.")]
+    IssueWorktree {
+        root: PathBuf,
+        workspace_root: PathBuf,
+    },
+    #[error("canonical checkout refresh failed: git fetch {remote} {branch} failed in {root}: status={status} stdout={stdout} stderr={stderr}")]
+    GitFetchFailed {
+        root: PathBuf,
+        remote: String,
+        branch: String,
+        status: i32,
+        stdout: String,
+        stderr: String,
+    },
+    #[error("canonical checkout refresh failed: git merge-base --is-ancestor {head} {upstream_head} failed in {root}: status={status} stdout={stdout} stderr={stderr}")]
+    GitMergeBaseFailed {
+        root: PathBuf,
+        head: String,
+        upstream_head: String,
+        status: i32,
+        stdout: String,
+        stderr: String,
+    },
+    #[error("canonical checkout refresh is blocked: local `main` at {head} cannot fast-forward to upstream `{upstream}` at {upstream_head}.")]
+    NonFastForward {
+        root: PathBuf,
+        head: String,
+        upstream: String,
+        upstream_head: String,
+    },
+    #[error("canonical checkout refresh failed: git merge --ff-only {upstream} failed in {root}: status={status} stdout={stdout} stderr={stderr}")]
+    GitMergeFailed {
+        root: PathBuf,
+        upstream: String,
+        status: i32,
+        stdout: String,
+        stderr: String,
+    },
     #[error(
         "failed to migrate canonical checkout artifact {artifact_path} to {destination}: {error}"
     )]
@@ -154,18 +228,16 @@ pub fn enforce_clean_canonical_checkout_for_write(
     config: &RuntimeConfig,
 ) -> Result<CanonicalCheckoutReport, CanonicalCheckoutError> {
     let mut report = inspect_canonical_checkout(root, config)?;
-    let head = report.head.as_deref().unwrap_or("unknown").to_string();
-    let Some(branch) = report.branch.as_deref() else {
-        return Err(CanonicalCheckoutError::Detached {
-            root: report.root.clone(),
-            head,
-        });
-    };
-    if branch != "main" {
-        return Err(CanonicalCheckoutError::NonMain {
-            root: report.root.clone(),
-            branch: branch.to_string(),
-        });
+    ensure_not_issue_worktree(&report, config)?;
+    ensure_attached_main(&report)?;
+    ensure_clean_enough_for_write(&report)?;
+    migrate_classified_artifacts(&mut report)?;
+    if !report.migrated.is_empty() {
+        let migrated = report.migrated.clone();
+        report = inspect_canonical_checkout(root, config)?;
+        report.migrated = migrated;
+        ensure_attached_main(&report)?;
+        ensure_clean_enough_for_write(&report)?;
     }
     if let (Some(upstream), Some(upstream_head), Some(head)) = (
         report.upstream.as_deref(),
@@ -181,6 +253,180 @@ pub fn enforce_clean_canonical_checkout_for_write(
             });
         }
     }
+
+    Ok(report)
+}
+
+pub fn refresh_canonical_checkout_before_write(
+    root: &Path,
+    config: &RuntimeConfig,
+    mode: CanonicalCheckoutRefreshMode,
+) -> Result<CanonicalCheckoutRefreshReport, CanonicalCheckoutError> {
+    let mut report = inspect_canonical_checkout(root, config)?;
+    ensure_not_issue_worktree(&report, config)?;
+    ensure_attached_main(&report)?;
+    ensure_clean_enough_for_write(&report)?;
+    let upstream = require_upstream(&report)?;
+
+    if matches!(mode, CanonicalCheckoutRefreshMode::Apply) {
+        migrate_classified_artifacts(&mut report)?;
+        fetch_upstream(&report.root, &upstream)?;
+        let migrated = report.migrated.clone();
+        report = inspect_canonical_checkout(root, config)?;
+        report.migrated = migrated;
+        ensure_attached_main(&report)?;
+        ensure_clean_enough_for_write(&report)?;
+    }
+
+    let head_before = report.head.as_deref().unwrap_or("unknown").to_string();
+    let upstream_head = report
+        .upstream_head
+        .as_deref()
+        .ok_or_else(|| CanonicalCheckoutError::MissingUpstream {
+            root: report.root.clone(),
+        })?
+        .to_string();
+
+    if head_before == upstream_head {
+        return Ok(CanonicalCheckoutRefreshReport {
+            action: CanonicalCheckoutRefreshAction::AlreadyCurrent,
+            root: report.root.clone(),
+            upstream,
+            head_before: head_before.clone(),
+            upstream_head,
+            head_after: head_before,
+            checkout: report,
+        });
+    }
+
+    if !git_can_fast_forward(&report.root, &head_before, &upstream_head)? {
+        return Err(CanonicalCheckoutError::NonFastForward {
+            root: report.root.clone(),
+            head: head_before,
+            upstream,
+            upstream_head,
+        });
+    }
+
+    if matches!(mode, CanonicalCheckoutRefreshMode::DryRun) {
+        return Ok(CanonicalCheckoutRefreshReport {
+            action: CanonicalCheckoutRefreshAction::WouldFfOnly,
+            root: report.root.clone(),
+            upstream,
+            head_before: head_before.clone(),
+            upstream_head,
+            head_after: head_before,
+            checkout: report,
+        });
+    }
+
+    merge_ff_only(&report.root, &upstream)?;
+    let migrated = report.migrated.clone();
+    let mut final_report = enforce_clean_canonical_checkout_for_write(root, config)?;
+    final_report.migrated = migrated;
+    let head_after = final_report
+        .head
+        .as_deref()
+        .unwrap_or("unknown")
+        .to_string();
+
+    Ok(CanonicalCheckoutRefreshReport {
+        action: CanonicalCheckoutRefreshAction::FfOnly,
+        root: final_report.root.clone(),
+        upstream,
+        head_before,
+        upstream_head,
+        head_after,
+        checkout: final_report,
+    })
+}
+
+pub fn canonical_checkout_status_line(report: &CanonicalCheckoutReport) -> String {
+    let unclassified = report.unclassified_untracked().len();
+    format!(
+        "canonical_checkout root={} branch={} upstream={} clean={} tracked_dirty={} untracked={} unclassified={} migrated={} quarantine={}",
+        report.root.display(),
+        report.branch.as_deref().unwrap_or("detached"),
+        report.upstream.as_deref().unwrap_or("none"),
+        report.is_clean(),
+        report.tracked_dirty.len(),
+        report.untracked.len(),
+        unclassified,
+        report.migrated.len(),
+        report.quarantine_root.display()
+    )
+}
+
+pub fn canonical_checkout_refresh_status_line(report: &CanonicalCheckoutRefreshReport) -> String {
+    format!(
+        "canonical_checkout_refresh={} upstream={} head_before={} upstream_head={} head_after={}",
+        report.action.as_str(),
+        report.upstream,
+        report.head_before,
+        report.upstream_head,
+        report.head_after
+    )
+}
+
+pub fn canonical_checkout_warning_lines(report: &CanonicalCheckoutReport) -> Vec<String> {
+    report
+        .migrated
+        .iter()
+        .map(|entry| {
+            format!(
+                "canonical_checkout_migrated kind={} source={} destination={}",
+                entry.kind,
+                entry.source.display(),
+                entry.destination.display()
+            )
+        })
+        .collect()
+}
+
+pub fn canonical_quarantine_root(config: &RuntimeConfig) -> PathBuf {
+    artifact_layout(config)
+        .scratch
+        .join("canonical-checkout-quarantine")
+}
+
+fn ensure_not_issue_worktree(
+    report: &CanonicalCheckoutReport,
+    config: &RuntimeConfig,
+) -> Result<(), CanonicalCheckoutError> {
+    let workspace_root = config
+        .workspace
+        .root
+        .canonicalize()
+        .unwrap_or_else(|_| config.workspace.root.clone());
+    if report.root == workspace_root || report.root.starts_with(&workspace_root) {
+        return Err(CanonicalCheckoutError::IssueWorktree {
+            root: report.root.clone(),
+            workspace_root,
+        });
+    }
+    Ok(())
+}
+
+fn ensure_attached_main(report: &CanonicalCheckoutReport) -> Result<(), CanonicalCheckoutError> {
+    let head = report.head.as_deref().unwrap_or("unknown").to_string();
+    let Some(branch) = report.branch.as_deref() else {
+        return Err(CanonicalCheckoutError::Detached {
+            root: report.root.clone(),
+            head,
+        });
+    };
+    if branch != "main" {
+        return Err(CanonicalCheckoutError::NonMain {
+            root: report.root.clone(),
+            branch: branch.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn ensure_clean_enough_for_write(
+    report: &CanonicalCheckoutReport,
+) -> Result<(), CanonicalCheckoutError> {
     if !report.tracked_dirty.is_empty() {
         return Err(CanonicalCheckoutError::TrackedDirty {
             root: report.root.clone(),
@@ -199,7 +445,22 @@ pub fn enforce_clean_canonical_checkout_for_write(
             paths: unclassified_paths.join(", "),
         });
     }
+    Ok(())
+}
 
+fn require_upstream(report: &CanonicalCheckoutReport) -> Result<String, CanonicalCheckoutError> {
+    report
+        .upstream
+        .clone()
+        .filter(|upstream| !upstream.trim().is_empty())
+        .ok_or_else(|| CanonicalCheckoutError::MissingUpstream {
+            root: report.root.clone(),
+        })
+}
+
+fn migrate_classified_artifacts(
+    report: &mut CanonicalCheckoutReport,
+) -> Result<(), CanonicalCheckoutError> {
     let run_root = report
         .quarantine_root
         .join(format!("run-{}", unix_timestamp_ms()));
@@ -226,45 +487,73 @@ pub fn enforce_clean_canonical_checkout_for_write(
     if !report.migrated.is_empty() {
         write_manifest(&run_root, &report.migrated)?;
     }
-
-    Ok(report)
+    Ok(())
 }
 
-pub fn canonical_checkout_status_line(report: &CanonicalCheckoutReport) -> String {
-    let unclassified = report.unclassified_untracked().len();
-    format!(
-        "canonical_checkout root={} branch={} upstream={} clean={} tracked_dirty={} untracked={} unclassified={} migrated={} quarantine={}",
-        report.root.display(),
-        report.branch.as_deref().unwrap_or("detached"),
-        report.upstream.as_deref().unwrap_or("none"),
-        report.is_clean(),
-        report.tracked_dirty.len(),
-        report.untracked.len(),
-        unclassified,
-        report.migrated.len(),
-        report.quarantine_root.display()
-    )
+fn fetch_upstream(root: &Path, upstream: &str) -> Result<(), CanonicalCheckoutError> {
+    let (remote, branch) =
+        upstream
+            .split_once('/')
+            .ok_or_else(|| CanonicalCheckoutError::MissingUpstream {
+                root: root.to_path_buf(),
+            })?;
+    let output = Command::new("git")
+        .args(["fetch", remote, branch])
+        .current_dir(root)
+        .output()?;
+    if !output.status.success() {
+        return Err(CanonicalCheckoutError::GitFetchFailed {
+            root: root.to_path_buf(),
+            remote: remote.into(),
+            branch: branch.into(),
+            status: output.status.code().unwrap_or(-1),
+            stdout: single_line(&String::from_utf8_lossy(&output.stdout)),
+            stderr: single_line(&String::from_utf8_lossy(&output.stderr)),
+        });
+    }
+    Ok(())
 }
 
-pub fn canonical_checkout_warning_lines(report: &CanonicalCheckoutReport) -> Vec<String> {
-    report
-        .migrated
-        .iter()
-        .map(|entry| {
-            format!(
-                "canonical_checkout_migrated kind={} source={} destination={}",
-                entry.kind,
-                entry.source.display(),
-                entry.destination.display()
-            )
-        })
-        .collect()
+fn git_can_fast_forward(
+    root: &Path,
+    head: &str,
+    upstream_head: &str,
+) -> Result<bool, CanonicalCheckoutError> {
+    let output = Command::new("git")
+        .args(["merge-base", "--is-ancestor", head, upstream_head])
+        .current_dir(root)
+        .output()?;
+    if output.status.success() {
+        return Ok(true);
+    }
+    if output.status.code() == Some(1) {
+        return Ok(false);
+    }
+    Err(CanonicalCheckoutError::GitMergeBaseFailed {
+        root: root.to_path_buf(),
+        head: head.into(),
+        upstream_head: upstream_head.into(),
+        status: output.status.code().unwrap_or(-1),
+        stdout: single_line(&String::from_utf8_lossy(&output.stdout)),
+        stderr: single_line(&String::from_utf8_lossy(&output.stderr)),
+    })
 }
 
-pub fn canonical_quarantine_root(config: &RuntimeConfig) -> PathBuf {
-    artifact_layout(config)
-        .scratch
-        .join("canonical-checkout-quarantine")
+fn merge_ff_only(root: &Path, upstream: &str) -> Result<(), CanonicalCheckoutError> {
+    let output = Command::new("git")
+        .args(["merge", "--ff-only", upstream])
+        .current_dir(root)
+        .output()?;
+    if !output.status.success() {
+        return Err(CanonicalCheckoutError::GitMergeFailed {
+            root: root.to_path_buf(),
+            upstream: upstream.into(),
+            status: output.status.code().unwrap_or(-1),
+            stdout: single_line(&String::from_utf8_lossy(&output.stdout)),
+            stderr: single_line(&String::from_utf8_lossy(&output.stderr)),
+        });
+    }
+    Ok(())
 }
 
 enum GitStatusEntry {
@@ -451,6 +740,10 @@ fn write_manifest(
     Ok(())
 }
 
+fn single_line(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 fn unix_timestamp_ms() -> u128 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -508,6 +801,235 @@ mod tests {
             .current_dir(path)
             .status()
             .unwrap();
+    }
+
+    fn git_ok(path: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|error| panic!("git {args:?} failed to start: {error}"));
+        assert!(
+            output.status.success(),
+            "git {:?} failed\nstdout={}\nstderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_head(path: &Path) -> String {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_repo_with_origin(root: &Path) -> (PathBuf, PathBuf) {
+        init_repo_with_origin_at(root, "repo")
+    }
+
+    fn init_repo_with_origin_at(root: &Path, repo_rel: &str) -> (PathBuf, PathBuf) {
+        let remote = root.join("origin.git");
+        let repo = root.join(repo_rel);
+        git_ok(
+            root,
+            &["init", "--bare", "--initial-branch=main", "origin.git"],
+        );
+        if let Some(parent) = repo.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        git_ok(
+            root,
+            &["init", "--initial-branch=main", repo.to_str().unwrap()],
+        );
+        git_ok(&repo, &["config", "user.email", "test@example.com"]);
+        git_ok(&repo, &["config", "user.name", "Test User"]);
+        fs::write(repo.join("tracked.txt"), "clean\n").unwrap();
+        git_ok(&repo, &["add", "tracked.txt"]);
+        git_ok(&repo, &["commit", "-qm", "init"]);
+        git_ok(
+            &repo,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        git_ok(&repo, &["push", "-u", "origin", "main"]);
+        (repo, remote)
+    }
+
+    fn advance_remote(root: &Path, remote: &Path, file: &str, text: &str) -> String {
+        let other = root.join(format!("other-{}", safe_identifier(file)));
+        git_ok(
+            root,
+            &["clone", remote.to_str().unwrap(), other.to_str().unwrap()],
+        );
+        git_ok(&other, &["config", "user.email", "test@example.com"]);
+        git_ok(&other, &["config", "user.name", "Test User"]);
+        fs::write(other.join(file), text).unwrap();
+        git_ok(&other, &["add", file]);
+        git_ok(&other, &["commit", "-qm", "advance main"]);
+        git_ok(&other, &["push", "origin", "main"]);
+        git_head(&other)
+    }
+
+    #[test]
+    fn refresh_reports_already_current() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, _remote) = init_repo_with_origin(temp.path());
+
+        let report = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap();
+
+        assert_eq!(
+            report.action,
+            CanonicalCheckoutRefreshAction::AlreadyCurrent
+        );
+        assert!(canonical_checkout_refresh_status_line(&report)
+            .contains("canonical_checkout_refresh=already_current"));
+        assert_eq!(report.head_before, report.head_after);
+    }
+
+    #[test]
+    fn refresh_fast_forwards_clean_main_behind_origin() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, remote) = init_repo_with_origin(temp.path());
+        let remote_head = advance_remote(temp.path(), &remote, "CHANGELOG.md", "change\n");
+
+        let report = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap();
+
+        assert_eq!(report.action, CanonicalCheckoutRefreshAction::FfOnly);
+        assert_eq!(report.head_after, remote_head);
+        assert_eq!(git_head(&repo), remote_head);
+    }
+
+    #[test]
+    fn refresh_dry_run_reports_would_ff_only_without_changing_head() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, remote) = init_repo_with_origin(temp.path());
+        advance_remote(temp.path(), &remote, "CHANGELOG.md", "change\n");
+        git_ok(&repo, &["fetch", "origin", "main"]);
+        let before = git_head(&repo);
+
+        let report = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::DryRun,
+        )
+        .unwrap();
+
+        assert_eq!(report.action, CanonicalCheckoutRefreshAction::WouldFfOnly);
+        assert_eq!(git_head(&repo), before);
+        assert_eq!(report.head_after, before);
+    }
+
+    #[test]
+    fn refresh_blocks_dirty_canonical_checkout() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, _remote) = init_repo_with_origin(temp.path());
+        fs::write(repo.join("tracked.txt"), "dirty\n").unwrap();
+
+        let error = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("tracked dirty files"));
+    }
+
+    #[test]
+    fn refresh_blocks_non_main_canonical_checkout() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, _remote) = init_repo_with_origin(temp.path());
+        git_ok(&repo, &["checkout", "-q", "-b", "feature/test"]);
+
+        let error = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("instead of `main`"));
+    }
+
+    #[test]
+    fn refresh_blocks_detached_canonical_checkout() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, _remote) = init_repo_with_origin(temp.path());
+        let head = git_head(&repo);
+        git_ok(&repo, &["checkout", "-q", "--detach", &head]);
+
+        let error = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("detached"));
+    }
+
+    #[test]
+    fn refresh_blocks_missing_upstream() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        init_repo(&repo);
+
+        let error = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("has no upstream"));
+    }
+
+    #[test]
+    fn refresh_blocks_issue_worktree_under_workspace_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, _remote) = init_repo_with_origin_at(temp.path(), "worktrees/issue-344");
+
+        let error = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("workflow workspace root"));
+    }
+
+    #[test]
+    fn refresh_blocks_non_fast_forward_update() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, remote) = init_repo_with_origin(temp.path());
+        fs::write(repo.join("local.txt"), "local\n").unwrap();
+        git_ok(&repo, &["add", "local.txt"]);
+        git_ok(&repo, &["commit", "-qm", "local change"]);
+        advance_remote(temp.path(), &remote, "remote.txt", "remote\n");
+
+        let error = refresh_canonical_checkout_before_write(
+            &repo,
+            &config(temp.path()),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("cannot fast-forward"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,9 @@ use jade_symphony::agent::{
 };
 use jade_symphony::artifacts::{artifact_layout, cleanup_plan, ArtifactClass, CleanupPlan};
 use jade_symphony::canonical_checkout::{
-    canonical_checkout_status_line, canonical_checkout_warning_lines, canonical_quarantine_root,
-    enforce_clean_canonical_checkout_for_write, inspect_canonical_checkout,
+    canonical_checkout_refresh_status_line, canonical_checkout_status_line,
+    canonical_checkout_warning_lines, canonical_quarantine_root, inspect_canonical_checkout,
+    refresh_canonical_checkout_before_write, CanonicalCheckoutRefreshMode,
 };
 use jade_symphony::config::RuntimeConfig;
 use jade_symphony::doctor::{
@@ -2331,6 +2332,7 @@ fn forge_rework(options: ForgeReworkOptions) -> Result<(), Box<dyn std::error::E
     }
     let dry_run = !write || dry_run;
     let config = load_config(&workflow_path)?;
+    preflight_canonical_checkout_for_write_mode(&config, "forge rework", write)?;
     let adapter = adapter_from_config(&config);
     forge_rework_with_adapter(
         &config,
@@ -3095,9 +3097,7 @@ fn review_claim(
     write: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = load_config(&workflow_path)?;
-    if write {
-        enforce_canonical_checkout_before_write(&config, "review claim")?;
-    }
+    preflight_canonical_checkout_for_write_mode(&config, "review claim", write)?;
     let adapter = adapter_from_config(&config);
     let issue = adapter
         .get_issue(&issue_ref)?
@@ -3183,9 +3183,11 @@ fn lane_claim_command(
     }
 
     let config = load_config(&workflow_path)?;
-    if write {
-        enforce_canonical_checkout_before_write(&config, &format!("{} claim", lane.label()))?;
-    }
+    preflight_canonical_checkout_for_write_mode(
+        &config,
+        &format!("{} claim", lane.label()),
+        write,
+    )?;
 
     let adapter = adapter_from_config(&config);
     let issue = adapter
@@ -3452,9 +3454,7 @@ fn review_manual_pass(
     write: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = load_config(&workflow_path)?;
-    if write {
-        enforce_canonical_checkout_before_write(&config, "review pass")?;
-    }
+    preflight_canonical_checkout_for_write_mode(&config, "review pass", write)?;
     let adapter = adapter_from_config(&config);
     let issue = adapter
         .get_issue(&issue_ref)?
@@ -3585,9 +3585,7 @@ fn review_manual_reject(
     }
 
     let config = load_config(&workflow_path)?;
-    if write {
-        enforce_canonical_checkout_before_write(&config, "review reject")?;
-    }
+    preflight_canonical_checkout_for_write_mode(&config, "review reject", write)?;
     let adapter = adapter_from_config(&config);
     let issue = adapter
         .get_issue(&issue_ref)?
@@ -4021,9 +4019,7 @@ fn review_loop(options: ReviewLoopOptions) -> Result<(), Box<dyn std::error::Err
         let workflow = WorkflowDefinition::load(&options.workflow_path)?;
         let config = RuntimeConfig::from_workflow(&workflow, &options.workflow_path)?;
         config.validate()?;
-        if options.write {
-            enforce_canonical_checkout_before_write(&config, "review_loop")?;
-        }
+        preflight_canonical_checkout_for_write_mode(&config, "review_loop", options.write)?;
         let adapter = adapter_from_config(&config);
         let issues = adapter
             .fetch_issues_by_states(std::slice::from_ref(&config.tracker.state_map.agent_review))?;
@@ -4454,8 +4450,8 @@ fn merge_once_tick(
     let workflow = WorkflowDefinition::load(&workflow_path)?;
     let config = RuntimeConfig::from_workflow(&workflow, &workflow_path)?;
     config.validate()?;
-    if write && config.tracker.fixture_path.is_none() {
-        enforce_canonical_checkout_before_write(&config, "merge_loop")?;
+    if config.tracker.fixture_path.is_none() {
+        preflight_canonical_checkout_for_write_mode(&config, "merge_loop", write)?;
     }
     let _merge_prompt = workflow.prompt_for_lane(AgentLane::MergeAgent);
 
@@ -5293,9 +5289,7 @@ fn agent_session_start(
     let config = RuntimeConfig::from_workflow(&workflow, &workflow_path)?;
     config.validate()?;
     validate_tmux_session_config(&config)?;
-    if write {
-        enforce_canonical_checkout_before_write(&config, "session start")?;
-    }
+    preflight_canonical_checkout_for_write_mode(&config, "session start", write)?;
 
     let adapter = adapter_from_config(&config);
     let issue = adapter
@@ -8054,9 +8048,7 @@ fn workspace_ensure(
     write: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = load_config(&workflow_path)?;
-    if write {
-        enforce_canonical_checkout_before_write(&config, "workspace ensure")?;
-    }
+    preflight_canonical_checkout_for_write_mode(&config, "workspace ensure", write)?;
 
     let adapter = adapter_from_config(&config);
     let issue = adapter
@@ -8856,12 +8848,71 @@ fn enforce_canonical_checkout_before_write(
     command: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let root = std::env::current_dir()?;
-    let report = enforce_clean_canonical_checkout_for_write(&root, config)?;
-    println!("{}", canonical_checkout_status_line(&report));
-    for line in canonical_checkout_warning_lines(&report) {
-        println!("{command}_{line}");
+    match refresh_canonical_checkout_before_write(
+        &root,
+        config,
+        CanonicalCheckoutRefreshMode::Apply,
+    ) {
+        Ok(refresh) => {
+            println!("{}", canonical_checkout_refresh_status_line(&refresh));
+            println!("{}", canonical_checkout_status_line(&refresh.checkout));
+            for line in canonical_checkout_warning_lines(&refresh.checkout) {
+                println!("{command}_{line}");
+            }
+            Ok(())
+        }
+        Err(error) => {
+            println!(
+                "canonical_checkout_refresh=blocked command={} reason=\"{}\"",
+                shell_quote_display(command),
+                single_line(&error.to_string())
+            );
+            Err(error.into())
+        }
     }
-    Ok(())
+}
+
+fn preview_canonical_checkout_before_dry_run(config: &RuntimeConfig, command: &str) {
+    let Ok(root) = std::env::current_dir() else {
+        println!(
+            "canonical_checkout_refresh=blocked command={} reason=\"current directory unavailable\"",
+            shell_quote_display(command)
+        );
+        return;
+    };
+    match refresh_canonical_checkout_before_write(
+        &root,
+        config,
+        CanonicalCheckoutRefreshMode::DryRun,
+    ) {
+        Ok(refresh) => {
+            println!("{}", canonical_checkout_refresh_status_line(&refresh));
+            println!("{}", canonical_checkout_status_line(&refresh.checkout));
+            for line in canonical_checkout_warning_lines(&refresh.checkout) {
+                println!("{command}_{line}");
+            }
+        }
+        Err(error) => {
+            println!(
+                "canonical_checkout_refresh=blocked command={} reason=\"{}\"",
+                shell_quote_display(command),
+                single_line(&error.to_string())
+            );
+        }
+    }
+}
+
+fn preflight_canonical_checkout_for_write_mode(
+    config: &RuntimeConfig,
+    command: &str,
+    write: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if write {
+        enforce_canonical_checkout_before_write(config, command)
+    } else {
+        preview_canonical_checkout_before_dry_run(config, command);
+        Ok(())
+    }
 }
 
 fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
@@ -8884,8 +8935,8 @@ fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error::Error>> {
         let max_concurrent = options.worker_limit(&config);
         if options.write {
             ensure_write_mode_main_agent_backend(&options.workflow_path, &config, "main loop")?;
-            enforce_canonical_checkout_before_write(&config, "run_loop")?;
         }
+        preflight_canonical_checkout_for_write_mode(&config, "run_loop", options.write)?;
         let adapter = adapter_from_config(&config);
         let mut active_main_workers = 0usize;
         let mut recoverable_runtime_states = Vec::new();

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -19,6 +19,14 @@ cargo run -- session start workflows/jade-symphony.md '#123' --lane main --run <
 cargo run -- session list workflows/jade-symphony.md
 ```
 
+Write-mode lane/control commands are safe to run from the canonical checkout on
+`main` even when local `main` is only behind `origin/main`: before tracker
+mutation, Jade Symphony fetches the configured upstream and performs a
+canonical-only `git merge --ff-only`. Dry-runs report `would_ff_only` without
+changing the checkout. Dirty, detached, non-`main`, missing-upstream, and
+non-fast-forward cases still fail closed; issue worktrees and PR branches are
+not refreshed by this path.
+
 Main Agent execution uses the local `tmux` backend. A bounded write tick creates
 an attachable session, prints `tmux attach-session -t ...`, records the session
 log path, persists a session registry record, and leaves the issue active until


### PR DESCRIPTION
## Summary

- Adds a shared canonical checkout pre-write refresh helper that fetches upstream, fast-forwards clean attached `main` with `git merge --ff-only`, and reports `already_current`, `ff_only`, `would_ff_only`, or `blocked`.
- Wires the helper through write-mode lane/control commands including Main/Review/Merge loops, manual lane claims, review pass/reject, forge rework, session start, and workspace ensure.
- Updates operator docs and Jade Symphony skills to describe canonical-only progress synchronization and keep PR branch freshness separate.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Focused canonical checkout tests cover already-current, clean behind, dry-run `would_ff_only`, dirty, non-main, detached, missing-upstream, issue-worktree, and non-ff blockers.
- UAT: ran the issue-branch binary from the clean canonical checkout with `main loop --max-iterations 1 --dry-run`; output began with `canonical_checkout_refresh=already_current` and the normal readable canonical checkout safety line.

Main implementation stops at `Agent Review`; review approval and merging remain separate lanes.

Closes #344
