### PR TITLE
#364: Add Forge and Project relationship support for blockers and native subissues

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -108,6 +108,18 @@ and rich linked-PR hydration. Use `project issue '#<issue>' --json` or
 workpad/timeline comments, linked PR readback, or detailed native topology
 evidence for one issue.
 
+Structured GitHub issue relationships have a small read/write surface under
+`project relationship`. `list` and `verify` are read-only and accept `--dry-run`
+for operator habit without requiring `--write`. Mutating commands require
+`--write` and verify readback after adding the native relationship:
+
+```bash
+cargo run -- project relationship list workflows/shea-symphony.md '#123' --dry-run
+cargo run -- project relationship verify workflows/shea-symphony.md '#123' --blocked-by '#122' --subissue '#124'
+cargo run -- project relationship add-blocked-by workflows/shea-symphony.md '#123' '#122' --write
+cargo run -- project relationship add-subissue workflows/shea-symphony.md '#120' '#123' --write
+```
+
 ## Long-Running Command Progress
 
 Live commands that wait longer than the centralized heartbeat threshold emit
@@ -463,8 +475,8 @@ cargo run -- project inspect workflows/shea-symphony.md '#123'
 | Command | Purpose | Boundary |
 | --- | --- | --- |
 | `forge validate` | Validate a body file, an existing issue, or candidate title/body content against live issue context for `Backlog` or `Todo`. | Read-only; `Todo` uses the full Issue Quality Gate, `Backlog` uses the lighter seed gate; output separates candidate contract gaps from live context gaps. |
-| `forge create` | Create a Project-backed issue in `Backlog` or `Todo`. | Dry-run by default unless `--write` is supplied; initializes the Project item to the requested status and verifies readback; write success keeps `issue_id` and adds readback issue number, URL, and `project_status` when the tracker provides them; live `Todo` creation requires `--assignee`. |
-| `forge promote` | Promote one existing Backlog issue in place by editing title/body, writing a structured Promotion Note comment, then moving it to `Todo`. | Dry-run by default unless `--write` is supplied; requires structured note inputs, keeps the `Todo` status mutation last, and reports the checkpoint where any failure stopped. |
+| `forge create` | Create a Project-backed issue in `Backlog` or `Todo`. | Dry-run by default unless `--write` is supplied; initializes the Project item to the requested status and verifies readback; write success keeps `issue_id` and adds readback issue number, URL, and `project_status` when the tracker provides them; live `Todo` creation requires `--assignee`; `--blocked-by` and `--parent` declare native relationship writes that must be read back before final `Todo` status. |
+| `forge promote` | Promote one existing Backlog issue in place by editing title/body, writing a structured Promotion Note comment, then moving it to `Todo`. | Dry-run by default unless `--write` is supplied; requires structured note inputs, keeps the `Todo` status mutation last, reports the checkpoint where any failure stopped, and can satisfy blocker/parent gates through `--blocked-by` / `--parent` relationship plans. |
 | `forge rework` | Revise one live `Human Review` issue into an explicit `Rework` contract. | Dry-run by default unless `--write` is supplied; requires a replacement title/body, evidence file, and operator confirmation; rejects active lane claims and keeps the `Rework` status mutation last. |
 
 Examples:
@@ -475,7 +487,9 @@ cargo run -- forge validate --workflow workflows/shea-symphony.md --status Todo 
 cargo run -- forge validate --workflow workflows/shea-symphony.md --issue '#293' --status Todo --title "Candidate promoted title" --body-file /tmp/candidate.md
 cargo run -- forge create --workflow workflows/shea-symphony.md --status Backlog --title "Backlog: follow-up title" --body-file /tmp/issue.md --dry-run
 cargo run -- forge create --workflow workflows/shea-symphony.md --status Todo --title "Follow-up title" --body-file /tmp/issue.md --assignee Alive24 --write
+cargo run -- forge create --workflow workflows/shea-symphony.md --status Todo --title "Blocked follow-up title" --body-file /tmp/issue.md --assignee Alive24 --blocked-by '#122' --dry-run
 cargo run -- forge promote '#241' --workflow workflows/shea-symphony.md --title "Executable title" --body-file /tmp/issue.md --operator-confirmation "promote it" --decision "Use the CLI-owned promotion note template." --scope-change "Backlog seed is now an executable Todo issue." --dependency-context "Dependencies: none; related context is non-blocking." --readback-summary "Operator confirmed the dry-run preview before write." --dry-run
