### PR TITLE
#388: Add bounded app-server live smoke gate before autopilot dogfood

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -242,15 +242,22 @@ the current PR body but appends a missing `Closes #<issue>` reference before
 readback so GitHub can establish a native issue/PR relationship instead of
 relying only on a timeline comment.
 
-The canonical `workflows/jade-symphony.md` file uses the local `tmux` main-agent
-backend. A launched tmux session records its session name, log path, workspace,
-branch, attach command, prompt artifact, actor, lane, attempt, and running
-status in a durable session registry under the configured artifact root. The
-registry is terminal-session evidence only; tracker state remains the issue
-lifecycle source of truth. The issue stays in the active main lane until later
-completion evidence satisfies the existing handoff rules. On later ticks,
-`main loop --write` probes the runtime state's recorded session through the
-session registry plus bounded tmux pane/log evidence before launching anything
+The canonical Main runtime is Codex app-server: `main_lane.backend: codex` plus
+`codex.command: codex app-server` and `codex.approval_policy: never`, matching
+the current local app-server approval-policy schema. `main loop --write` records prompt,
+protocol, stderr, normalized-event, runtime-state, and session-registry
+evidence for that app-server turn before any `Agent Review` handoff. If
+`main_lane.backend: tmux` is selected as explicit fallback/debug, the tmux path
+records its session name, log path, workspace, branch, attach command, prompt
+artifact, actor, lane, attempt, and running status in the durable session
+registry under the configured artifact root. It still captures the pane before
+prompt injection and may auto-advance the Codex workspace trust prompt only
+inside the configured Jade Symphony issue worktree root. Set
+`JADE_SYMPHONY_TMUX_AUTO_TRUST=0` to opt out; a visible trust prompt or missing
+readiness then fails closed and preserves attach/log evidence for inspection.
+The registry is runtime evidence only; tracker state remains the issue lifecycle
+source of truth. On later ticks,
+`main loop --write` probes runtime/session evidence before launching anything
 new. Completed sessions continue through verification, PR publication,
 linked-PR readback, PR readiness, and `Agent Review` handoff; active, waiting,
 unknown, or missing-registry sessions are preserved without launching a
@@ -259,19 +266,10 @@ classified as interrupted or unavailable. Recover-first handling is enabled by
 default for `--write` and can be disabled with `--no-recover`. If an operator
 overrides the workflow back to `main_lane.backend: dry-run`, `main loop --write`
 exits non-zero before loading runtime state, creating worktrees, claiming
-Project fields, or writing workpads.
-
-The canonical Main runtime is Codex app-server: `main_lane.backend: codex` plus
-`codex.command: codex app-server` and `codex.approval_policy: never`, matching
-the current local app-server approval-policy schema. `main loop --write` records prompt,
-protocol, stderr, normalized-event, runtime-state, and session-registry
-evidence for that app-server turn before any `Agent Review` handoff. If
-`main_lane.backend: tmux` is selected as explicit fallback/debug, the tmux path
-captures the pane before prompt injection and may auto-advance the Codex
-workspace trust prompt only inside the configured Jade Symphony issue worktree
-root. Set `JADE_SYMPHONY_TMUX_AUTO_TRUST=0` to opt out; a visible trust prompt
-or missing readiness then fails closed and preserves attach/log evidence for
-inspection.
+Project fields, or writing workpads. The dry-run preflight prints the selected
+Main backend, backend source, command, approval policy, and session-registry
+path so a bounded post-merge app-server smoke can stop before write mode if the
+selected issue or backend is unexpected.
 
 For manual lane recovery, first claim the lane and keep the printed `run=`.
 Then `session start WORKFLOW ISSUE --lane main|review|merge --run RUN --write`

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -159,6 +159,48 @@ If an operator switches the workflow back to `main_lane.backend: dry-run`, the
 mutating tick exits before runtime-state writes, worktree creation, Project
 claims, or workpad mutation.
 
