### PR TITLE
#383: Finalize terminal lane claim states after handoff and merge

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -258,7 +258,12 @@ labels may contain spaces; the CLI stores those values with reversible quoting,
 such as `worker="Codex Manual Main"`, and validates the rendered pointer before
 writing Project fields. The Project field stores the compact pointer; the
 session registry and workpad store the durable paths, logs, and handoff evidence
-for the same `run=`.
+for the same `run=`. When a lane's authority ends, the owning field remains as
+terminal audit evidence instead of being cleared: Main handoff writes
+`state=done result=agent_review_handoff`, terminal Main blockers write
+`state=failed result=<reason>`, Review pass/reject/inconclusive paths write a
+terminal `Review Agent` claim with `result=passed|rejected|inconclusive|...`,
+and Merge completion writes `state=done result=merged`.
 
 Manual claim and session control are separate operations. Claim commands write
 the lane claim Project field, create a matching `codex-app-manual` registry

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -688,9 +688,12 @@ worker=<worker> source=<loop|manual|goal> issue=#N run=<id>
 state=<active|done|stale|failed|superseded> thread=<codex-link|unknown>
 registry=run/<id>`. Keep full paths and terminal logs in the session registry
 or workpad, and update terminal completed work to `state=done` instead of
-clearing useful claim evidence by default. Display labels with spaces are stored
-with reversible quoting, for example `worker="Codex Manual Main"`; raw Project
-field edits are a break-glass repair path, not normal claim ownership.
+clearing useful claim evidence by default. Terminal handoffs also append a
+compact `result=...` token so operators can distinguish `agent_review_handoff`,
+Review `passed` or `rejected`, and Merge `merged` audit pointers from live
+ownership. Display labels with spaces are stored with reversible quoting, for
+example `worker="Codex Manual Main"`; raw Project field edits are a break-glass
+repair path, not normal claim ownership.
 If GitHub returns a transient transport, rate-limit, or HTTP 5xx error after a
 claim, workpad, timeline comment, Project status, merge, or issue-close write,
 the CLI performs read-after-write reconciliation instead of blindly retrying the

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -9,7 +9,9 @@ mod topology;
 
 use crate::model::{SessionStatusSnapshot, TrackerIssue};
 use crate::runtime_state::RuntimeState;
-use lane_claims::{audit_lane_claim_fields, claimed_main_agent};
+use lane_claims::{
+    audit_lane_claim_fields, audit_terminal_active_lane_claim_fields, claimed_main_agent,
+};
 use project_state::{
     audit_project_state_post_claims, audit_project_state_pre_claims, audit_terminal_state_mismatch,
 };
@@ -90,6 +92,7 @@ pub fn audit_project_issues_with_context(
     for issue in issues {
         let state = issue.normalized_state();
         audit_terminal_state_mismatch(issue, &state, &mut violations);
+        audit_terminal_active_lane_claim_fields(issue, &state, &mut violations);
 
         if state == "done" {
             continue;

--- a/src/doctor/lane_claims.rs
+++ b/src/doctor/lane_claims.rs
@@ -117,6 +117,38 @@ pub(super) fn audit_lane_claim_fields(
     }
 }
 
+pub(super) fn audit_terminal_active_lane_claim_fields(
+    issue: &TrackerIssue,
+    normalized_issue_state: &str,
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    if !matches!(normalized_issue_state, "done" | "closed") {
+        return;
+    }
+
+    for field in ["Main Agent", "Review Agent", "Merging Agent"] {
+        let Some(value) = string_project_field(issue, field)
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+
+        if LaneClaim::parse(&value)
+            .map(|claim| claim.state == LaneClaimState::Active)
+            .unwrap_or(false)
+        {
+            violations.push(violation(
+                issue,
+                AuditSeverity::Warning,
+                "terminal_issue_active_lane_claim",
+                &format!("{field} claim is still `state=active` on a terminal issue."),
+                "Update the structured claim to `state=done` after preserving run evidence.",
+            ));
+        }
+    }
+}
+
 pub(super) fn has_runtime_owner_metadata(issue: &TrackerIssue) -> bool {
     issue.project_fields.contains_key("runtime_owner")
         || issue.project_fields.contains_key("runtime_state")

--- a/src/doctor/tests/lane_claims.rs
+++ b/src/doctor/tests/lane_claims.rs
@@ -33,7 +33,7 @@ fn skips_done_issue_legacy_lane_claims() {
 }
 
 #[test]
-fn skips_done_issue_active_structured_claims_without_registry() {
+fn reports_done_issue_active_structured_claims_as_terminal_warning() {
     let mut issue = with_github_issue_state(issue("#244", "Done"), "CLOSED");
     issue.project_fields.insert(
         "Main Agent".into(),
@@ -51,7 +51,14 @@ fn skips_done_issue_active_structured_claims_without_registry() {
 
     let report = audit_project_issues_with_context(&[issue], Some(&context));
 
-    assert!(report.is_clean());
+    assert!(report.violations.iter().any(|violation| {
+        violation.code == "terminal_issue_active_lane_claim"
+            && violation.severity == AuditSeverity::Warning
+    }));
+    assert!(!report
+        .violations
+        .iter()
+        .any(|violation| violation.code == "active_lane_claim_missing_registry"));
 }
 
 #[test]

--- a/src/lanes/claim.rs
+++ b/src/lanes/claim.rs
@@ -187,16 +187,31 @@ pub(crate) fn write_lane_claim_field(
     Ok(())
 }
 
-pub(crate) fn write_lane_claim_state(
+pub(crate) fn terminal_lane_claim_value(
+    claim: &LaneClaim,
+    state: LaneClaimState,
+    result: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if result.trim().is_empty() || result.chars().any(char::is_whitespace) {
+        return Err("terminal lane claim result must be a non-empty compact token".into());
+    }
+    Ok(format!(
+        "{} result={}",
+        claim.with_state(state).render(),
+        result
+    ))
+}
+
+pub(crate) fn write_lane_claim_terminal_result(
     config: &RuntimeConfig,
     adapter: &dyn TrackerAdapter,
     issue: &TrackerIssue,
     lane: WorkerLane,
     claim: &LaneClaim,
     state: LaneClaimState,
+    result: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let updated = claim.with_state(state);
-    let value = render_parseable_lane_claim(&updated)?;
+    let value = terminal_lane_claim_value(claim, state, result)?;
     let outcome = set_project_field_with_recovery(
         adapter,
         issue,
@@ -216,17 +231,18 @@ pub(crate) fn write_lane_claim_state(
                 target: Some(format!("{}={value}", lane.claim_field())),
                 from_state: Some(issue.state.clone()),
                 to_state: None,
-                reason: "lane worker claim state update",
+                reason: "lane worker terminal claim result",
             },
         );
     }
     println!(
-        "{}_pool_action=claim_field_state issue={} field={:?} run={} state={} outcome={}",
+        "{}_pool_action=claim_field_terminal issue={} field={:?} run={} state={} result={} outcome={}",
         lane.label(),
         issue.identifier,
         lane.claim_field(),
         claim.run,
         state.as_str(),
+        result,
         outcome.as_str()
     );
     Ok(())

--- a/src/lanes/main_loop/write_candidate/terminal.rs
+++ b/src/lanes/main_loop/write_candidate/terminal.rs
@@ -17,7 +17,7 @@ use super::super::{
     run_loop_agent_review_handoff_evidence, run_loop_runtime_state_with_transition,
     run_loop_usage_limit_pause_workpad, IssueExecutionResult,
 };
-use crate::lanes::claim::{write_lane_claim_state, WorkerLane};
+use crate::lanes::claim::{write_lane_claim_terminal_result, WorkerLane};
 use crate::orchestration::{
     append_tracker_mutation_audit, current_time_ms, latest_status_for_issue, print_latest_status,
     recovery_key, set_state_with_recovery, stable_recovery_hash, upsert_workpad_with_recovery,
@@ -107,13 +107,14 @@ fn complete_successful_run(
             "agent review handoff invariant failed",
         );
         upsert_runtime_state(config, &runtime_state)?;
-        write_lane_claim_state(
+        write_lane_claim_terminal_result(
             config,
             adapter,
             latest,
             WorkerLane::Main,
             main_claim,
             LaneClaimState::Failed,
+            "handoff_invariant_failed",
         )?;
         let state_outcome = set_state_with_recovery(
             adapter,
@@ -159,13 +160,14 @@ fn complete_successful_run(
     );
     mark_runtime_state_updated(&mut runtime_state, current_time_ms());
     upsert_runtime_state(config, &runtime_state)?;
-    write_lane_claim_state(
+    write_lane_claim_terminal_result(
         config,
         adapter,
         latest,
         WorkerLane::Main,
         main_claim,
         LaneClaimState::Done,
+        "agent_review_handoff",
     )?;
     let state_outcome = set_state_with_recovery(
         adapter,
@@ -296,13 +298,14 @@ fn complete_failed_run(
         );
         mark_runtime_state_updated(&mut runtime_state, current_time_ms());
         upsert_runtime_state(config, &runtime_state)?;
-        write_lane_claim_state(
+        write_lane_claim_terminal_result(
             config,
             adapter,
             latest,
             WorkerLane::Main,
             main_claim,
             LaneClaimState::Failed,
+            "handoff_pr_linkage_failed",
         )?;
         let state_outcome = set_state_with_recovery(
             adapter,
@@ -383,6 +386,15 @@ fn complete_failed_run(
     );
     mark_runtime_state_updated(&mut runtime_state, current_time_ms());
     upsert_runtime_state(config, &runtime_state)?;
+    write_lane_claim_terminal_result(
+        config,
+        adapter,
+        latest,
+        WorkerLane::Main,
+        main_claim,
+        LaneClaimState::Failed,
+        "backend_retry_limit",
+    )?;
     let state_outcome = set_state_with_recovery(
         adapter,
         &latest.identifier,

--- a/src/lanes/merge/evidence.rs
+++ b/src/lanes/merge/evidence.rs
@@ -1,8 +1,10 @@
 use shea_symphony::config::RuntimeConfig;
+use shea_symphony::lane_claim::{LaneClaim, LaneClaimState};
 use shea_symphony::merge_lane::{MergeLaneDecision, MergeLaneDecisionKind};
 use shea_symphony::model::TrackerIssue;
 use shea_symphony::tracker::TrackerAdapter;
 
+use crate::lanes::claim::{write_lane_claim_terminal_result, WorkerLane};
 use crate::orchestration::{
     add_timeline_comment_with_recovery, append_tracker_mutation_audit, close_issue_with_recovery,
     merge_completion_recovery_key, merge_decision_recovery_key, set_state_with_recovery,
@@ -86,6 +88,7 @@ pub(crate) fn record_done_merge_lane_completion(
     config: &RuntimeConfig,
     adapter: &dyn TrackerAdapter,
     issue: &TrackerIssue,
+    merge_claim: &LaneClaim,
     workpad: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let pr_url = issue
@@ -106,6 +109,15 @@ pub(crate) fn record_done_merge_lane_completion(
         &completion_decision,
         workpad,
         "merge completion evidence",
+    )?;
+    write_lane_claim_terminal_result(
+        config,
+        adapter,
+        issue,
+        WorkerLane::Merging,
+        merge_claim,
+        LaneClaimState::Done,
+        "merged",
     )?;
     set_merge_state_with_recovery(config, adapter, issue, "done", pr_url, "merge completed")?;
     close_completed_issue(config, adapter, &issue.identifier, Some(issue))?;

--- a/src/lanes/merge/tick.rs
+++ b/src/lanes/merge/tick.rs
@@ -273,7 +273,13 @@ pub(crate) fn merge_once_tick(
             output
         };
         let workpad = merge_lane_workpad(&issue, &decision, Some(&output));
-        record_done_merge_lane_completion(&config, adapter.as_ref(), &issue, &workpad)?;
+        record_done_merge_lane_completion(
+            &config,
+            adapter.as_ref(),
+            &issue,
+            &merge_claim,
+            &workpad,
+        )?;
         println!(
             "merge_once_action=merged issue={} target_state=done",
             issue.identifier

--- a/src/main/tests.rs
+++ b/src/main/tests.rs
@@ -41,7 +41,8 @@ use super::commands::workspace::{
 };
 use super::lanes::claim::{
     pool_claim_eligibility, project_text_field, render_parseable_lane_claim,
-    select_pool_worker_issues, write_lane_claim_field, PoolClaimEligibility, WorkerLane,
+    select_pool_worker_issues, terminal_lane_claim_value, write_lane_claim_field,
+    PoolClaimEligibility, WorkerLane,
 };
 use super::lanes::main_loop::{
     apply_live_handoff_pr_link, execute_issue_once_with_workspace_key, main_app_server_smoke_gate,

--- a/src/main/tests/main_loop.rs
+++ b/src/main/tests/main_loop.rs
@@ -572,6 +572,28 @@ fn resume_preflight_detects_stalled_active_state() {
 }
 
 #[test]
+fn main_handoff_terminal_claim_records_result_context() {
+    let claim = LaneClaim::active(
+        "#383",
+        LaneClaimLane::Main,
+        LaneClaimActor::Codex,
+        LaneClaimSource::Loop,
+        1_779_000_000_000,
+    )
+    .with_worker("Shea Symphony Agent");
+
+    let value =
+        terminal_lane_claim_value(&claim, LaneClaimState::Done, "agent_review_handoff").unwrap();
+
+    assert!(value.contains("state=done"));
+    assert!(value.contains("result=agent_review_handoff"));
+    assert_eq!(
+        LaneClaim::parse(&value).unwrap(),
+        claim.with_state(LaneClaimState::Done)
+    );
+}
+
+#[test]
 fn resume_preflight_archives_completed_tracker_state() {
     let config = test_config();
     let tracker = MemoryTracker::new(vec![tracker_issue("Agent Review")]);

--- a/src/main/tests/merge.rs
+++ b/src/main/tests/merge.rs
@@ -212,17 +212,70 @@ fn merge_recover_selection_does_not_adopt_manual_claims() {
 fn merge_completion_closes_issue_after_workpad_and_done_state() {
     let adapter = RecordingAdapter::default();
     let issue = tracker_issue("Merging");
+    let claim = LaneClaim::active(
+        &issue.identifier,
+        LaneClaimLane::Merge,
+        LaneClaimActor::Codex,
+        LaneClaimSource::Loop,
+        1_779_000_000_000,
+    )
+    .with_worker("Shea Symphony Agent");
     let workpad = "## Shea Symphony Merge Run\n\n### Merge Action\n";
 
     let config = test_config();
-    record_done_merge_lane_completion(&config, &adapter, &issue, workpad).unwrap();
+    record_done_merge_lane_completion(&config, &adapter, &issue, &claim, workpad).unwrap();
 
     assert_eq!(
         adapter.operations(),
         vec![
             "comment:#29".to_string(),
+            format!(
+                "set_project_field:#29:Merging Agent={}",
+                terminal_lane_claim_value(&claim, LaneClaimState::Done, "merged").unwrap()
+            ),
             "set_state:#29:done".to_string(),
             "close_issue:#29".to_string()
         ]
+    );
+}
+
+#[test]
+fn merge_completion_preserves_terminal_claim_audit_pointer() {
+    let adapter = RecordingAdapter::default();
+    let issue = tracker_issue("Merging");
+    adapter
+        .issues
+        .borrow_mut()
+        .insert(issue.identifier.clone(), issue.clone());
+    let claim = LaneClaim::active(
+        &issue.identifier,
+        LaneClaimLane::Merge,
+        LaneClaimActor::Codex,
+        LaneClaimSource::Loop,
+        1_779_000_000_000,
+    )
+    .with_worker("Shea Symphony Agent");
+
+    record_done_merge_lane_completion(
+        &test_config(),
+        &adapter,
+        &issue,
+        &claim,
+        "## Shea Symphony Merge Run\n\n### Merge Action\n",
+    )
+    .unwrap();
+
+    let stored_issue = adapter
+        .issues
+        .borrow()
+        .get(&issue.identifier)
+        .unwrap()
+        .clone();
+    let stored_claim = project_text_field(&stored_issue, "Merging Agent").unwrap();
+    assert!(stored_claim.contains("state=done"));
+    assert!(stored_claim.contains("result=merged"));
+    assert_eq!(
+        LaneClaim::parse(&stored_claim).unwrap(),
+        claim.with_state(LaneClaimState::Done)
     );
 }


### PR DESCRIPTION
## Summary
- Implements #383: Finalize terminal lane claim states after handoff and merge.

## Branch Target Evidence
- Branch target role: `Subissue`
- PR base branch: `integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s`
- Native parent issue: `#400`
- Parent integration branch: `integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s`
- Parent final PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #383