+cargo run -- forge promote '#241' --workflow workflows/shea-symphony.md --title "Executable title" --body-file /tmp/issue.md --operator-confirmation "promote it" --decision "Use the CLI-owned promotion note template." --scope-change "Backlog seed is now an executable Todo issue." --dependency-context "Blocked by #122 until the prerequisite lands." --blocked-by '#122' --readback-summary "Operator confirmed the dry-run preview before write." --dry-run
 cargo run -- forge promote '#241' --workflow examples/promote-fixture-workflow.md --title "Harden Issue Forge Reflect promotion fixture" --body-file examples/fixtures/promoted-issue.md --operator-confirmation "promote it" --decision "Keep the promotion in place." --scope-change "Backlog seed becomes an executable Todo issue." --dependency-context "Dependencies: none." --readback-summary "Dry-run preview verified before write." --dry-run
 cargo run -- forge rework '#282' --workflow workflows/shea-symphony.md --title "Rework: revised execution contract" --body-file /tmp/rework-body.md --evidence-file /tmp/rework-evidence.md --operator-confirmation "route Human Review back to Rework" --dry-run
 ```
@@ -504,6 +518,14 @@ issue body/title, verifies that content readback, writes the Promotion Note, and
 only then moves the Project status from `Backlog` to `Todo`; after that final
 mutation it performs read-only status readback. On write success, the comment
 uses this short Markdown shape:
+
+When a Todo candidate names blocking dependencies in `## Issue Setup`
+`Dependencies:` or in a standalone `## Dependencies` section, the quality gate
+requires either `Dependencies: None` or a structured relationship plan. Use
+repeatable `--blocked-by '#<issue>'` for native GitHub blocked-by relationships
+and `--parent '#<issue>'` when the candidate should become a native subissue.
+`forge create --write` stages relationship-backed Todo candidates in `Backlog`,
+adds and verifies relationships, then performs the final Todo status mutation.
 
 ```md
 ## Promotion Note

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -346,13 +346,17 @@ Project v2 issues:
      assignee and Project context while checking replacement contract text.
      Validation output separates candidate-side gaps from live-context gaps.
    - `forge create` creates tracker issues, always inserts them into the
-     configured Project, supports `--status Backlog|Todo`, and accepts repeatable
-     `--project-field NAME=VALUE` assignments.
+     configured Project, supports `--status Backlog|Todo`, accepts repeatable
+     `--project-field NAME=VALUE` assignments, and can stage relationship-backed
+     Todo candidates in `Backlog` while native blocked-by or parent/subissue
+     relationships are written and read back.
    - `forge promote` reads a Backlog issue, validates an explicit replacement
-     title/body with the same Todo validation categories, requires structured
-     Promotion Note inputs, edits the same issue in place, writes the Promotion
-     Note comment, sets Project status to `Todo` as the final mutation, and then
-     performs read-only status readback verification.
+     title/body with the same Todo validation categories, can satisfy declared
+     blocker or parent gates through repeatable `--blocked-by` and optional
+     `--parent`, requires structured Promotion Note inputs, edits the same issue
+     in place, writes the Promotion Note comment, sets Project status to `Todo`
+     as the final mutation, and then performs read-only status readback
+     verification.
    - Reflection, discussion, and repair are skill-owned workflows, not
      Shea Symphony CLI subcommands.
    - Remaining work: text/number/date field writes and richer Project selection

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ use shea_symphony::tracker::ProjectFieldAssignment;
 
 use crate::commands::autopilot::AutopilotLoopOptions;
 use crate::commands::doctor::{DoctorAction, DoctorOptions, DoctorRepairIssueOptions};
-use crate::commands::forge::{ForgeReworkOptions, PromotionNoteInput};
+use crate::commands::forge::{ForgeRelationshipPlan, ForgeReworkOptions, PromotionNoteInput};
 use crate::commands::project::ProjectStateOptions;
 use crate::commands::session::AgentSessionLaneArg;
 use crate::lanes::main_loop::RunLoopOptions;
@@ -57,6 +57,30 @@ pub(crate) enum Command {
         workflow_path: PathBuf,
         issue_ref: String,
         lane: Option<AgentSessionLaneArg>,
+    },
+    ProjectRelationshipList {
+        workflow_path: PathBuf,
+        issue_ref: String,
+    },
+    ProjectRelationshipVerify {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        blocked_by: Vec<String>,
+        subissue: Vec<String>,
+    },
+    ProjectRelationshipAddBlockedBy {
+        workflow_path: PathBuf,
+        issue_ref: String,
+        blocker_ref: String,
+        write: bool,
+        dry_run: bool,
+    },
+    ProjectRelationshipAddSubissue {
+        workflow_path: PathBuf,
+        parent_ref: String,
+        subissue_ref: String,
+        write: bool,
+        dry_run: bool,
     },
     Doctor {
         options: DoctorOptions,
@@ -269,6 +293,7 @@ pub(crate) enum Command {
         project: Option<String>,
         project_fields: Vec<ProjectFieldAssignment>,
         assignees: Vec<String>,
+        relationships: ForgeRelationshipPlan,
         write: bool,
         dry_run: bool,
     },
@@ -278,6 +303,7 @@ pub(crate) enum Command {
         title: String,
         markdown: String,
         promotion_note: PromotionNoteInput,
+        relationships: ForgeRelationshipPlan,
         write: bool,
         dry_run: bool,
     },
@@ -945,6 +971,8 @@ enum ProjectCommandArgs {
     Issue(ProjectIssueArgs),
     #[command(about = "Inspect live issue readiness without mutating tracker state")]
     Inspect(ProjectInspectArgs),
+    #[command(about = "List, add, and verify GitHub issue relationships")]
+    Relationship(ProjectRelationshipArgs),
     #[command(name = "set-state", about = "Set one issue Project status")]
     SetState(SetStateArgs),
     #[command(name = "link-pr", about = "Record pull request evidence for one issue")]
@@ -958,6 +986,77 @@ enum ProjectCommandArgs {
         about = "Append a standalone issue timeline comment"
     )]
     TimelineComment(TimelineCommentArgs),
+}
+
+#[derive(Debug, Args)]
+struct ProjectRelationshipArgs {
+    #[command(subcommand)]
+    command: ProjectRelationshipCommandArgs,
+}
+
+#[derive(Debug, Subcommand)]
+enum ProjectRelationshipCommandArgs {
+    #[command(about = "List structured blocked-by and native subissue relationships")]
+    List(ProjectRelationshipListArgs),
+    #[command(about = "Verify expected structured issue relationships")]
+    Verify(ProjectRelationshipVerifyArgs),
+    #[command(name = "add-blocked-by", about = "Add a blocked-by relationship")]
+    AddBlockedBy(ProjectRelationshipAddBlockedByArgs),
+    #[command(
+        name = "add-subissue",
+        about = "Add a native subissue to a parent issue"
+    )]
+    AddSubissue(ProjectRelationshipAddSubissueArgs),
+}
+
+#[derive(Debug, Args)]
+struct ProjectRelationshipListArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+    #[arg(long = "write")]
+    _write: bool,
+}
+
+#[derive(Debug, Args)]
+struct ProjectRelationshipVerifyArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    #[arg(long = "blocked-by")]
+    blocked_by: Vec<String>,
+    #[arg(long = "subissue")]
+    subissue: Vec<String>,
+    #[arg(long = "dry-run")]
+    _dry_run: bool,
+    #[arg(long = "write")]
+    _write: bool,
+}
+
+#[derive(Debug, Args)]
+struct ProjectRelationshipAddBlockedByArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    issue_ref: String,
+    blocker_ref: String,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    dry_run: bool,
+}
+
+#[derive(Debug, Args)]
+struct ProjectRelationshipAddSubissueArgs {
+    #[arg(value_name = "path-to-WORKFLOW.md")]
+    workflow_path: PathBuf,
+    parent_ref: String,
+    subissue_ref: String,
+    #[arg(long)]
+    write: bool,
+    #[arg(long = "dry-run")]
+    dry_run: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1368,6 +1467,10 @@ struct ForgeCreateArgs {
     project_fields: Vec<String>,
     #[arg(long = "assignee")]
     assignees: Vec<String>,
+    #[arg(long = "blocked-by")]
+    blocked_by: Vec<String>,
+    #[arg(long = "parent")]
+    parent: Option<String>,
     #[arg(long)]
     write: bool,
     #[arg(long = "dry-run")]
@@ -1385,6 +1488,10 @@ struct ForgePromoteArgs {
     markdown: ForgeMarkdownArgs,
     #[command(flatten)]
     promotion_note: PromotionNoteArgs,
+    #[arg(long = "blocked-by")]
+    blocked_by: Vec<String>,
+    #[arg(long = "parent")]
+    parent: Option<String>,
     #[arg(long)]
     write: bool,
     #[arg(long = "dry-run")]
@@ -1548,6 +1655,38 @@ fn command_from_project_args(command: ProjectCommandArgs) -> Result<Command, Str
             issue_ref: args.issue_ref,
             lane: args.lane,
         }),
+        ProjectCommandArgs::Relationship(args) => match args.command {
+            ProjectRelationshipCommandArgs::List(args) => Ok(Command::ProjectRelationshipList {
+                workflow_path: args.workflow_path,
+                issue_ref: args.issue_ref,
+            }),
+            ProjectRelationshipCommandArgs::Verify(args) => {
+                Ok(Command::ProjectRelationshipVerify {
+                    workflow_path: args.workflow_path,
+                    issue_ref: args.issue_ref,
+                    blocked_by: args.blocked_by,
+                    subissue: args.subissue,
+                })
+            }
+            ProjectRelationshipCommandArgs::AddBlockedBy(args) => {
+                Ok(Command::ProjectRelationshipAddBlockedBy {
+                    workflow_path: args.workflow_path,
+                    issue_ref: args.issue_ref,
+                    blocker_ref: args.blocker_ref,
+                    write: args.write,
+                    dry_run: args.dry_run,
+                })
+            }
+            ProjectRelationshipCommandArgs::AddSubissue(args) => {
+                Ok(Command::ProjectRelationshipAddSubissue {
+                    workflow_path: args.workflow_path,
+                    parent_ref: args.parent_ref,
+                    subissue_ref: args.subissue_ref,
+                    write: args.write,
+                    dry_run: args.dry_run,
+                })
+            }
+        },
         ProjectCommandArgs::SetState(args) => Ok(Command::SetState {
             workflow_path: args.workflow_path,
             issue_ref: args.issue_ref,
@@ -1754,6 +1893,10 @@ impl TryFrom<Cli> for Command {
                             project: args.project,
                             project_fields: parse_project_field_assignments(args.project_fields)?,
                             assignees: args.assignees,
+                            relationships: ForgeRelationshipPlan {
+                                blocked_by: args.blocked_by,
+                                parent: args.parent,
+                            },
                             write: args.write,
                             dry_run: args.dry_run,
                         }),
@@ -1763,6 +1906,10 @@ impl TryFrom<Cli> for Command {
                             title: args.title,
                             markdown: read_forge_markdown_arg(args.markdown)?,
                             promotion_note: promotion_note_input(args.promotion_note)?,
+                            relationships: ForgeRelationshipPlan {
+                                blocked_by: args.blocked_by,
+                                parent: args.parent,
+                            },
                             write: args.write,
                             dry_run: args.dry_run,
                         }),

--- a/src/commands/autopilot/looping.rs
+++ b/src/commands/autopilot/looping.rs
@@ -1,4 +1,6 @@
-use std::path::PathBuf;
+#![allow(clippy::items_after_test_module)]
+
+use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -622,7 +624,7 @@ fn autopilot_plan_lane<'a>(
 }
 
 fn refresh_autopilot_plan_or_keep(
-    workflow_path: &PathBuf,
+    workflow_path: &Path,
     fallback: AutopilotPlanSnapshot,
 ) -> AutopilotPlanSnapshot {
     build_autopilot_plan(workflow_path).unwrap_or(fallback)

--- a/src/commands/forge.rs
+++ b/src/commands/forge.rs
@@ -1,7 +1,9 @@
 use shea_symphony::config::RuntimeConfig;
 use shea_symphony::issue_forge::{next_clarification_question, ForgeValidationReport};
-use shea_symphony::model::{normalize_state, GateDecision, GateDecisionKind, TrackerIssue};
-use shea_symphony::tracker::adapter_from_config;
+use shea_symphony::model::{
+    normalize_state, BlockerRef, GateDecision, GateDecisionKind, TrackerIssue,
+};
+use shea_symphony::tracker::{adapter_from_config, TrackerAdapter};
 use std::path::PathBuf;
 
 use crate::cli::ForgeStatusArg;
@@ -11,12 +13,11 @@ mod rework;
 #[cfg(test)]
 pub(crate) use create::{
     find_duplicate_issue_title, forge_create_requires_assignee, render_forge_create_success,
-    validate_forge_create_contract, verify_forge_created_issue_status, write_forge_created_issue,
-    ForgeCreateResult, ForgeCreateWriteInput,
+    validate_forge_create_contract, validate_forge_create_report_with_assignees,
+    verify_forge_created_issue_status, write_forge_created_issue, ForgeCreateResult,
+    ForgeCreateWriteInput,
 };
-pub(crate) use create::{
-    forge_create, validate_forge_create_report_with_assignees, ForgeCreateOptions,
-};
+pub(crate) use create::{forge_create, ForgeCreateOptions};
 
 pub(crate) use rework::{forge_rework, ForgeReworkOptions};
 #[cfg(test)]
@@ -24,15 +25,29 @@ pub(crate) use rework::{forge_rework_with_adapter, ForgeReworkInput};
 
 use crate::orchestration::{append_tracker_mutation_audit, load_config, TrackerMutationAudit};
 
-pub(crate) fn forge_promote(
-    workflow_path: PathBuf,
-    issue_ref: String,
-    title: String,
-    markdown: String,
-    promotion_note: PromotionNoteInput,
-    write: bool,
-    dry_run: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) struct ForgePromoteInput {
+    pub(crate) workflow_path: PathBuf,
+    pub(crate) issue_ref: String,
+    pub(crate) title: String,
+    pub(crate) markdown: String,
+    pub(crate) promotion_note: PromotionNoteInput,
+    pub(crate) relationships: ForgeRelationshipPlan,
+    pub(crate) write: bool,
+    pub(crate) dry_run: bool,
+}
+
+pub(crate) fn forge_promote(input: ForgePromoteInput) -> Result<(), Box<dyn std::error::Error>> {
+    let ForgePromoteInput {
+        workflow_path,
+        issue_ref,
+        title,
+        markdown,
+        promotion_note,
+        relationships,
+        write,
+        dry_run,
+    } = input;
+
     if write && dry_run {
         return Err("forge promote cannot use --write and --dry-run together".into());
     }
@@ -53,12 +68,13 @@ pub(crate) fn forge_promote(
         .into());
     }
 
-    let report = forge_validation_report(
+    let report = forge_validation_report_with_relationships(
         ForgeStatusArg::Todo,
         &title,
         &markdown,
         &config,
         &source.assignees,
+        &relationships,
     )
     .map_err(|error| format!("forge promote stopped at validate: {error}"))?;
     print_forge_validation(&report);
@@ -81,6 +97,13 @@ pub(crate) fn forge_promote(
             "forge_promote_dry_run=ok issue={} from=Backlog to=Todo title={:?}",
             source.identifier, report.title
         );
+        if !relationships.is_empty() {
+            println!(
+                "relationship_plan=planned blocked_by={} parent={}",
+                relationships.blocked_by.join(","),
+                relationships.parent.as_deref().unwrap_or("")
+            );
+        }
         println!("promotion_note_preview=\n{note}");
         return Ok(());
     }
@@ -118,10 +141,18 @@ pub(crate) fn forge_promote(
         .into());
     }
 
-    let write_readbacks = vec![format!(
+    let relationship_readbacks = apply_forge_relationship_plan(
+        adapter.as_ref(),
+        &content_verified.identifier,
+        &relationships,
+    )
+    .map_err(|error| format!("forge promote stopped at relationships: {error}"))?;
+
+    let mut write_readbacks = vec![format!(
         "`forge promote --write` updated the existing issue content; pre-status readback confirmed issue `{}` title `{}` before the final Project status mutation.",
         content_verified.identifier, content_verified.title
     )];
+    write_readbacks.extend(relationship_readbacks);
     let note = render_promotion_note(
         &source.identifier,
         &content_verified.title,
@@ -194,6 +225,45 @@ pub(crate) struct PromotionNoteInput {
     pub(crate) scope_changes: Vec<String>,
     pub(crate) dependencies_context: Vec<String>,
     pub(crate) readback_summaries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ForgeRelationshipPlan {
+    pub(crate) blocked_by: Vec<String>,
+    pub(crate) parent: Option<String>,
+}
+
+impl ForgeRelationshipPlan {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.blocked_by.is_empty() && self.parent.is_none()
+    }
+}
+
+pub(crate) fn apply_forge_relationship_plan(
+    adapter: &dyn TrackerAdapter,
+    issue_ref: &str,
+    relationships: &ForgeRelationshipPlan,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut readbacks = Vec::new();
+    for blocker_ref in &relationships.blocked_by {
+        let readback = adapter.add_blocked_by_relationship(issue_ref, blocker_ref)?;
+        readbacks.push(format!(
+            "`{}` blocked-by `{}` readback verified (blocked_by_count={}).",
+            readback.issue_identifier,
+            blocker_ref,
+            readback.blocked_by.len()
+        ));
+    }
+    if let Some(parent_ref) = &relationships.parent {
+        let readback = adapter.add_subissue_relationship(parent_ref, issue_ref)?;
+        readbacks.push(format!(
+            "`{}` native subissue `{}` readback verified (native_subissue_count={}).",
+            parent_ref,
+            issue_ref,
+            readback.native_subissues.len()
+        ));
+    }
+    Ok(readbacks)
 }
 
 pub(crate) fn render_promotion_note(
@@ -306,12 +376,49 @@ pub(crate) fn forge_validation_report(
     config: &RuntimeConfig,
     intended_assignees: &[String],
 ) -> Result<ForgeValidationReport, Box<dyn std::error::Error>> {
+    forge_validation_report_with_relationships(
+        status,
+        title,
+        markdown,
+        config,
+        intended_assignees,
+        &ForgeRelationshipPlan::default(),
+    )
+}
+
+pub(crate) fn forge_validation_report_with_relationships(
+    status: ForgeStatusArg,
+    title: &str,
+    markdown: &str,
+    config: &RuntimeConfig,
+    intended_assignees: &[String],
+    relationships: &ForgeRelationshipPlan,
+) -> Result<ForgeValidationReport, Box<dyn std::error::Error>> {
     match status {
         ForgeStatusArg::Backlog => Ok(validate_backlog_seed(title, markdown)),
-        ForgeStatusArg::Todo => {
-            validate_forge_create_report_with_assignees(title, markdown, config, intended_assignees)
-        }
+        ForgeStatusArg::Todo => create::validate_forge_create_report_with_relationships(
+            title,
+            markdown,
+            config,
+            intended_assignees,
+            relationships,
+        ),
     }
+}
+
+pub(crate) fn blocker_refs_from_relationship_plan(
+    relationships: &ForgeRelationshipPlan,
+    config: &RuntimeConfig,
+) -> Vec<BlockerRef> {
+    relationships
+        .blocked_by
+        .iter()
+        .map(|blocker_ref| BlockerRef {
+            id: None,
+            identifier: Some(blocker_ref.clone()),
+            state: Some(config.tracker.state_map.done.clone()),
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/commands/forge/create.rs
+++ b/src/commands/forge/create.rs
@@ -13,7 +13,10 @@ use crate::cli::ForgeStatusArg;
 use crate::commands::gate::evaluate_issue_for_current_source;
 use crate::orchestration::{append_tracker_mutation_audit, load_config, TrackerMutationAudit};
 
-use super::{forge_validation_report, print_forge_validation};
+use super::{
+    apply_forge_relationship_plan, blocker_refs_from_relationship_plan,
+    forge_validation_report_with_relationships, print_forge_validation, ForgeRelationshipPlan,
+};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ForgeCreateOptions {
@@ -24,6 +27,7 @@ pub(crate) struct ForgeCreateOptions {
     pub(crate) project: Option<String>,
     pub(crate) project_fields: Vec<ProjectFieldAssignment>,
     pub(crate) assignees: Vec<String>,
+    pub(crate) relationships: ForgeRelationshipPlan,
     pub(crate) write: bool,
     pub(crate) dry_run: bool,
 }
@@ -37,6 +41,7 @@ pub(crate) fn forge_create(options: ForgeCreateOptions) -> Result<(), Box<dyn st
         project,
         project_fields,
         assignees,
+        relationships,
         write,
         dry_run,
     } = options;
@@ -52,7 +57,14 @@ pub(crate) fn forge_create(options: ForgeCreateOptions) -> Result<(), Box<dyn st
             "forge create --status Todo requires --assignee for live GitHub issue creation".into(),
         );
     }
-    let report = forge_validation_report(status, &title, &markdown, &config, &assignees)?;
+    let report = forge_validation_report_with_relationships(
+        status,
+        &title,
+        &markdown,
+        &config,
+        &assignees,
+        &relationships,
+    )?;
     print_forge_validation(&report);
     if !report.decision.is_dispatchable() {
         return Err(format!(
@@ -70,6 +82,13 @@ pub(crate) fn forge_create(options: ForgeCreateOptions) -> Result<(), Box<dyn st
             report.title,
             project_fields.len()
         );
+        if !relationships.is_empty() {
+            println!(
+                "relationship_plan=planned blocked_by={} parent={}",
+                relationships.blocked_by.join(","),
+                relationships.parent.as_deref().unwrap_or("")
+            );
+        }
         return Ok(());
     }
 
@@ -84,6 +103,7 @@ pub(crate) fn forge_create(options: ForgeCreateOptions) -> Result<(), Box<dyn st
             status,
             project_label: &project_label,
             project_fields: &project_fields,
+            relationships: &relationships,
         },
     )?;
 
@@ -101,6 +121,7 @@ pub(crate) struct ForgeCreateWriteInput<'a> {
     pub(crate) status: ForgeStatusArg,
     pub(crate) project_label: &'a str,
     pub(crate) project_fields: &'a [ProjectFieldAssignment],
+    pub(crate) relationships: &'a ForgeRelationshipPlan,
 }
 
 #[derive(Debug, Clone)]
@@ -145,7 +166,12 @@ pub(crate) fn write_forge_created_issue(
         },
     );
 
-    adapter.add_issue_to_project_with_state(&issue_id, input.status.normalized_state())?;
+    let stage_state = if input.status == ForgeStatusArg::Todo && !input.relationships.is_empty() {
+        "backlog"
+    } else {
+        input.status.normalized_state()
+    };
+    adapter.add_issue_to_project_with_state(&issue_id, stage_state)?;
     append_tracker_mutation_audit(
         config,
         TrackerMutationAudit {
@@ -154,7 +180,7 @@ pub(crate) fn write_forge_created_issue(
             issue_ref: Some(&issue_id),
             target: Some(input.project_label.into()),
             from_state: None,
-            to_state: Some(input.status.normalized_state().into()),
+            to_state: Some(stage_state.into()),
             reason: "forge issue added to project with requested initial status",
         },
     );
@@ -170,6 +196,24 @@ pub(crate) fn write_forge_created_issue(
                 from_state: None,
                 to_state: None,
                 reason: "forge project field assignment",
+            },
+        );
+    }
+    if !input.relationships.is_empty() {
+        apply_forge_relationship_plan(adapter, &issue_id, input.relationships)?;
+    }
+    if input.status == ForgeStatusArg::Todo && stage_state != "todo" {
+        adapter.set_state(&issue_id, "todo")?;
+        append_tracker_mutation_audit(
+            config,
+            TrackerMutationAudit {
+                command: "forge create",
+                mutation_type: "status",
+                issue_ref: Some(&issue_id),
+                target: Some("Todo".into()),
+                from_state: Some("backlog".into()),
+                to_state: Some("todo".into()),
+                reason: "forge relationship-verified Todo creation final status update",
             },
         );
     }
@@ -356,11 +400,28 @@ pub(crate) fn validate_forge_create_contract(
     }
 }
 
+#[cfg(test)]
 pub(crate) fn validate_forge_create_report_with_assignees(
     title: &str,
     markdown: &str,
     config: &RuntimeConfig,
     intended_assignees: &[String],
+) -> Result<shea_symphony::issue_forge::ForgeValidationReport, Box<dyn std::error::Error>> {
+    validate_forge_create_report_with_relationships(
+        title,
+        markdown,
+        config,
+        intended_assignees,
+        &ForgeRelationshipPlan::default(),
+    )
+}
+
+pub(crate) fn validate_forge_create_report_with_relationships(
+    title: &str,
+    markdown: &str,
+    config: &RuntimeConfig,
+    intended_assignees: &[String],
+    relationships: &ForgeRelationshipPlan,
 ) -> Result<shea_symphony::issue_forge::ForgeValidationReport, Box<dyn std::error::Error>> {
     let issue = TrackerIssue {
         tracker_kind: config.tracker.kind.clone(),
@@ -376,7 +437,7 @@ pub(crate) fn validate_forge_create_report_with_assignees(
         priority: None,
         branch_name: None,
         linked_pull_requests: Vec::new(),
-        blocked_by: Vec::new(),
+        blocked_by: blocker_refs_from_relationship_plan(relationships, config),
         project_fields: Default::default(),
         created_at: None,
         updated_at: None,

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -9,15 +9,18 @@ use shea_symphony::review_status::{
     load_review_status, render_project_inspect_review_summary, ReviewStatusOptions,
 };
 use shea_symphony::session_registry::unix_timestamp_ms;
-use shea_symphony::tracker::{adapter_from_config, classify_project_state_error};
+use shea_symphony::tracker::{
+    adapter_from_config, classify_project_state_error, IssueRelationshipReadback, TrackerAdapter,
+};
 use shea_symphony::workflow::WorkflowDefinition;
 
 use crate::cli::DisplayMode;
 use crate::commands::gate::evaluate_issue_for_current_source;
 use crate::commands::session::AgentSessionLaneArg;
 use crate::orchestration::{
-    append_canonical_checkout_gap, load_config, progress_spec_for_config,
-    report_canonical_checkout_readonly, tracker_backend_label, warn_if_temporary_workflow_path,
+    append_canonical_checkout_gap, append_tracker_mutation_audit, load_config,
+    progress_spec_for_config, report_canonical_checkout_readonly, require_write_intent,
+    tracker_backend_label, warn_if_temporary_workflow_path, TrackerMutationAudit,
 };
 
 mod write;
@@ -245,6 +248,218 @@ pub(crate) fn project_inspect(
     }
 
     Ok(())
+}
+
+pub(crate) fn project_relationship_list(
+    workflow_path: PathBuf,
+    issue_ref: String,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let readback = adapter.relationship_readback(&issue_ref)?;
+    print_relationship_readback("relationship_list=ok", &readback);
+    Ok(())
+}
+
+pub(crate) fn project_relationship_verify(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    blocked_by: Vec<String>,
+    subissue: Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    let readback = adapter.relationship_readback(&issue_ref)?;
+    let missing_blocked_by = blocked_by
+        .iter()
+        .filter(|expected| !readback.has_blocker(expected))
+        .cloned()
+        .collect::<Vec<_>>();
+    let missing_subissues = subissue
+        .iter()
+        .filter(|expected| !readback.has_native_subissue(expected))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    print_relationship_readback("relationship_verify=ok", &readback);
+    if !missing_blocked_by.is_empty() || !missing_subissues.is_empty() {
+        return Err(format!(
+            "relationship verify failed: issue={} missing_blocked_by={} missing_subissues={}",
+            readback.issue_identifier,
+            missing_or_none(&missing_blocked_by),
+            missing_or_none(&missing_subissues)
+        )
+        .into());
+    }
+    Ok(())
+}
+
+pub(crate) fn project_relationship_add_blocked_by(
+    workflow_path: PathBuf,
+    issue_ref: String,
+    blocker_ref: String,
+    write: bool,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    project_relationship_add_blocked_by_with_adapter(
+        &config,
+        adapter.as_ref(),
+        &issue_ref,
+        &blocker_ref,
+        write,
+        dry_run,
+    )
+}
+
+fn project_relationship_add_blocked_by_with_adapter(
+    config: &RuntimeConfig,
+    adapter: &dyn TrackerAdapter,
+    issue_ref: &str,
+    blocker_ref: &str,
+    write: bool,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if write && dry_run {
+        return Err(
+            "relationship add command accepts either --write or --dry-run, not both".into(),
+        );
+    }
+    if dry_run {
+        let readback = adapter.relationship_readback(issue_ref)?;
+        println!("relationship_add_blocked_by_dry_run=ok");
+        println!(
+            "action=add_blocked_by issue={} blocker={} already_present={} would_add={}",
+            issue_ref,
+            blocker_ref,
+            readback.has_blocker(blocker_ref),
+            !readback.has_blocker(blocker_ref)
+        );
+        print_relationship_readback("relationship_dry_run_readback=ok", &readback);
+        return Ok(());
+    }
+
+    require_write_intent(write)?;
+    let readback = adapter.add_blocked_by_relationship(issue_ref, blocker_ref)?;
+    append_tracker_mutation_audit(
+        config,
+        TrackerMutationAudit {
+            command: "project relationship add-blocked-by",
+            mutation_type: "relationship",
+            issue_ref: Some(issue_ref),
+            target: Some(blocker_ref.to_string()),
+            from_state: None,
+            to_state: None,
+            reason: "native blocked-by relationship add with readback verification",
+        },
+    );
+    print_relationship_readback("relationship_add_blocked_by=ok", &readback);
+    Ok(())
+}
+
+pub(crate) fn project_relationship_add_subissue(
+    workflow_path: PathBuf,
+    parent_ref: String,
+    subissue_ref: String,
+    write: bool,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = load_config(&workflow_path)?;
+    let adapter = adapter_from_config(&config);
+    project_relationship_add_subissue_with_adapter(
+        &config,
+        adapter.as_ref(),
+        &parent_ref,
+        &subissue_ref,
+        write,
+        dry_run,
+    )
+}
+
+fn project_relationship_add_subissue_with_adapter(
+    config: &RuntimeConfig,
+    adapter: &dyn TrackerAdapter,
+    parent_ref: &str,
+    subissue_ref: &str,
+    write: bool,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if write && dry_run {
+        return Err(
+            "relationship add command accepts either --write or --dry-run, not both".into(),
+        );
+    }
+    if dry_run {
+        let readback = adapter.relationship_readback(parent_ref)?;
+        println!("relationship_add_subissue_dry_run=ok");
+        println!(
+            "action=add_subissue parent={} subissue={} already_present={} would_add={}",
+            parent_ref,
+            subissue_ref,
+            readback.has_native_subissue(subissue_ref),
+            !readback.has_native_subissue(subissue_ref)
+        );
+        print_relationship_readback("relationship_dry_run_readback=ok", &readback);
+        return Ok(());
+    }
+
+    require_write_intent(write)?;
+    let readback = adapter.add_subissue_relationship(parent_ref, subissue_ref)?;
+    append_tracker_mutation_audit(
+        config,
+        TrackerMutationAudit {
+            command: "project relationship add-subissue",
+            mutation_type: "relationship",
+            issue_ref: Some(parent_ref),
+            target: Some(subissue_ref.to_string()),
+            from_state: None,
+            to_state: None,
+            reason: "native parent/subissue relationship add with readback verification",
+        },
+    );
+    print_relationship_readback("relationship_add_subissue=ok", &readback);
+    Ok(())
+}
+
+fn print_relationship_readback(prefix: &str, readback: &IssueRelationshipReadback) {
+    println!("{prefix}");
+    println!("issue={}", readback.issue_identifier);
+    println!(
+        "native_parent={}",
+        readback.native_parent.as_deref().unwrap_or("")
+    );
+    println!("blocked_by_count={}", readback.blocked_by.len());
+    for blocker in &readback.blocked_by {
+        println!(
+            "blocked_by={} state={} id={}",
+            blocker
+                .identifier
+                .as_deref()
+                .or(blocker.id.as_deref())
+                .unwrap_or("unknown"),
+            blocker.state.as_deref().unwrap_or("unknown"),
+            blocker.id.as_deref().unwrap_or("")
+        );
+    }
+    println!("native_subissue_count={}", readback.native_subissues.len());
+    for subissue in &readback.native_subissues {
+        println!(
+            "native_subissue={} project_state={} github_state={} title={}",
+            subissue.identifier,
+            subissue.project_state.as_deref().unwrap_or("missing"),
+            subissue.github_state.as_deref().unwrap_or("unknown"),
+            subissue.title.as_deref().unwrap_or("")
+        );
+    }
+}
+
+fn missing_or_none(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".into()
+    } else {
+        values.join(",")
+    }
 }
 
 fn compact_json_value(value: &serde_json::Value) -> String {

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -307,7 +307,7 @@ pub fn render_agent_review_handoff_workpad(
     ];
 
     if let Some(blocker) = &evidence.no_pr_blocker {
-        lines.push(format!("- No-PR blocker: {}", blocker));
+        lines.push(format!("- No-PR blocker: {blocker}"));
     }
     if let Some(parent_issue) = &evidence.branch_target.parent_issue {
         lines.push(format!("- Native parent issue: `{parent_issue}`"));

--- a/src/issue_forge.rs
+++ b/src/issue_forge.rs
@@ -766,9 +766,9 @@ fn reflective_table_title(line: &str) -> Option<String> {
     let capability = cells.first()?;
     let status = cells.get(1).copied().unwrap_or_default().to_lowercase();
     if status.contains("not implemented") || status.contains("remaining work") {
-        Some(format!("Follow-up: close {} readiness gap", capability))
+        Some(format!("Follow-up: close {capability} readiness gap"))
     } else {
-        Some(format!("Follow-up: {}", capability))
+        Some(format!("Follow-up: {capability}"))
     }
 }
 

--- a/src/lanes/main_loop.rs
+++ b/src/lanes/main_loop.rs
@@ -205,15 +205,13 @@ pub(crate) fn run_loop(options: RunLoopOptions) -> Result<(), Box<dyn std::error
         if options.write && available_slots == 0 {
             if let Some(delay_ms) = unbounded_loop_sleep_ms(limit, config.polling.interval_ms) {
                 println!(
-                    "run_loop_idle action=sleep reason=max_concurrent_reached active_workers={} max_concurrent={} delay_ms={delay_ms} iterations={iterations}",
-                    active_main_workers, max_concurrent
+                    "run_loop_idle action=sleep reason=max_concurrent_reached active_workers={active_main_workers} max_concurrent={max_concurrent} delay_ms={delay_ms} iterations={iterations}"
                 );
                 thread::sleep(Duration::from_millis(delay_ms));
                 continue;
             } else {
                 println!(
-                    "run_loop=stopped reason=max_concurrent_reached active_workers={} max_concurrent={}",
-                    active_main_workers, max_concurrent
+                    "run_loop=stopped reason=max_concurrent_reached active_workers={active_main_workers} max_concurrent={max_concurrent}"
                 );
                 break;
             }

--- a/src/lanes/main_loop/handoff.rs
+++ b/src/lanes/main_loop/handoff.rs
@@ -610,7 +610,7 @@ pub(crate) fn run_loop_handoff_failure_workpad(
         "- Source: `shea-symphony main loop`".to_string(),
         String::new(),
         "### Handoff Planning Blocker".to_string(),
-        format!("- Error: `{}`", error),
+        format!("- Error: `{error}`"),
         "- Backend execution was skipped before claim/run to avoid mixing issue scope.".to_string(),
         String::new(),
         "### Required Human Decision".to_string(),

--- a/src/lanes/main_loop/runtime.rs
+++ b/src/lanes/main_loop/runtime.rs
@@ -144,8 +144,7 @@ pub(crate) fn run_loop_resume_preflight_many(
                         &format!("issue={issue_identifier} reason={reason}"),
                     )?;
                     println!(
-                        "run_loop_resume_preflight action=recover_read_skipped issue={} reason={}",
-                        issue_identifier, reason
+                        "run_loop_resume_preflight action=recover_read_skipped issue={issue_identifier} reason={reason}"
                     );
                     retained_states.push(state.clone());
                     continue;
@@ -235,8 +234,7 @@ pub(crate) fn run_loop_resume_preflight_many(
                         &format!("issue={issue_identifier} reason={reason}"),
                     )?;
                     println!(
-                        "run_loop_resume_preflight action=recoverable issue={} reason={}",
-                        issue_identifier, reason
+                        "run_loop_resume_preflight action=recoverable issue={issue_identifier} reason={reason}"
                     );
                     recoverable_states.push(RuntimeRecoveryCandidate {
                         state: state.clone(),

--- a/src/lanes/main_loop/runtime/recovery.rs
+++ b/src/lanes/main_loop/runtime/recovery.rs
@@ -164,8 +164,7 @@ fn recover_registry_issue_allows_active_retention(
                 &format!("issue={issue_identifier} reason={reason}"),
             )?;
             println!(
-                "run_loop_resume_preflight action=recover_registry_read_skipped issue={} reason={}",
-                issue_identifier, reason
+                "run_loop_resume_preflight action=recover_registry_read_skipped issue={issue_identifier} reason={reason}"
             );
             Ok(true)
         }
@@ -193,8 +192,7 @@ fn recover_registry_issue_for_restart(
                 &format!("issue={issue_identifier} reason={reason}"),
             )?;
             println!(
-                "run_loop_resume_preflight action=recover_registry_read_skipped issue={} reason={}",
-                issue_identifier, reason
+                "run_loop_resume_preflight action=recover_registry_read_skipped issue={issue_identifier} reason={reason}"
             );
             Ok(None)
         }

--- a/src/lanes/main_loop/session.rs
+++ b/src/lanes/main_loop/session.rs
@@ -310,13 +310,11 @@ pub(crate) fn reconcile_main_handoff_runtime_state(
             runtime_state.as_ref(),
             "MainHandoffRuntimeReconciled",
             &format!(
-                "issue={} target_state=agent_review sessions_completed={} runtime_cleared={}",
-                issue_ref, completed_sessions, runtime_matches_main_issue
+                "issue={issue_ref} target_state=agent_review sessions_completed={completed_sessions} runtime_cleared={runtime_matches_main_issue}"
             ),
         )?;
         println!(
-            "main_handoff_runtime_reconcile issue={} sessions_completed={} runtime_cleared={}",
-            issue_ref, completed_sessions, runtime_matches_main_issue
+            "main_handoff_runtime_reconcile issue={issue_ref} sessions_completed={completed_sessions} runtime_cleared={runtime_matches_main_issue}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use commands::gate::quality_gate;
 use commands::profiles::list_profiles;
 use commands::project::{
     add_to_project, append_timeline_comment, link_pr, project_inspect, project_issue,
-    project_state, set_state, upsert_workpad,
+    project_relationship_add_blocked_by, project_relationship_add_subissue,
+    project_relationship_list, project_relationship_verify, project_state, set_state,
+    upsert_workpad,
 };
 use commands::session::{
     agent_session_attach, agent_session_list, agent_session_start, lane_claim_command,
@@ -78,6 +80,42 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             issue_ref,
             lane,
         } => project_inspect(workflow_path, issue_ref, lane),
+        Command::ProjectRelationshipList {
+            workflow_path,
+            issue_ref,
+        } => project_relationship_list(workflow_path, issue_ref),
+        Command::ProjectRelationshipVerify {
+            workflow_path,
+            issue_ref,
+            blocked_by,
+            subissue,
+        } => project_relationship_verify(workflow_path, issue_ref, blocked_by, subissue),
+        Command::ProjectRelationshipAddBlockedBy {
+            workflow_path,
+            issue_ref,
+            blocker_ref,
+            write,
+            dry_run,
+        } => project_relationship_add_blocked_by(
+            workflow_path,
+            issue_ref,
+            blocker_ref,
+            write,
+            dry_run,
+        ),
+        Command::ProjectRelationshipAddSubissue {
+            workflow_path,
+            parent_ref,
+            subissue_ref,
+            write,
+            dry_run,
+        } => project_relationship_add_subissue(
+            workflow_path,
+            parent_ref,
+            subissue_ref,
+            write,
+            dry_run,
+        ),
         Command::Doctor { options } => doctor(options),
         Command::DoctorRepairHumanReview {
             workflow_path,
@@ -260,6 +298,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             project,
             project_fields,
             assignees,
+            relationships,
             write,
             dry_run,
         } => forge_create(ForgeCreateOptions {
@@ -270,6 +309,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             project,
             project_fields,
             assignees,
+            relationships,
             write,
             dry_run,
         }),
@@ -279,17 +319,19 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             title,
             markdown,
             promotion_note,
+            relationships,
             write,
             dry_run,
-        } => forge_promote(
+        } => forge_promote(crate::commands::forge::ForgePromoteInput {
             workflow_path,
             issue_ref,
             title,
             markdown,
             promotion_note,
+            relationships,
             write,
             dry_run,
-        ),
+        }),
         Command::ForgeRework { options } => forge_rework(options),
         Command::Help(text) => {
             print!("{text}");

--- a/src/main/tests.rs
+++ b/src/main/tests.rs
@@ -20,11 +20,11 @@ use super::commands::doctor::{
 };
 use super::commands::forge::{
     find_duplicate_issue_title, forge_create_requires_assignee, forge_missing_categories,
-    forge_rework_with_adapter, forge_validation_report, issue_contract_assignees,
+    forge_promote, forge_rework_with_adapter, forge_validation_report, issue_contract_assignees,
     render_forge_create_success, render_promotion_note, validate_forge_create_contract,
     validate_forge_create_report_with_assignees, verify_forge_created_issue_status,
-    write_forge_created_issue, ForgeCreateResult, ForgeCreateWriteInput, ForgeReworkInput,
-    PromotionNoteInput,
+    write_forge_created_issue, ForgeCreateResult, ForgeCreateWriteInput, ForgePromoteInput,
+    ForgeRelationshipPlan, ForgeReworkInput, PromotionNoteInput,
 };
 use super::commands::gate::live_missing_assignee_gate_blocker;
 use super::commands::project::{

--- a/src/main/tests/forge.rs
+++ b/src/main/tests/forge.rs
@@ -358,6 +358,7 @@ fn forge_create_entrypoint_rejects_live_github_without_assignee() {
         project: None,
         project_fields: Vec::new(),
         assignees: Vec::new(),
+        relationships: ForgeRelationshipPlan::default(),
         write: true,
         dry_run: false,
     })
@@ -417,6 +418,7 @@ fn forge_create_blocks_duplicate_tracker_title_before_mutation() {
         project: None,
         project_fields: Vec::new(),
         assignees: Vec::new(),
+        relationships: ForgeRelationshipPlan::default(),
         write: true,
         dry_run: false,
     })
@@ -446,6 +448,7 @@ fn forge_create_can_use_memory_tracker_adapter() {
         project: None,
         project_fields: Vec::new(),
         assignees: Vec::new(),
+        relationships: ForgeRelationshipPlan::default(),
         write: true,
         dry_run: false,
     })
@@ -469,6 +472,7 @@ fn forge_create_write_initializes_backlog_without_status_transition() {
             status: ForgeStatusArg::Backlog,
             project_label: "test project",
             project_fields: &[],
+            relationships: &ForgeRelationshipPlan::default(),
         },
     )
     .unwrap();
@@ -489,6 +493,80 @@ fn forge_create_write_initializes_backlog_without_status_transition() {
             .normalized_state(),
         "backlog"
     );
+}
+
+fn test_promotion_note() -> PromotionNoteInput {
+    PromotionNoteInput {
+        operator_confirmation: "promote it".into(),
+        decisions: vec!["Promote the Backlog seed through Forge.".into()],
+        scope_changes: vec!["Backlog seed becomes an executable Todo issue.".into()],
+        dependencies_context: vec!["Relationship requirements are explicit.".into()],
+        readback_summaries: vec!["Operator reviewed the dry-run preview.".into()],
+    }
+}
+
+fn memory_workflow_with_backlog_issue() -> (tempfile::TempDir, PathBuf) {
+    let temp = tempfile::tempdir().unwrap();
+    let fixture_path = temp.path().join("issues.json");
+    let workflow_path = temp.path().join("WORKFLOW.md");
+    let mut issue = tracker_issue_with_ref("#360", "Backlog child seed", "Backlog");
+    issue.assignees = vec!["Alive24".into()];
+    std::fs::write(&fixture_path, serde_json::to_string(&vec![issue]).unwrap()).unwrap();
+    std::fs::write(
+        &workflow_path,
+        format!(
+            "---\ntracker:\n  kind: memory\n  fixture_path: {}\nobservability:\n  logs_root: log\n---\nPrompt",
+            fixture_path.display()
+        ),
+    )
+    .unwrap();
+    (temp, workflow_path)
+}
+
+#[test]
+fn forge_todo_promotion_rejects_issue_setup_blocker_without_relationship_plan() {
+    let (_temp, workflow_path) = memory_workflow_with_backlog_issue();
+    let body = forge_contract().replace(
+        "- UAT Required: No",
+        "- UAT Required: No\n- Dependencies: Blocked By: #358 must finish before this issue dispatches.",
+    );
+
+    let error = forge_promote(ForgePromoteInput {
+        workflow_path,
+        issue_ref: "#360".into(),
+        title: "Promoted child".into(),
+        markdown: body,
+        promotion_note: test_promotion_note(),
+        relationships: ForgeRelationshipPlan::default(),
+        write: false,
+        dry_run: true,
+    })
+    .unwrap_err()
+    .to_string();
+
+    assert!(error.contains("forge promote stopped at validate"));
+    assert!(error.contains("promoted body failed Todo gate"));
+}
+
+#[test]
+fn forge_todo_promotion_accepts_issue_setup_dependencies_none() {
+    let (_temp, workflow_path) = memory_workflow_with_backlog_issue();
+    let body = forge_contract().replace(
+        "- UAT Required: No",
+        "- UAT Required: No\n- Dependencies: None",
+    );
+
+    forge_promote(ForgePromoteInput {
+        workflow_path,
+        issue_ref: "#360".into(),
+        title: "Promoted child".into(),
+        markdown: body,
+        promotion_note: test_promotion_note(),
+        relationships: ForgeRelationshipPlan::default(),
+        write: false,
+        dry_run: true,
+    })
+    .unwrap();
 }
 
 #[test]

--- a/src/main/tests/parser/forge.rs
+++ b/src/main/tests/parser/forge.rs
@@ -31,6 +31,7 @@ fn parses_forge_create_flags() {
         project,
         project_fields,
         assignees,
+        relationships,
         write,
         dry_run,
     } = command
@@ -51,6 +52,7 @@ fn parses_forge_create_flags() {
         }]
     );
     assert_eq!(assignees, vec!["@Alive24".to_string()]);
+    assert!(relationships.is_empty());
     assert!(write);
     assert!(!dry_run);
 }
@@ -87,6 +89,7 @@ fn parses_forge_promote_flags() {
         title,
         markdown,
         promotion_note,
+        relationships,
         write,
         dry_run,
     } = command
@@ -107,6 +110,7 @@ fn parses_forge_promote_flags() {
         promotion_note.readback_summaries,
         vec!["Operator confirmed the dry-run preview before write.".to_string()]
     );
+    assert!(relationships.is_empty());
     assert!(!write);
     assert!(dry_run);
 }

--- a/src/main/tests/support.rs
+++ b/src/main/tests/support.rs
@@ -98,8 +98,7 @@ pub(crate) fn live_github_config(allow_unassigned: bool) -> RuntimeConfig {
     let workflow = WorkflowDefinition::parse(
             "/tmp/WORKFLOW.md",
             &format!(
-                "---\ntracker:\n  kind: github_project_v2\n  owner: Alive24\n  repo: shea-symphony\n  project_owner: Alive24\n  project_number: 9\n  assignee_filter:\n    allow_unassigned: {}\n---\nPrompt",
-                allow_unassigned
+                "---\ntracker:\n  kind: github_project_v2\n  owner: Alive24\n  repo: shea-symphony\n  project_owner: Alive24\n  project_number: 9\n  assignee_filter:\n    allow_unassigned: {allow_unassigned}\n---\nPrompt"
             ),
         )
         .unwrap();
@@ -448,6 +447,92 @@ impl TrackerAdapter for RecordingAdapter {
     ) -> Result<Vec<shea_symphony::model::LinkedPullRequest>, shea_symphony::tracker::TrackerError>
     {
         Ok(self.linked_pull_requests.borrow().clone())
+    }
+
+    fn relationship_readback(
+        &self,
+        issue_ref: &str,
+    ) -> Result<
+        shea_symphony::tracker::IssueRelationshipReadback,
+        shea_symphony::tracker::TrackerError,
+    > {
+        let issue = self
+            .issues
+            .borrow()
+            .get(issue_ref)
+            .cloned()
+            .ok_or_else(|| {
+                shea_symphony::tracker::TrackerError::Payload(format!(
+                    "issue not found: {issue_ref}"
+                ))
+            })?;
+        Ok(shea_symphony::tracker::relationship_readback_from_issue(
+            &issue,
+        ))
+    }
+
+    fn add_blocked_by_relationship(
+        &self,
+        issue_ref: &str,
+        blocker_ref: &str,
+    ) -> Result<
+        shea_symphony::tracker::IssueRelationshipReadback,
+        shea_symphony::tracker::TrackerError,
+    > {
+        if let Some(issue) = self.issues.borrow_mut().get_mut(issue_ref) {
+            if !issue
+                .blocked_by
+                .iter()
+                .any(|blocker| blocker.identifier.as_deref() == Some(blocker_ref))
+            {
+                issue.blocked_by.push(shea_symphony::model::BlockerRef {
+                    id: None,
+                    identifier: Some(blocker_ref.to_string()),
+                    state: Some("closed".into()),
+                });
+            }
+        }
+        self.operations
+            .borrow_mut()
+            .push(format!("add_blocked_by:{issue_ref}:{blocker_ref}"));
+        self.relationship_readback(issue_ref)
+    }
+
+    fn add_subissue_relationship(
+        &self,
+        parent_ref: &str,
+        subissue_ref: &str,
+    ) -> Result<
+        shea_symphony::tracker::IssueRelationshipReadback,
+        shea_symphony::tracker::TrackerError,
+    > {
+        if let Some(parent) = self.issues.borrow_mut().get_mut(parent_ref) {
+            let mut subissues = parent
+                .project_fields
+                .get("GitHub Native Subissues")
+                .and_then(serde_json::Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            if !subissues.iter().any(|subissue| {
+                subissue
+                    .get("identifier")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(subissue_ref)
+            }) {
+                subissues.push(serde_json::json!({
+                    "identifier": subissue_ref,
+                    "project_state": "Backlog"
+                }));
+            }
+            parent.project_fields.insert(
+                "GitHub Native Subissues".into(),
+                serde_json::Value::Array(subissues),
+            );
+        }
+        self.operations
+            .borrow_mut()
+            .push(format!("add_subissue:{parent_ref}:{subissue_ref}"));
+        self.relationship_readback(parent_ref)
     }
 
     fn close_issue(&self, issue_ref: &str) -> Result<(), shea_symphony::tracker::TrackerError> {

--- a/src/orchestration/tracker_recovery.rs
+++ b/src/orchestration/tracker_recovery.rs
@@ -279,8 +279,7 @@ pub(crate) fn set_state_with_recovery(
 ) -> Result<TrackerMutationOutcome, Box<dyn std::error::Error>> {
     if initial_issue.is_some_and(|issue| issue_state_matches(issue, normalized_state)) {
         println!(
-            "tracker_recovery action=already_applied mutation_type={} issue={} state={}",
-            mutation_type, issue_ref, normalized_state
+            "tracker_recovery action=already_applied mutation_type={mutation_type} issue={issue_ref} state={normalized_state}"
         );
         return Ok(TrackerMutationOutcome::AlreadyApplied);
     }

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -104,7 +104,7 @@ pub fn render_project_state_panel(issues: &[TrackerIssue], integration_gaps: &[S
             title: "States".into(),
             rows: state_counts
                 .into_iter()
-                .map(|(state, count)| row(state, format!("{}", count)))
+                .map(|(state, count)| row(state, format!("{count}")))
                 .collect(),
         },
     ];

--- a/src/quality_gate.rs
+++ b/src/quality_gate.rs
@@ -394,11 +394,44 @@ fn validate_dependency_semantics(issue: &TrackerIssue, markdown: &str) -> Result
         return Ok(());
     }
 
-    let lines = section_lines(markdown, "Dependencies");
-    let dependencies = lines
+    let mut dependencies = setup_dependency_values(markdown);
+    dependencies.extend(
+        section_lines(markdown, "Dependencies")
+            .iter()
+            .filter_map(|line| line.trim().strip_prefix('-'))
+            .map(clean_markdown_value)
+            .filter(|value| !value.trim().is_empty()),
+    );
+
+    if dependencies.is_empty() {
+        return Ok(());
+    }
+
+    validate_dependency_values(&dependencies)
+}
+
+fn setup_dependency_values(markdown: &str) -> Vec<String> {
+    section_lines(markdown, "Issue Setup")
         .iter()
-        .filter_map(|line| line.trim().strip_prefix('-'))
-        .map(clean_markdown_value)
+        .filter_map(|line| setup_dependency_value(line))
+        .filter(|value| !value.trim().is_empty())
+        .collect()
+}
+
+fn setup_dependency_value(line: &str) -> Option<String> {
+    let line = line.trim().trim_start_matches('-').trim();
+    let (label, value) = line.split_once(':')?;
+    if label.trim().eq_ignore_ascii_case("Dependencies") {
+        Some(clean_markdown_value(value))
+    } else {
+        None
+    }
+}
+
+fn validate_dependency_values(dependencies: &[String]) -> Result<(), String> {
+    let dependencies = dependencies
+        .iter()
+        .map(|value| clean_markdown_value(value))
         .filter(|value| !value.trim().is_empty())
         .collect::<Vec<_>>();
 
@@ -406,12 +439,21 @@ fn validate_dependency_semantics(issue: &TrackerIssue, markdown: &str) -> Result
         return Ok(());
     }
 
-    let joined = dependencies.join(" ").to_ascii_lowercase();
-    if contains_ambiguous_dependency_marker(&joined) {
+    let normalized = dependencies
+        .iter()
+        .map(|dependency| dependency.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    if normalized
+        .iter()
+        .any(|dependency| contains_ambiguous_dependency_marker(dependency))
+    {
         Err("resolved dependency semantics".into())
-    } else if claims_blocking_dependency_without_relationship(&joined) {
+    } else if normalized
+        .iter()
+        .any(|dependency| claims_blocking_dependency_without_relationship(dependency))
+    {
         Err("structured blocked-by relationship".into())
-    } else if contains_any_dependency_marker(&joined) {
+    } else if contains_any_dependency_marker(&normalized.join(" ")) {
         Ok(())
     } else {
         Err("resolved dependency semantics".into())
@@ -936,6 +978,33 @@ mod tests {
         assert!(decision
             .missing
             .contains(&"structured blocked-by relationship".to_string()));
+    }
+
+    #[test]
+    fn issue_setup_dependency_blocker_needs_structured_relationship() {
+        let body = aligned_body_with_uat("No").replace(
+            "- UAT Required: No",
+            "- UAT Required: No\n- Dependencies: Blocked By: #358 must finish before this issue dispatches.",
+        );
+
+        let decision = evaluate_issue(&issue(Some(body)));
+
+        assert_eq!(decision.kind, GateDecisionKind::NeedToClarify);
+        assert!(decision
+            .missing
+            .contains(&"structured blocked-by relationship".to_string()));
+    }
+
+    #[test]
+    fn issue_setup_dependency_none_is_dispatchable() {
+        let body = aligned_body_with_uat("No").replace(
+            "- UAT Required: No",
+            "- UAT Required: No\n- Dependencies: None",
+        );
+
+        let decision = evaluate_issue(&issue(Some(body)));
+
+        assert!(decision.is_dispatchable(), "{decision:?}");
     }
 
     #[test]

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -4,9 +4,9 @@ use std::fs;
 #[cfg(test)]
 use crate::config::AssigneeFilter;
 use crate::config::RuntimeConfig;
-#[cfg(test)]
-use crate::model::BlockerRef;
-use crate::model::{LinkedPullRequest, TrackerIssue};
+use crate::model::{
+    native_parent_identifier, native_subissue_statuses, BlockerRef, LinkedPullRequest, TrackerIssue,
+};
 
 mod error;
 mod follow_up;
@@ -27,6 +27,42 @@ pub use linear::LinearAdapter;
 pub use memory::MemoryTracker;
 pub use project_field::ProjectFieldAssignment;
 pub use state::{claim_decision, ClaimDecision};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct IssueRelationshipRef {
+    pub id: Option<String>,
+    pub identifier: String,
+    pub title: Option<String>,
+    pub github_state: Option<String>,
+    pub url: Option<String>,
+    pub project_state: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct IssueRelationshipReadback {
+    pub issue_identifier: String,
+    pub native_parent: Option<String>,
+    pub blocked_by: Vec<BlockerRef>,
+    pub native_subissues: Vec<IssueRelationshipRef>,
+}
+
+impl IssueRelationshipReadback {
+    pub fn has_blocker(&self, blocker_ref: &str) -> bool {
+        self.blocked_by.iter().any(|blocker| {
+            blocker
+                .identifier
+                .as_deref()
+                .is_some_and(|identifier| issue_refs_match(identifier, blocker_ref))
+                || blocker.id.as_deref().is_some_and(|id| id == blocker_ref)
+        })
+    }
+
+    pub fn has_native_subissue(&self, subissue_ref: &str) -> bool {
+        self.native_subissues
+            .iter()
+            .any(|subissue| issue_refs_match(&subissue.identifier, subissue_ref))
+    }
+}
 
 #[cfg(test)]
 use follow_up::follow_up_issue_body;
@@ -126,6 +162,35 @@ pub trait TrackerAdapter {
         &self,
         issue_ref: &str,
     ) -> Result<Vec<LinkedPullRequest>, TrackerError>;
+    fn relationship_readback(
+        &self,
+        issue_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        Err(TrackerError::NotImplemented(format!(
+            "{} tracker does not support issue relationship readback for {issue_ref}",
+            self.kind()
+        )))
+    }
+    fn add_blocked_by_relationship(
+        &self,
+        issue_ref: &str,
+        blocker_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        Err(TrackerError::NotImplemented(format!(
+            "{} tracker does not support adding blocked-by relationship {issue_ref} <- {blocker_ref}",
+            self.kind()
+        )))
+    }
+    fn add_subissue_relationship(
+        &self,
+        parent_ref: &str,
+        subissue_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        Err(TrackerError::NotImplemented(format!(
+            "{} tracker does not support adding native subissue relationship {parent_ref} -> {subissue_ref}",
+            self.kind()
+        )))
+    }
     fn close_issue(&self, _issue_ref: &str) -> Result<(), TrackerError> {
         Err(TrackerError::NotImplemented(format!(
             "{} tracker does not support issue closure",
@@ -263,6 +328,35 @@ fn apply_github_read_filters(
         .into_iter()
         .filter(|issue| issue_matches_assignee_filter(issue, &config.tracker.assignee_filter))
         .collect()
+}
+
+pub fn relationship_readback_from_issue(issue: &TrackerIssue) -> IssueRelationshipReadback {
+    let native_subissues = native_subissue_statuses(issue)
+        .into_iter()
+        .map(|subissue| IssueRelationshipRef {
+            id: None,
+            identifier: subissue.identifier,
+            title: None,
+            github_state: subissue.github_state,
+            url: None,
+            project_state: subissue.project_state,
+        })
+        .collect();
+
+    IssueRelationshipReadback {
+        issue_identifier: issue.identifier.clone(),
+        native_parent: native_parent_identifier(issue),
+        blocked_by: issue.blocked_by.clone(),
+        native_subissues,
+    }
+}
+
+fn issue_refs_match(left: &str, right: &str) -> bool {
+    let left = left.trim();
+    let right = right.trim();
+    left.eq_ignore_ascii_case(right)
+        || (github_issue_number(left).is_some()
+            && github_issue_number(left) == github_issue_number(right))
 }
 
 fn github_issue_needs_native_blocker_prefetch(
@@ -503,6 +597,51 @@ impl TrackerAdapter for GithubProjectV2Adapter {
         }
 
         GithubProjectV2GhClient::new(&self.config).list_linked_pull_requests(issue_ref)
+    }
+
+    fn relationship_readback(
+        &self,
+        issue_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        if self.config.tracker.fixture_path.is_some() {
+            return MemoryTracker::new(self.fixture_issues.clone())
+                .relationship_readback(issue_ref);
+        }
+
+        let issue = self
+            .get_issue(issue_ref)?
+            .ok_or_else(|| TrackerError::Payload(format!("issue not found: {issue_ref}")))?;
+        Ok(relationship_readback_from_issue(&issue))
+    }
+
+    fn add_blocked_by_relationship(
+        &self,
+        issue_ref: &str,
+        blocker_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        if self.config.tracker.fixture_path.is_some() {
+            return Err(TrackerError::IntegrationUnavailable(
+                "GitHub Project v2 fixture mode cannot mutate live issue relationships".into(),
+            ));
+        }
+
+        GithubProjectV2GhClient::new(&self.config)
+            .add_blocked_by_relationship(issue_ref, blocker_ref)
+    }
+
+    fn add_subissue_relationship(
+        &self,
+        parent_ref: &str,
+        subissue_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        if self.config.tracker.fixture_path.is_some() {
+            return Err(TrackerError::IntegrationUnavailable(
+                "GitHub Project v2 fixture mode cannot mutate live issue relationships".into(),
+            ));
+        }
+
+        GithubProjectV2GhClient::new(&self.config)
+            .add_subissue_relationship(parent_ref, subissue_ref)
     }
 
     fn close_issue(&self, issue_ref: &str) -> Result<(), TrackerError> {

--- a/src/tracker/github/client.rs
+++ b/src/tracker/github/client.rs
@@ -8,7 +8,7 @@ use crate::model::{normalize_state, LinkedPullRequest, TrackerIssue};
 mod project;
 mod read;
 
-use super::cli::{gh_available, GithubCliAccess};
+use super::cli::{gh_available, run_gh_api_json, GithubCliAccess};
 use super::evidence::github_issue_number;
 use super::project_v2::{
     apply_rest_project_item_overlay_fallback, apply_rest_project_item_overlays,
@@ -24,7 +24,10 @@ use super::GithubProjectReadMode;
 use crate::tracker::follow_up::follow_up_issue_body;
 use crate::tracker::state::status_update_required;
 use crate::tracker::workpad::{duplicate_workpad_body, ensure_workpad_marker, merge_workpad_body};
-use crate::tracker::{FollowUpIssueInput, ProjectFieldAssignment, TrackerError};
+use crate::tracker::{
+    relationship_readback_from_issue, FollowUpIssueInput, IssueRelationshipReadback,
+    ProjectFieldAssignment, TrackerError,
+};
 
 #[derive(Debug, Clone)]
 pub(in crate::tracker) struct GithubProjectV2GhClient {
@@ -538,6 +541,129 @@ impl GithubProjectV2GhClient {
         Ok(issue.linked_pull_requests)
     }
 
+    pub(in crate::tracker) fn add_blocked_by_relationship(
+        &self,
+        issue_ref: &str,
+        blocker_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        let issue = self.resolve_github_rest_issue_identity(issue_ref)?;
+        let blocker = self.resolve_github_rest_issue_identity(blocker_ref)?;
+        let readback = relationship_readback_from_issue(&self.resolve_issue(&issue.identifier)?);
+        if readback.has_blocker(&blocker.identifier) {
+            return Ok(readback);
+        }
+
+        let owner = self
+            .config
+            .tracker
+            .owner
+            .as_deref()
+            .ok_or_else(|| TrackerError::Payload("tracker.owner is required".into()))?;
+        let repo = self
+            .config
+            .tracker
+            .repo
+            .as_deref()
+            .ok_or_else(|| TrackerError::Payload("tracker.repo is required".into()))?;
+        GithubCliAccess::run_status(
+            github_add_blocked_by_args(owner, repo, issue.number, blocker.rest_id),
+            "github issue dependency add",
+        )?;
+
+        let verified = relationship_readback_from_issue(&self.resolve_issue(&issue.identifier)?);
+        if verified.has_blocker(&blocker.identifier) {
+            Ok(verified)
+        } else {
+            Err(TrackerError::IntegrationUnavailable(format!(
+                "blocked-by relationship readback missing: issue={} blocked_by={}",
+                issue.identifier, blocker.identifier
+            )))
+        }
+    }
+
+    pub(in crate::tracker) fn add_subissue_relationship(
+        &self,
+        parent_ref: &str,
+        subissue_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        let parent = self.resolve_github_rest_issue_identity(parent_ref)?;
+        let subissue = self.resolve_github_rest_issue_identity(subissue_ref)?;
+        let readback = relationship_readback_from_issue(&self.resolve_issue(&parent.identifier)?);
+        if readback.has_native_subissue(&subissue.identifier) {
+            return Ok(readback);
+        }
+
+        let owner = self
+            .config
+            .tracker
+            .owner
+            .as_deref()
+            .ok_or_else(|| TrackerError::Payload("tracker.owner is required".into()))?;
+        let repo = self
+            .config
+            .tracker
+            .repo
+            .as_deref()
+            .ok_or_else(|| TrackerError::Payload("tracker.repo is required".into()))?;
+        GithubCliAccess::run_status(
+            github_add_subissue_args(owner, repo, parent.number, subissue.rest_id),
+            "github native subissue add",
+        )?;
+
+        let verified = relationship_readback_from_issue(&self.resolve_issue(&parent.identifier)?);
+        if verified.has_native_subissue(&subissue.identifier) {
+            Ok(verified)
+        } else {
+            Err(TrackerError::IntegrationUnavailable(format!(
+                "native subissue relationship readback missing: parent={} subissue={}",
+                parent.identifier, subissue.identifier
+            )))
+        }
+    }
+
+    fn resolve_github_rest_issue_identity(
+        &self,
+        issue_ref: &str,
+    ) -> Result<GithubRestIssueIdentity, TrackerError> {
+        let issue = self.resolve_issue(issue_ref)?;
+        let number = github_issue_number(&issue.identifier).ok_or_else(|| {
+            TrackerError::Payload(format!(
+                "issue ref {issue_ref:?} did not resolve to a GitHub issue number"
+            ))
+        })?;
+        let owner = self
+            .config
+            .tracker
+            .owner
+            .as_deref()
+            .ok_or_else(|| TrackerError::Payload("tracker.owner is required".into()))?;
+        let repo = self
+            .config
+            .tracker
+            .repo
+            .as_deref()
+            .ok_or_else(|| TrackerError::Payload("tracker.repo is required".into()))?;
+        let response = run_gh_api_json(vec![
+            "api".into(),
+            format!("repos/{owner}/{repo}/issues/{number}"),
+        ])?;
+        let rest_id = response
+            .get("id")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| {
+                TrackerError::Payload(format!(
+                    "GitHub REST issue response missing numeric id for {}",
+                    issue.identifier
+                ))
+            })?;
+
+        Ok(GithubRestIssueIdentity {
+            number,
+            rest_id,
+            identifier: issue.identifier,
+        })
+    }
+
     pub(in crate::tracker) fn close_issue(&self, issue_ref: &str) -> Result<(), TrackerError> {
         let issue = self.resolve_issue(issue_ref)?;
         if issue
@@ -656,4 +782,43 @@ fn project_owner_type_miss(error: &TrackerError) -> bool {
         || message.contains("could not resolve to user")
         || message.contains("not an organization account")
         || message.contains("not a user account")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GithubRestIssueIdentity {
+    number: u64,
+    rest_id: u64,
+    identifier: String,
+}
+
+fn github_add_blocked_by_args(
+    owner: &str,
+    repo: &str,
+    issue_number: u64,
+    blocker_rest_id: u64,
+) -> Vec<String> {
+    vec![
+        "api".into(),
+        "-X".into(),
+        "POST".into(),
+        format!("repos/{owner}/{repo}/issues/{issue_number}/dependencies/blocked_by"),
+        "-F".into(),
+        format!("issue_id={blocker_rest_id}"),
+    ]
+}
+
+fn github_add_subissue_args(
+    owner: &str,
+    repo: &str,
+    parent_number: u64,
+    subissue_rest_id: u64,
+) -> Vec<String> {
+    vec![
+        "api".into(),
+        "-X".into(),
+        "POST".into(),
+        format!("repos/{owner}/{repo}/issues/{parent_number}/sub_issues"),
+        "-F".into(),
+        format!("sub_issue_id={subissue_rest_id}"),
+    ]
 }

--- a/src/tracker/memory.rs
+++ b/src/tracker/memory.rs
@@ -2,7 +2,8 @@ use crate::config::RuntimeConfig;
 use crate::model::{normalize_state, LinkedPullRequest, TrackerIssue};
 
 use super::{
-    load_fixture, FollowUpIssueInput, ProjectFieldAssignment, TrackerAdapter, TrackerError,
+    load_fixture, relationship_readback_from_issue, FollowUpIssueInput, IssueRelationshipReadback,
+    ProjectFieldAssignment, TrackerAdapter, TrackerError,
 };
 
 #[derive(Debug, Clone)]
@@ -109,6 +110,16 @@ impl TrackerAdapter for MemoryTracker {
             .get_issue(issue_ref)?
             .map(|issue| issue.linked_pull_requests)
             .unwrap_or_default())
+    }
+
+    fn relationship_readback(
+        &self,
+        issue_ref: &str,
+    ) -> Result<IssueRelationshipReadback, TrackerError> {
+        let issue = self
+            .get_issue(issue_ref)?
+            .ok_or_else(|| TrackerError::Payload(format!("issue not found: {issue_ref}")))?;
+        Ok(relationship_readback_from_issue(&issue))
     }
 
     fn close_issue(&self, _issue_ref: &str) -> Result<(), TrackerError> {


### PR DESCRIPTION
## Summary
- Implements #364: Add Forge and Project relationship support for blockers and native subissues.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #364
