### PR TITLE
#384: Suppress stale usage-limit diagnostics when Review output is conclusive

### DIFF
--- a/src/review.rs
+++ b/src/review.rs
@@ -648,6 +648,7 @@ pub fn render_review_workpad(issue: &TrackerIssue, job: &ReviewJob) -> String {
     let gemini_health_section = render_gemini_health_section(job);
 
     let usage_limit_section = review_usage_limit_pause(job)
+        .filter(|_| should_render_usage_limit_diagnostic(job))
         .map(|pause| {
             render_section(
                 "Usage Limit Diagnostic",
@@ -754,6 +755,14 @@ pub fn render_review_workpad(issue: &TrackerIssue, job: &ReviewJob) -> String {
             ("pass_evidence_section", pass_evidence_section),
         ],
     )
+}
+
+fn should_render_usage_limit_diagnostic(job: &ReviewJob) -> bool {
+    !matches!(job.state, ReviewJobState::Completed)
+        || !job
+            .report
+            .as_ref()
+            .is_some_and(AgentReviewReport::has_parsed_review_result)
 }
 
 fn review_pr_line(issue: &TrackerIssue) -> String {
@@ -2415,5 +2424,65 @@ mod tests {
         );
         assert!(workpad.contains("Usage-limit classifier: `rate_limit`"));
         assert!(workpad.contains("must not move to Human Review"));
+    }
+
+    #[test]
+    fn review_workpad_suppresses_stale_usage_limit_for_completed_pass() {
+        let mut job = completed_gemini_review(
+            "Review Result: PASS\n\nEvidence: implementation and verification are complete.",
+        );
+        job.report.as_mut().unwrap().stderr =
+            Some("warning: previous attempt hit rate limit exceeded; retry later".into());
+
+        let workpad = render_review_workpad(&issue(), &job);
+
+        assert_eq!(
+            review_usage_limit_pause(&job).unwrap().classifier,
+            "rate_limit"
+        );
+        assert!(workpad.contains("- Result: `PassedToHumanReview`"));
+        assert!(workpad.contains("Review pass evidence: `recorded`"));
+        assert!(!workpad.contains("### Usage Limit Diagnostic"));
+        assert!(!workpad.contains("Review did not pass"));
+    }
+
+    #[test]
+    fn review_workpad_suppresses_stale_usage_limit_for_completed_rework() {
+        let mut job = completed_gemini_review(
+            "Review Result: REWORK\n\n[Confirmed] Missing guard: The renderer still emits contradictory diagnostics.",
+        );
+        job.report.as_mut().unwrap().summary =
+            Some("quota exceeded appeared in an earlier streamed summary".into());
+
+        let workpad = render_review_workpad(&issue(), &job);
+
+        assert_eq!(
+            review_usage_limit_pause(&job).unwrap().classifier,
+            "quota_exceeded"
+        );
+        assert!(workpad.contains("- Result: `NeedsRework`"));
+        assert!(workpad.contains("Confirmed Agent Review findings require Rework."));
+        assert!(!workpad.contains("### Usage Limit Diagnostic"));
+        assert!(!workpad.contains("Review did not pass; unavailable"));
+    }
+
+    #[test]
+    fn review_workpad_suppresses_stale_usage_limit_for_completed_needs_context() {
+        let mut job = completed_gemini_review(
+            "Review Result: NEEDS_CONTEXT\n\nThe linked PR evidence could not be inspected.",
+        );
+        job.report.as_mut().unwrap().stderr =
+            Some("quota exceeded text from a stale backend warning".into());
+
+        let workpad = render_review_workpad(&issue(), &job);
+
+        assert_eq!(
+            review_usage_limit_pause(&job).unwrap().classifier,
+            "quota_exceeded"
+        );
+        assert!(workpad.contains("- Result: `InconclusiveNeedsRework`"));
+        assert!(workpad.contains("### Inconclusive Review Diagnostic"));
+        assert!(!workpad.contains("### Usage Limit Diagnostic"));
+        assert!(!workpad.contains("unavailable or inconclusive review must not move"));
     }
 }

--- a/src/review/report.rs
+++ b/src/review/report.rs
@@ -28,6 +28,17 @@ pub struct AgentReviewReport {
 }
 
 impl AgentReviewReport {
+    pub(crate) fn has_parsed_review_result(&self) -> bool {
+        [
+            self.summary.as_deref(),
+            self.stdout.as_deref(),
+            self.stderr.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|text| parse_review_result(text).is_some())
+    }
+
     pub fn blocks_progress(&self) -> bool {
         self.findings.iter().any(review_finding_blocks_progress)
     }


### PR DESCRIPTION
## Summary
- Implements #384: Suppress stale usage-limit diagnostics when Review output is conclusive.

## Branch Target Evidence
- Branch target role: `Subissue`
- PR base branch: `integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s`
- Native parent issue: `#400`
- Parent integration branch: `integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s`
- Parent final PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #384