+## Post-Merge App-Server Smoke Gate
+
+Before using #359 or another broader autopilot dogfood issue for a long-running
+write-mode run, perform one bounded Main-lane app-server smoke after #367 is
+`Done` and visible on canonical `main`. This is an evidence gate, not a
+production-readiness claim.
+
+Start with readback and dry-run preflight:
+
+```bash
+target/debug/jade-symphony project issue workflows/jade-symphony.md '#367' --json
+target/debug/jade-symphony project issue workflows/jade-symphony.md '#388' --json
+target/debug/jade-symphony debug workflows/jade-symphony.md
+target/debug/jade-symphony main loop workflows/jade-symphony.md --max-iterations 1 --dry-run
+```
+
+The preflight must show that #367 is terminal, #388's structured blocker is no
+longer active, the selected Main issue is expected, and the Main backend line
+reports `backend=codex`, `backend_source=codex-app-server`,
+`approval_policy=never`, and `app_server_live_smoke_ready=true`. If the dry-run
+selects an unsafe or surprising issue, stop there and record the mismatch as
+operator-blocked smoke evidence.
+
+Only then run the bounded live tick:
+
+```bash
+target/debug/jade-symphony main loop workflows/jade-symphony.md --max-iterations 1 --write
+```
+
+A passing smoke leaves citeable evidence in the selected issue's Main Workpad,
+the PR handoff/readiness evidence, runtime state or reconciled session registry,
+the prompt/protocol/stderr/normalized-event app-server artifacts, `status`, and
+`doctor` readback. The smoke is sufficient for #359 or the next dogfood plan to
+cite "one bounded Main app-server write path completed with durable evidence";
+it does not prove merge-agent repair behavior, unattended overnight resilience,
+quota resilience, or full app-server production readiness. Merge-agent
+app-server smoke remains deferred until a natural repair candidate exists.
+
+Backend, auth, quota, GitHub API, or schema failures must be classified in the
+workpad or timeline evidence. Treat them as blocked/retry guidance, not as a
+passing app-server smoke.
+
 ## Evidence Timeline
 
 Jade Symphony uses two issue-comment evidence surfaces:

--- a/src/main.rs
+++ b/src/main.rs
@@ -7629,6 +7629,33 @@ fn debug_report(workflow_path: PathBuf) -> Result<(), Box<dyn std::error::Error>
         "integration_gap_warning_count={}",
         dogfood_gap_report.warnings.len()
     );
+    let smoke_gate = main_app_server_smoke_gate(&config);
+    println!("main_backend={}", smoke_gate.backend);
+    println!("main_backend_source={}", smoke_gate.backend_source);
+    println!(
+        "main_backend_command={}",
+        shell_quote_display(&smoke_gate.command)
+    );
+    println!(
+        "main_backend_approval_policy={}",
+        smoke_gate.approval_policy
+    );
+    println!(
+        "app_server_live_smoke_ready={}",
+        smoke_gate.app_server_live_smoke_ready
+    );
+    println!(
+        "app_server_live_smoke_reason={}",
+        smoke_gate.app_server_live_smoke_reason
+    );
+    println!(
+        "app_server_live_smoke_dry_run_command=\"cargo run -- main loop {} --max-iterations 1 --dry-run\"",
+        workflow_path.display()
+    );
+    println!(
+        "app_server_live_smoke_write_command=\"cargo run -- main loop {} --max-iterations 1 --write\"",
+        workflow_path.display()
+    );
     println!("supervised_ready={supervised_ready}");
     println!("unattended_ready=false");
     println!("unattended_reason=Jade Symphony CLI still requires supervised lane commands for dogfood and repair decisions.");
@@ -8829,6 +8856,79 @@ fn dogfood_integration_gap_severity(gap: &str) -> DogfoodIntegrationGapSeverity 
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MainAppServerSmokeGate {
+    backend: String,
+    backend_source: String,
+    command: String,
+    approval_policy: String,
+    app_server_live_smoke_ready: bool,
+    app_server_live_smoke_reason: String,
+}
+
+fn main_app_server_smoke_gate(config: &RuntimeConfig) -> MainAppServerSmokeGate {
+    match config.backend.kind.as_str() {
+        "codex" if config.codex.command.contains("app-server") => MainAppServerSmokeGate {
+            backend: config.backend.kind.clone(),
+            backend_source: "codex-app-server".into(),
+            command: config.codex.command.clone(),
+            approval_policy: codex_approval_policy_label(config),
+            app_server_live_smoke_ready: true,
+            app_server_live_smoke_reason:
+                "main_lane.backend=codex and codex.command includes app-server".into(),
+        },
+        "codex" => MainAppServerSmokeGate {
+            backend: config.backend.kind.clone(),
+            backend_source: "codex-subprocess".into(),
+            command: config.codex.command.clone(),
+            approval_policy: codex_approval_policy_label(config),
+            app_server_live_smoke_ready: false,
+            app_server_live_smoke_reason: "codex command does not select the app-server transport"
+                .into(),
+        },
+        "tmux" => MainAppServerSmokeGate {
+            backend: config.backend.kind.clone(),
+            backend_source: "tmux-fallback".into(),
+            command: config
+                .tmux
+                .main_agent_command
+                .clone()
+                .unwrap_or_else(|| config.tmux.agent_command.clone()),
+            approval_policy: "n/a".into(),
+            app_server_live_smoke_ready: false,
+            app_server_live_smoke_reason:
+                "tmux is explicit fallback/debug and is not the app-server smoke path".into(),
+        },
+        "dry-run" => MainAppServerSmokeGate {
+            backend: config.backend.kind.clone(),
+            backend_source: "dry-run".into(),
+            command: "dry-run".into(),
+            approval_policy: "n/a".into(),
+            app_server_live_smoke_ready: false,
+            app_server_live_smoke_reason: "dry-run backend cannot perform a live app-server smoke"
+                .into(),
+        },
+        other => MainAppServerSmokeGate {
+            backend: config.backend.kind.clone(),
+            backend_source: other.into(),
+            command: other.into(),
+            approval_policy: "n/a".into(),
+            app_server_live_smoke_ready: false,
+            app_server_live_smoke_reason:
+                "configured Main backend is not the Codex app-server runtime".into(),
+        },
+    }
+}
+
+fn codex_approval_policy_label(config: &RuntimeConfig) -> String {
+    config
+        .codex
+        .approval_policy
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| config.codex.approval_policy.to_string())
+}
+
 fn is_controlled_dogfood_smoke_issue(issue: &TrackerIssue) -> bool {
     issue
         .labels_lowercase()
@@ -9585,6 +9685,17 @@ fn print_run_loop_write_selection(
             slot_index + 1
         );
     }
