### PR TITLE
feat: implement parent integration branch management for subissues

### DIFF
--- a/src/commands/autopilot/looping.rs
+++ b/src/commands/autopilot/looping.rs
@@ -680,9 +680,9 @@ fn autopilot_main_recovery_can_tick(
     settings: AutopilotLoopSettings,
 ) -> bool {
     settings.write
-        && settings.recover
         && settings.main_max_concurrent > 0
-        && autopilot_main_recovery_blocker_is_lane_local(plan)
+        && (settings.recover && autopilot_main_recovery_blocker_is_lane_local(plan)
+            || autopilot_main_parent_topology_can_tick(plan))
 }
 
 fn autopilot_main_recovery_blocker_is_lane_local(plan: &AutopilotPlanSnapshot) -> bool {
@@ -706,6 +706,21 @@ fn autopilot_main_recovery_blocker_is_lane_local(plan: &AutopilotPlanSnapshot) -
 
 fn autopilot_active_runtime_blocker(blocker: &str) -> bool {
     blocker.starts_with("active_runtime_states=")
+}
+
+fn autopilot_main_parent_topology_can_tick(plan: &AutopilotPlanSnapshot) -> bool {
+    plan.canonical_checkout.safe_for_write
+        && plan.doctor.blocker_codes == ["parent_topology_missing_integration_branch"]
+        && plan.readiness.blockers == ["doctor_blockers=1"]
+        && autopilot_lane_plan_should_tick(autopilot_plan_lane(Some(plan), "main"))
+}
+
+fn autopilot_readiness_blocker_is_main_recoverable(
+    plan: &AutopilotPlanSnapshot,
+    blocker: &str,
+) -> bool {
+    autopilot_active_runtime_blocker(blocker)
+        || (blocker == "doctor_blockers=1" && autopilot_main_parent_topology_can_tick(plan))
 }
 
 fn print_autopilot_lane_running(
@@ -1031,7 +1046,7 @@ pub(crate) fn autopilot_loop_status_from_plan(
         plan.readiness
             .blockers
             .iter()
-            .filter(|blocker| !autopilot_active_runtime_blocker(blocker))
+            .filter(|blocker| !autopilot_readiness_blocker_is_main_recoverable(plan, blocker))
             .cloned()
             .collect::<Vec<_>>()
     } else {

--- a/src/git_handoff.rs
+++ b/src/git_handoff.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::handoff::IssueHandoffPlan;
+use crate::handoff::{BranchTargetRole, IssueHandoffPlan};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiveWorktreeResult {
@@ -173,21 +173,9 @@ pub fn prepare_issue_worktree(
         fs::create_dir_all(parent)?;
     }
 
-    let branch_ref = format!("refs/heads/{}", plan.branch_name);
-    let branch_exists = command_status(
-        "git",
-        &[
-            "-C".into(),
-            repo_root.display().to_string(),
-            "show-ref".into(),
-            "--verify".into(),
-            "--quiet".into(),
-            branch_ref,
-        ],
-        repo_root,
-        runner,
-    )? == 0;
+    ensure_local_parent_integration_branch(repo_root, plan, runner)?;
 
+    let branch_exists = local_branch_exists(repo_root, &plan.branch_name, runner)?;
     let args = if branch_exists {
         vec![
             "-C".into(),
@@ -223,6 +211,7 @@ pub fn publish_issue_pull_request(
     runner: &dyn HandoffCommandRunner,
 ) -> Result<PullRequestPublication, GitHandoffError> {
     ensure_publishable_branch(plan, runner)?;
+    ensure_remote_parent_integration_branch(plan, runner)?;
 
     require_success(
         "git",
@@ -282,6 +271,104 @@ pub fn publish_issue_pull_request(
         pr_url: extract_url(&created.stdout)?,
         pr_created: true,
     })
+}
+
+fn ensure_local_parent_integration_branch(
+    repo_root: &Path,
+    plan: &IssueHandoffPlan,
+    runner: &dyn HandoffCommandRunner,
+) -> Result<(), GitHandoffError> {
+    if plan.branch_target.role != BranchTargetRole::Subissue {
+        return Ok(());
+    }
+    let Some(parent_branch) = &plan.branch_target.parent_integration_branch else {
+        return Ok(());
+    };
+    if local_branch_exists(repo_root, parent_branch, runner)? {
+        return Ok(());
+    }
+
+    let base_branch = plan
+        .branch_target
+        .parent_final_base_branch
+        .as_deref()
+        .unwrap_or("main");
+    require_success(
+        "git",
+        runner.run(
+            "git",
+            &[
+                "-C".into(),
+                repo_root.display().to_string(),
+                "branch".into(),
+                parent_branch.clone(),
+                base_branch.into(),
+            ],
+            repo_root,
+        )?,
+    )
+}
+
+fn ensure_remote_parent_integration_branch(
+    plan: &IssueHandoffPlan,
+    runner: &dyn HandoffCommandRunner,
+) -> Result<(), GitHandoffError> {
+    if plan.branch_target.role != BranchTargetRole::Subissue {
+        return Ok(());
+    }
+    let Some(parent_branch) = &plan.branch_target.parent_integration_branch else {
+        return Ok(());
+    };
+    let remote_exists = command_status(
+        "git",
+        &[
+            "ls-remote".into(),
+            "--exit-code".into(),
+            "--heads".into(),
+            "origin".into(),
+            parent_branch.clone(),
+        ],
+        &plan.workspace_path,
+        runner,
+    )? == 0;
+    if remote_exists {
+        return Ok(());
+    }
+
+    require_success(
+        "git",
+        runner.run(
+            "git",
+            &[
+                "push".into(),
+                "-u".into(),
+                "origin".into(),
+                parent_branch.clone(),
+            ],
+            &plan.workspace_path,
+        )?,
+    )
+}
+
+fn local_branch_exists(
+    repo_root: &Path,
+    branch_name: &str,
+    runner: &dyn HandoffCommandRunner,
+) -> Result<bool, GitHandoffError> {
+    let branch_ref = format!("refs/heads/{branch_name}");
+    Ok(command_status(
+        "git",
+        &[
+            "-C".into(),
+            repo_root.display().to_string(),
+            "show-ref".into(),
+            "--verify".into(),
+            "--quiet".into(),
+            branch_ref,
+        ],
+        repo_root,
+        runner,
+    )? == 0)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -540,6 +627,7 @@ mod tests {
         dirty_status: Option<String>,
         ahead_count: u32,
         pr_is_draft: bool,
+        remote_parent_branch_exists: bool,
     }
 
     impl FakeRunner {
@@ -564,6 +652,17 @@ mod tests {
             if command.contains("show-ref --verify --quiet") {
                 return Ok(CommandOutput {
                     status: if self.existing_branch { 0 } else { 1 },
+                    stdout: String::new(),
+                    stderr: String::new(),
+                });
+            }
+            if command.contains("ls-remote --exit-code --heads") {
+                return Ok(CommandOutput {
+                    status: if self.remote_parent_branch_exists {
+                        0
+                    } else {
+                        2
+                    },
                     stdout: String::new(),
                     stderr: String::new(),
                 });
@@ -672,6 +771,22 @@ mod tests {
         }
     }
 
+    fn subissue() -> TrackerIssue {
+        let mut issue = issue();
+        issue.identifier = "#383".into();
+        issue.title = "Surface write queue state in Tauri".into();
+        issue
+            .project_fields
+            .insert("Native Parent Issue".into(), serde_json::json!("#400"));
+        issue.project_fields.insert(
+            "Native Parent Title".into(),
+            serde_json::json!(
+                "Harden operator trust for supervised dogfood before persistent service mode"
+            ),
+        );
+        issue
+    }
+
     #[test]
     fn commits_dirty_issue_worktree_changes_before_handoff_publication() {
         let temp = tempfile::tempdir().unwrap();
@@ -722,6 +837,46 @@ mod tests {
         let commands = runner.commands.borrow().join("\n");
         assert!(commands.contains("show-ref --verify --quiet"));
         assert!(commands.contains("worktree add -b feature/issue-45"));
+    }
+
+    #[test]
+    fn creates_parent_integration_branch_before_subissue_worktree() {
+        let temp = tempfile::tempdir().unwrap();
+        let plan = plan_issue_handoff(temp.path(), &subissue(), "main").unwrap();
+        let runner = FakeRunner::default();
+
+        let result = prepare_issue_worktree(temp.path(), &plan, &runner).unwrap();
+
+        assert!(result.created);
+        let commands = runner.commands.borrow().join("\n");
+        assert!(commands.contains("git -C "));
+        assert!(commands.contains(
+            "branch integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s main"
+        ));
+        assert!(commands
+            .contains("worktree add -b feature/issue-383-surface-write-queue-state-in-tauri"));
+    }
+
+    #[test]
+    fn pushes_parent_integration_branch_before_subissue_pr_creation() {
+        let temp = tempfile::tempdir().unwrap();
+        let plan = plan_issue_handoff(temp.path(), &subissue(), "main").unwrap();
+        let runner = FakeRunner::clean_with_commits();
+
+        let publication = publish_issue_pull_request(&plan, &runner).unwrap();
+
+        assert!(publication.pr_created);
+        let commands = runner.commands.borrow().join("\n");
+        assert!(commands.contains(
+            "git ls-remote --exit-code --heads origin integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s"
+        ));
+        assert!(commands.contains(
+            "git push -u origin integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s"
+        ));
+        assert!(commands.contains("gh pr create --title #383: Surface write queue state in Tauri"));
+        assert!(commands.contains(
+            "--base integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s"
+        ));
     }
 
     #[test]

--- a/src/lanes/main_loop/write_candidate.rs
+++ b/src/lanes/main_loop/write_candidate.rs
@@ -1,5 +1,6 @@
 use shea_symphony::config::RuntimeConfig;
 use shea_symphony::git_handoff::{prepare_issue_worktree, ProcessHandoffCommandRunner};
+use shea_symphony::handoff::{BranchTargetRole, IssueHandoffPlan};
 use shea_symphony::lane_claim::{LaneClaimActor, LaneClaimSource};
 use shea_symphony::model::{normalize_state, LatestStatus, TrackerIssue};
 use shea_symphony::ownership::{runtime_ownership_decision, RuntimeOwnershipDecision};
@@ -83,6 +84,7 @@ pub(crate) fn run_loop_dispatch_write_candidate(
             return Ok(RunLoopWorkerOutcome::Completed);
         }
     };
+    ensure_parent_integration_branch_evidence(config, adapter, &latest, &handoff)?;
 
     let profile_login = selected_profile_github_login(config)?;
     let active_login = if live_github_tracker(config) && profile_login.is_none() {
@@ -561,4 +563,142 @@ pub(crate) fn run_loop_dispatch_write_candidate(
         runtime_state,
         &result,
     )
+}
+
+fn ensure_parent_integration_branch_evidence(
+    config: &RuntimeConfig,
+    adapter: &dyn TrackerAdapter,
+    issue: &TrackerIssue,
+    handoff: &IssueHandoffPlan,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if handoff.branch_target.role != BranchTargetRole::Subissue {
+        return Ok(());
+    }
+    let Some(parent_issue_ref) = handoff.branch_target.parent_issue.as_deref() else {
+        return Ok(());
+    };
+    let Some(parent_integration_branch) =
+        handoff.branch_target.parent_integration_branch.as_deref()
+    else {
+        return Ok(());
+    };
+
+    let parent_issue = run_with_progress_heartbeat(
+        progress_spec_with_event_log(config, "github_project_read")
+            .issue(parent_issue_ref.to_string())
+            .backend(tracker_backend_label(config))
+            .next("parent_topology_read"),
+        || adapter.get_issue(parent_issue_ref),
+    )?
+    .ok_or_else(|| {
+        format!(
+            "native parent issue {parent_issue_ref} disappeared before Main parent topology ensure"
+        )
+    })?;
+    if parent_issue_has_integration_branch_evidence(&parent_issue, parent_integration_branch) {
+        println!(
+            "run_loop_action=parent_topology issue={} parent={} branch={} outcome=already_recorded",
+            issue.identifier, parent_issue_ref, parent_integration_branch
+        );
+        return Ok(());
+    }
+
+    let workpad = run_loop_parent_topology_workpad(issue, &parent_issue, handoff);
+    let topology_key = recovery_key(
+        "main-parent-topology-workpad",
+        parent_issue_ref,
+        &format!(
+            "{}|{}|{}",
+            parent_issue_ref, issue.identifier, parent_integration_branch
+        ),
+    );
+    let topology_outcome = upsert_workpad_with_recovery(
+        adapter,
+        parent_issue_ref,
+        Some(&parent_issue),
+        &workpad,
+        &topology_key,
+    )?;
+    if topology_outcome.should_record_audit() {
+        append_tracker_mutation_audit(
+            config,
+            TrackerMutationAudit {
+                command: "main loop",
+                mutation_type: "workpad_write",
+                issue_ref: Some(parent_issue_ref),
+                target: Some(issue.identifier.clone()),
+                from_state: Some(parent_issue.state.clone()),
+                to_state: None,
+                reason: "parent integration branch evidence",
+            },
+        );
+    }
+    println!(
+        "run_loop_action=parent_topology issue={} parent={} branch={} outcome={}",
+        issue.identifier,
+        parent_issue_ref,
+        parent_integration_branch,
+        topology_outcome.as_str()
+    );
+    Ok(())
+}
+
+fn parent_issue_has_integration_branch_evidence(issue: &TrackerIssue, branch: &str) -> bool {
+    issue.branch_name.as_deref() == Some(branch)
+        || issue
+            .description
+            .as_deref()
+            .is_some_and(|description| description.contains(branch))
+        || issue
+            .project_fields
+            .values()
+            .any(|value| project_field_contains_branch(value, branch))
+}
+
+fn project_field_contains_branch(value: &serde_json::Value, branch: &str) -> bool {
+    match value {
+        serde_json::Value::String(value) => value == branch || value.contains(branch),
+        serde_json::Value::Array(values) => values
+            .iter()
+            .any(|value| project_field_contains_branch(value, branch)),
+        serde_json::Value::Object(values) => values
+            .values()
+            .any(|value| project_field_contains_branch(value, branch)),
+        _ => false,
+    }
+}
+
+fn run_loop_parent_topology_workpad(
+    issue: &TrackerIssue,
+    parent_issue: &TrackerIssue,
+    handoff: &IssueHandoffPlan,
+) -> String {
+    let parent_integration_branch = handoff
+        .branch_target
+        .parent_integration_branch
+        .as_deref()
+        .unwrap_or("n/a");
+    let parent_final_base_branch = handoff
+        .branch_target
+        .parent_final_base_branch
+        .as_deref()
+        .unwrap_or("n/a");
+    [
+        "## Shea Symphony Workpad".to_string(),
+        String::new(),
+        "### Parent Topology".to_string(),
+        format!(
+            "- Parent issue: {} {}",
+            parent_issue.identifier, parent_issue.title
+        ),
+        format!(
+            "- First observed subissue: {} {}",
+            issue.identifier, issue.title
+        ),
+        format!("- Parent integration branch: `{parent_integration_branch}`"),
+        format!("- Parent final base branch: `{parent_final_base_branch}`"),
+        "- Source: `shea-symphony main loop parent topology ensure`".to_string(),
+        "- Purpose: durable branch evidence before native subissue PR handoff.".to_string(),
+    ]
+    .join("\n")
 }

--- a/src/main/tests/autopilot.rs
+++ b/src/main/tests/autopilot.rs
@@ -35,7 +35,7 @@ fn clean_autopilot_doctor(total_issues: usize) -> ProjectAuditReport {
 }
 
 fn test_autopilot_plan(issues: Vec<TrackerIssue>) -> AutopilotPlanSnapshot {
-    let config = test_config();
+    let config = main_loop_test_config();
     let adapter = shea_symphony::tracker::MemoryTracker::new(issues.clone());
     build_autopilot_plan_from_parts(AutopilotPlanInputs {
         workflow_path: Path::new("/tmp/WORKFLOW.md"),
@@ -274,6 +274,110 @@ fn autopilot_loop_status_allows_main_recovery_runtime_blocker() {
     assert_eq!(status.counts.running, 1);
     assert!(status.blocked_reasons.is_empty());
     assert_eq!(status.active_issues[0].identifier, "#364");
+}
+
+#[test]
+fn autopilot_loop_status_allows_main_parent_topology_ensure() {
+    let config = main_loop_test_config();
+    let mut subissue = tracker_issue_with_ref("#383", "Surface write queue state", "Todo");
+    subissue.description = Some(
+        [
+            "## Issue Setup",
+            "- UAT Required: No",
+            "## Issue Goal",
+            "Ship the child issue.",
+            "## Why Now",
+            "It blocks the parent branch flow.",
+            "## Issue Context",
+            "Context.",
+            "## Dependencies",
+            "- No blocking dependencies.",
+            "## Non-Negotiable Guardrails",
+            "- Keep tracker writes owned by Main.",
+            "## Scope",
+            "### In Scope",
+            "- Code.",
+            "## Canonical References",
+            "### Target Repository / Package",
+            "- Alive24/shea-symphony",
+            "## Verification",
+            "### Functional Verification",
+            "- `cargo test`",
+            "### Completion Criteria",
+            "- Tests pass.",
+        ]
+        .join("\n"),
+    );
+    subissue
+        .project_fields
+        .insert("Native Parent Issue".into(), serde_json::json!("#400"));
+    subissue.project_fields.insert(
+        "Native Parent Title".into(),
+        serde_json::json!("Harden operator trust for supervised dogfood"),
+    );
+    let issues = vec![subissue];
+    let adapter = shea_symphony::tracker::MemoryTracker::new(issues.clone());
+    let doctor = ProjectAuditReport {
+        total_issues: 1,
+        violations: vec![ProjectAuditViolation {
+            issue_ref: "#400".into(),
+            title: "Harden operator trust for supervised dogfood".into(),
+            state: "Todo".into(),
+            severity: AuditSeverity::Blocker,
+            code: "parent_topology_missing_integration_branch".into(),
+            message: "Parent issue has native subissues but no parent integration branch evidence."
+                .into(),
+            suggestion: "Record the parent integration branch before subissue PRs advance.".into(),
+        }],
+        integration_gaps: Vec::new(),
+        skill_readiness_summary: None,
+    };
+
+    let plan = build_autopilot_plan_from_parts(AutopilotPlanInputs {
+        workflow_path: Path::new("/tmp/WORKFLOW.md"),
+        config: &config,
+        adapter: &adapter,
+        issues,
+        doctor_report: doctor,
+        canonical_checkout: clean_autopilot_canonical(),
+        runtime: clean_autopilot_runtime(),
+        integration_gaps: Vec::new(),
+    })
+    .unwrap();
+
+    assert_eq!(
+        plan.readiness.status,
+        "blocked_by_doctor_or_canonical_checkout"
+    );
+    assert_eq!(
+        plan.doctor.blocker_codes,
+        vec!["parent_topology_missing_integration_branch"]
+    );
+    let main_lane = plan.lanes.iter().find(|lane| lane.lane == "main").unwrap();
+    assert_eq!(main_lane.status, "ready", "{main_lane:?}");
+
+    let status = autopilot_loop_status_from_plan(
+        &plan,
+        AutopilotLoopSettings {
+            write: true,
+            dry_run: false,
+            recover: false,
+            poll_interval_ms: 5_000,
+            main_max_concurrent: 1,
+            review_max_concurrent: 1,
+            merge_max_concurrent: 1,
+        },
+        1,
+        Some(5_000),
+        &[],
+        false,
+    );
+
+    assert_eq!(status.phase, "running");
+    assert_eq!(status.counts.blocked, 0);
+    assert_eq!(status.counts.running, 1);
+    assert!(status.blocked_reasons.is_empty());
+    assert_eq!(status.selected_issues[0].identifier, "#383");
 }
 
 #[test]


### PR DESCRIPTION
- Added functions to ensure the creation and existence of parent integration branches before subissue worktree preparation and pull request publication.
- Enhanced the `prepare_issue_worktree` and `publish_issue_pull_request` functions to check for local and remote parent integration branches.
- Introduced tests to validate the new functionality, ensuring that parent integration branches are correctly handled in the context of subissues.
- Updated related components to improve the overall workflow for managing subissue dependencies.