+    let smoke_gate = main_app_server_smoke_gate(config);
+    println!(
+        "run_loop_action=backend issue={} backend={} backend_source={} command={} approval_policy={} app_server_live_smoke_ready={} session_registry={}",
+        issue.identifier,
+        smoke_gate.backend,
+        smoke_gate.backend_source,
+        shell_quote_display(&smoke_gate.command),
+        smoke_gate.approval_policy,
+        smoke_gate.app_server_live_smoke_ready,
+        session_registry_path(config).display()
+    );
 }
 
 fn run_loop_dispatch_write_candidate(
@@ -13285,6 +13396,7 @@ fn print_run_loop_dry_run_actions(
     config: &RuntimeConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let profile = selected_execution_profile(&config.profiles)?;
+    let smoke_gate = main_app_server_smoke_gate(config);
     if normalize_state(&issue.state) != "in progress" {
         println!(
             "run_loop_dry_run action=claim issue={} target_state=in_progress",
@@ -13309,8 +13421,14 @@ fn print_run_loop_dry_run_actions(
         config.identity.git.author()
     );
     println!(
-        "run_loop_dry_run action=run issue={} backend=configured",
-        issue.identifier
+        "run_loop_dry_run action=run issue={} backend={} backend_source={} command={} approval_policy={} app_server_live_smoke_ready={} session_registry={}",
+        issue.identifier,
+        smoke_gate.backend,
+        smoke_gate.backend_source,
+        shell_quote_display(&smoke_gate.command),
+        smoke_gate.approval_policy,
+        smoke_gate.app_server_live_smoke_ready,
+        session_registry_path(config).display()
     );
     if let Some(profile) = profile {
         println!(
@@ -18058,6 +18176,45 @@ mod tests {
         issue.labels.clear();
         issue.title = "[dogfood-smoke] controlled run".into();
         assert!(is_controlled_dogfood_smoke_issue(&issue));
+    }
+
+    #[test]
+    fn main_app_server_smoke_gate_is_ready_for_codex_app_server() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nmain_lane:\n  backend: codex\ncodex:\n  command: /opt/homebrew/bin/codex app-server\n  approval_policy: never\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        let gate = main_app_server_smoke_gate(&config);
+
+        assert_eq!(gate.backend, "codex");
+        assert_eq!(gate.backend_source, "codex-app-server");
+        assert_eq!(gate.command, "/opt/homebrew/bin/codex app-server");
+        assert_eq!(gate.approval_policy, "never");
+        assert!(gate.app_server_live_smoke_ready);
+    }
+
+    #[test]
+    fn main_app_server_smoke_gate_rejects_non_app_server_codex() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nmain_lane:\n  backend: codex\ncodex:\n  command: codex exec\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        let gate = main_app_server_smoke_gate(&config);
+
+        assert_eq!(gate.backend, "codex");
+        assert_eq!(gate.backend_source, "codex-subprocess");
+        assert!(!gate.app_server_live_smoke_ready);
+        assert!(gate
+            .app_server_live_smoke_reason
+            .contains("does not select the app-server"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Implements #388: Add bounded app-server live smoke gate before autopilot dogfood.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #388
