### PR TITLE
#399: Recover stale issue worktrees before Main app-server launch

### DIFF
--- a/src/commands/autopilot/lanes.rs
+++ b/src/commands/autopilot/lanes.rs
@@ -14,7 +14,7 @@ use crate::commands::gate::{evaluate_issue_for_current_source, gate_target_state
 use crate::lanes::claim::{
     pool_claim_eligibility, select_pool_worker_issues, worker_identity, WorkerLane,
 };
-use crate::lanes::main_loop::run_loop_handoff_plan;
+use crate::lanes::main_loop::{run_loop_handoff_plan, run_loop_preflight_launch_workspace};
 use crate::lanes::merge::merge_preflight_status;
 use crate::lanes::review::{review_backend_kind, select_review_worker_issues};
 use crate::orchestration::hydrate_issues_for_review_lane;
@@ -93,24 +93,39 @@ fn autopilot_main_lane_plan(
                 .collect(),
         },
         Ok(_) => match run_loop_handoff_plan(config, &issue) {
-            Ok(handoff) => {
-                let action = if normalize_state(&issue.state) == "in progress" {
-                    "resume_main_issue"
-                } else {
-                    "claim_main_issue"
-                };
-                AutopilotLanePlan {
-                    lane: "main".into(),
-                    status: "ready".into(),
-                    selected_issue: Some(AutopilotIssueSummary::from_issue(&issue)),
-                    proposed_action: action.into(),
-                    target_state: Some(config.tracker.state_map.agent_review.clone()),
-                    reason: "dispatchable_issue".into(),
-                    evidence: vec![
-                        format!("workspace={}", handoff.workspace_path.display()),
-                        format!("branch={}", handoff.branch_name),
-                        "source=main loop dry-run selection".into(),
-                    ],
+            Ok(mut handoff) => {
+                match run_loop_preflight_launch_workspace(config, &issue, &mut handoff) {
+                    Ok(workspace_preflight) => {
+                        let action = if normalize_state(&issue.state) == "in progress" {
+                            "resume_main_issue"
+                        } else {
+                            "claim_main_issue"
+                        };
+                        let mut evidence = vec![
+                            format!("workspace={}", handoff.workspace_path.display()),
+                            format!("branch={}", handoff.branch_name),
+                            "source=main loop dry-run selection".into(),
+                        ];
+                        evidence.extend(workspace_preflight.evidence);
+                        AutopilotLanePlan {
+                            lane: "main".into(),
+                            status: "ready".into(),
+                            selected_issue: Some(AutopilotIssueSummary::from_issue(&issue)),
+                            proposed_action: action.into(),
+                            target_state: Some(config.tracker.state_map.agent_review.clone()),
+                            reason: "dispatchable_issue".into(),
+                            evidence,
+                        }
+                    }
+                    Err(error) => AutopilotLanePlan {
+                        lane: "main".into(),
+                        status: "blocked".into(),
+                        selected_issue: Some(AutopilotIssueSummary::from_issue(&issue)),
+                        proposed_action: "workspace_preflight_failed".into(),
+                        target_state: Some(config.tracker.state_map.need_human_input.clone()),
+                        reason: error.to_string(),
+                        evidence: vec!["source=run_loop_preflight_launch_workspace".into()],
+                    },
                 }
             }
             Err(error) => AutopilotLanePlan {

--- a/src/handoff.rs
+++ b/src/handoff.rs
@@ -113,6 +113,8 @@ pub enum HandoffError {
         issue_ref: String,
         pull_request_url: String,
     },
+    #[error("issue {issue_ref} workspace preflight blocked Main launch: {reason}")]
+    WorkspacePreflightBlocked { issue_ref: String, reason: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/lanes/main_loop.rs
+++ b/src/lanes/main_loop.rs
@@ -41,13 +41,16 @@ pub(crate) use execution::{
     execute_issue_once, execute_issue_once_with_workspace_key, IssueExecutionResult,
 };
 pub(crate) use failure::{handle_run_loop_gate_failure, handle_run_loop_handoff_failure};
+#[cfg(test)]
+pub(crate) use handoff::run_loop_apply_launch_workspace_report;
 pub(crate) use handoff::{
     apply_live_handoff_pr_link, compact_evidence, linked_pull_requests_contain,
     pull_request_number_from_url, run_handoff_verification, run_loop_agent_review_handoff_evidence,
     run_loop_apply_recovery_handoff, run_loop_assignee_ownership_workpad,
     run_loop_handoff_failure_workpad, run_loop_handoff_plan, run_loop_handoff_workpad,
-    run_loop_live_handoff_enabled, run_loop_ownership_workpad, run_loop_runtime_ownership,
-    run_loop_usage_limit_pause_workpad, HandoffVerification, RunLoopLiveHandoff,
+    run_loop_live_handoff_enabled, run_loop_ownership_workpad, run_loop_preflight_launch_workspace,
+    run_loop_runtime_ownership, run_loop_usage_limit_pause_workpad, HandoffVerification,
+    RunLoopLiveHandoff,
 };
 pub(crate) use preflight::{ensure_write_mode_main_agent_backend, main_app_server_smoke_gate};
 #[cfg(test)]

--- a/src/lanes/main_loop/handoff.rs
+++ b/src/lanes/main_loop/handoff.rs
@@ -9,7 +9,8 @@ use shea_symphony::handoff::{
     plan_issue_handoff_for_profile, AgentReviewHandoffEvidence, HandoffError, IssueHandoffPlan,
 };
 use shea_symphony::issue_workspace::{
-    discover_issue_workspaces, infer_issue_ref_from_branch_or_path,
+    discover_issue_workspaces, infer_issue_ref_from_branch_or_path, IssueWorkspaceCandidate,
+    IssueWorkspaceReport, WorkspaceMatchStrength,
 };
 use shea_symphony::lane_claim::LaneClaim;
 use shea_symphony::model::{LinkedPullRequest, TrackerIssue};
@@ -35,6 +36,11 @@ pub(crate) struct RunLoopLiveHandoff {
 pub(crate) struct HandoffVerification {
     pub(crate) success: bool,
     pub(crate) summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MainLaunchWorkspacePreflight {
+    pub(crate) evidence: Vec<String>,
 }
 
 pub(crate) fn run_loop_handoff_plan(
@@ -68,6 +74,131 @@ pub(crate) fn run_loop_handoff_plan(
     }
 
     Ok(plan)
+}
+
+pub(crate) fn run_loop_preflight_launch_workspace(
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+    handoff: &mut IssueHandoffPlan,
+) -> Result<MainLaunchWorkspacePreflight, HandoffError> {
+    if config.tracker.kind != "github_project_v2" {
+        return Ok(MainLaunchWorkspacePreflight {
+            evidence: vec![format!(
+                "workspace_preflight action=prepare path={} branch={} mode=fixture_or_non_github",
+                handoff.workspace_path.display(),
+                handoff.branch_name
+            )],
+        });
+    }
+    let repo_root =
+        std::env::current_dir().map_err(|error| HandoffError::WorkspacePreflightBlocked {
+            issue_ref: issue.identifier.clone(),
+            reason: format!("cannot inspect current repository worktrees: {error}"),
+        })?;
+    let report = discover_issue_workspaces(config, issue, &repo_root).map_err(|error| {
+        HandoffError::WorkspacePreflightBlocked {
+            issue_ref: issue.identifier.clone(),
+            reason: error.to_string(),
+        }
+    })?;
+    run_loop_apply_launch_workspace_report(config, issue, handoff, &report)
+}
+
+pub(crate) fn run_loop_apply_launch_workspace_report(
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+    handoff: &mut IssueHandoffPlan,
+    report: &IssueWorkspaceReport,
+) -> Result<MainLaunchWorkspacePreflight, HandoffError> {
+    let mut evidence = Vec::new();
+    for warning in &report.warnings {
+        evidence.push(format!("workspace_warning={}", compact_evidence(warning)));
+    }
+
+    let (missing_candidates, live_candidates): (Vec<_>, Vec<_>) = report
+        .candidates
+        .iter()
+        .partition(|candidate| !candidate.path.exists());
+
+    for candidate in &missing_candidates {
+        evidence.push(format!(
+            "ignored_missing_workspace path={} namespace={} evidence={} next=`git worktree prune` after operator review or `workspace ensure`",
+            candidate.path.display(),
+            workspace_namespace_label(&candidate.path),
+            candidate_evidence_summary(candidate)
+        ));
+    }
+
+    let strong_live = live_candidates
+        .iter()
+        .copied()
+        .filter(|candidate| candidate.strength == WorkspaceMatchStrength::Strong)
+        .collect::<Vec<_>>();
+    let selected = if strong_live.len() > 1 {
+        return Err(workspace_preflight_error(
+            issue,
+            format!(
+                "multiple strong live workspace candidates: {}; run `workspace show` and resolve with `workspace adopt`",
+                candidate_path_list(&strong_live)
+            ),
+        ));
+    } else if let Some(candidate) = strong_live.first() {
+        Some(*candidate)
+    } else if live_candidates.len() > 1 {
+        return Err(workspace_preflight_error(
+            issue,
+            format!(
+                "multiple live workspace candidates without a canonical match: {}; run `workspace show` and resolve with `workspace adopt`",
+                candidate_path_list(&live_candidates)
+            ),
+        ));
+    } else {
+        live_candidates.first().copied()
+    };
+
+    if let Some(candidate) = selected {
+        validate_launch_candidate_clean(issue, candidate)?;
+        let branch = candidate.branch.as_deref().ok_or_else(|| {
+            workspace_preflight_error(
+                issue,
+                format!(
+                    "detached workspace candidate {}; resolve with `workspace adopt` after choosing a branch worktree",
+                    candidate.path.display()
+                ),
+            )
+        })?;
+        let inferred_issue = infer_issue_ref_from_branch_or_path(Some(branch), &candidate.path);
+        if inferred_issue.as_deref() != Some(issue.identifier.as_str())
+            && branch != handoff.branch_name
+        {
+            return Err(workspace_preflight_error(
+                issue,
+                format!(
+                    "workspace candidate {} on branch {} does not match issue {}; run `workspace show` before launch",
+                    candidate.path.display(),
+                    branch,
+                    issue.identifier
+                ),
+            ));
+        }
+        apply_recovery_worktree_to_handoff(config, issue, handoff, &candidate.path, branch)
+            .map_err(|error| workspace_preflight_error(issue, error.to_string()))?;
+        evidence.push(format!(
+            "workspace_preflight action=reuse path={} branch={} evidence={}",
+            candidate.path.display(),
+            branch,
+            candidate_evidence_summary(candidate)
+        ));
+    } else {
+        evidence.push(format!(
+            "workspace_preflight action=prepare path={} branch={} next=`workspace ensure {}`",
+            handoff.workspace_path.display(),
+            handoff.branch_name,
+            issue.identifier
+        ));
+    }
+
+    Ok(MainLaunchWorkspacePreflight { evidence })
 }
 
 pub(crate) fn run_loop_apply_recovery_handoff(
@@ -138,6 +269,96 @@ fn apply_recovery_worktree_to_handoff(
     handoff.branch_name = branch.to_string();
     handoff.pull_request.head_branch = branch.to_string();
     Ok(())
+}
+
+fn validate_launch_candidate_clean(
+    issue: &TrackerIssue,
+    candidate: &IssueWorkspaceCandidate,
+) -> Result<(), HandoffError> {
+    if candidate.branch.is_none() {
+        return Err(workspace_preflight_error(
+            issue,
+            format!(
+                "workspace candidate {} is detached and cannot be launched safely",
+                candidate.path.display()
+            ),
+        ));
+    }
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(&candidate.path)
+        .output()
+        .map_err(|error| {
+            workspace_preflight_error(
+                issue,
+                format!(
+                    "could not inspect workspace candidate {}: {error}",
+                    candidate.path.display()
+                ),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(workspace_preflight_error(
+            issue,
+            format!(
+                "could not inspect workspace candidate {}: {}",
+                candidate.path.display(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        ));
+    }
+    let dirty = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !dirty.is_empty() {
+        return Err(workspace_preflight_error(
+            issue,
+            format!(
+                "workspace candidate {} is dirty: {}; stop before app-server launch and inspect it",
+                candidate.path.display(),
+                dirty.replace('\n', "; ")
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn workspace_preflight_error(issue: &TrackerIssue, reason: impl Into<String>) -> HandoffError {
+    HandoffError::WorkspacePreflightBlocked {
+        issue_ref: issue.identifier.clone(),
+        reason: reason.into(),
+    }
+}
+
+fn candidate_path_list(candidates: &[&IssueWorkspaceCandidate]) -> String {
+    candidates
+        .iter()
+        .map(|candidate| candidate.path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn candidate_evidence_summary(candidate: &IssueWorkspaceCandidate) -> String {
+    candidate
+        .evidence
+        .iter()
+        .map(|evidence| format!("{}:{}", evidence.source, evidence.detail.replace(' ', "_")))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+fn workspace_namespace_label(path: &Path) -> &'static str {
+    if path
+        .components()
+        .any(|component| component.as_os_str() == ".jade-symphony")
+    {
+        "jade-symphony"
+    } else if path
+        .components()
+        .any(|component| component.as_os_str() == ".shea-symphony")
+    {
+        "shea-symphony"
+    } else {
+        "unknown"
+    }
 }
 
 fn recovery_workspace_key(

--- a/src/lanes/main_loop/write_candidate.rs
+++ b/src/lanes/main_loop/write_candidate.rs
@@ -24,10 +24,10 @@ use super::{
     reconcile_pending_main_session, run_loop_apply_recovery_handoff,
     run_loop_assignee_ownership_decision, run_loop_assignee_ownership_workpad,
     run_loop_claim_action, run_loop_handoff_plan, run_loop_handoff_workpad,
-    run_loop_live_handoff_enabled, run_loop_ownership_workpad, run_loop_runtime_ownership,
-    run_loop_runtime_state_for_issue, run_loop_runtime_state_with_result,
-    selected_profile_github_login, AssigneeOwnershipDecision, MainSessionReconciliation,
-    RunLoopClaimAction, RunLoopOptions,
+    run_loop_live_handoff_enabled, run_loop_ownership_workpad, run_loop_preflight_launch_workspace,
+    run_loop_runtime_ownership, run_loop_runtime_state_for_issue,
+    run_loop_runtime_state_with_result, selected_profile_github_login, AssigneeOwnershipDecision,
+    MainSessionReconciliation, RunLoopClaimAction, RunLoopOptions,
 };
 use crate::commands::gate::evaluate_issue_for_current_source;
 use crate::lanes::claim::{
@@ -149,6 +149,20 @@ pub(crate) fn run_loop_dispatch_write_candidate(
                 );
             }
         }
+    }
+    let workspace_preflight =
+        match run_loop_preflight_launch_workspace(config, &latest, &mut handoff) {
+            Ok(preflight) => preflight,
+            Err(error) => {
+                handle_run_loop_handoff_failure(adapter, &latest, &error, options, config)?;
+                return Ok(RunLoopWorkerOutcome::Completed);
+            }
+        };
+    for evidence in &workspace_preflight.evidence {
+        println!(
+            "run_loop_action=workspace_preflight issue={} evidence={}",
+            latest.identifier, evidence
+        );
     }
 
     let ownership = run_loop_runtime_ownership(&latest, config, &handoff)?;

--- a/src/main/tests.rs
+++ b/src/main/tests.rs
@@ -47,8 +47,8 @@ use super::lanes::main_loop::{
     apply_live_handoff_pr_link, execute_issue_once_with_workspace_key, main_app_server_smoke_gate,
     no_dispatch_action, pull_request_number_from_url, reconcile_main_handoff_runtime_state,
     reconcile_pending_main_session, run_handoff_verification,
-    run_loop_agent_review_handoff_evidence, run_loop_apply_recovery_handoff,
-    run_loop_assignee_ownership_decision, run_loop_claim_action,
+    run_loop_agent_review_handoff_evidence, run_loop_apply_launch_workspace_report,
+    run_loop_apply_recovery_handoff, run_loop_assignee_ownership_decision, run_loop_claim_action,
     run_loop_dispatch_write_candidates, run_loop_handoff_plan, run_loop_handoff_workpad,
     run_loop_ownership_workpad, run_loop_resume_preflight, run_loop_resume_preflight_many,
     run_loop_runtime_ownership, run_loop_runtime_state_for_issue,
@@ -92,12 +92,15 @@ use shea_symphony::git_handoff::{
 };
 use shea_symphony::handoff::evaluate_agent_review_handoff;
 use shea_symphony::handoff::{plan_issue_handoff_for_profile, HandoffError, IssueHandoffPlan};
+use shea_symphony::issue_workspace::{
+    IssueWorkspaceCandidate, IssueWorkspaceReport, WorkspaceEvidence, WorkspaceMatchStrength,
+};
 use shea_symphony::lane_claim::{
     LaneClaim, LaneClaimActor, LaneClaimLane, LaneClaimSource, LaneClaimState,
 };
-use shea_symphony::model::normalize_state;
 use shea_symphony::model::SessionStatusSnapshot;
 use shea_symphony::model::TrackerIssue;
+use shea_symphony::model::{normalize_state, LinkedPullRequest};
 use shea_symphony::orchestrator::Orchestrator;
 use shea_symphony::ownership::render_runtime_ownership_marker;
 use shea_symphony::ownership::{runtime_ownership_decision, RuntimeOwnershipDecision};

--- a/src/main/tests/main_loop/handoff.rs
+++ b/src/main/tests/main_loop/handoff.rs
@@ -44,6 +44,167 @@ fn run_loop_handoff_plan_rejects_branch_for_different_issue() {
 }
 
 #[test]
+fn launch_workspace_preflight_ignores_missing_historical_jade_candidate() {
+    let mut config = test_config();
+    let temp = tempfile::tempdir().unwrap();
+    config.workspace.root = temp.path().join(".shea-symphony").join("worktrees");
+    let mut issue = tracker_issue("In Progress");
+    issue.linked_pull_requests.push(LinkedPullRequest {
+        head_ref_name: Some(
+            "feature/issue-29-wire-runtime-state-persistence-into-main-loop".into(),
+        ),
+        number: Some(29),
+        ..Default::default()
+    });
+    let mut handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+    let planned_path = handoff.workspace_path.clone();
+    let stale_path = temp
+        .path()
+        .join(".jade-symphony")
+        .join("worktrees")
+        .join("issue-29-old-main");
+    let report = workspace_report(
+        &issue,
+        vec![workspace_candidate(
+            stale_path,
+            Some("feature/issue-29-wire-runtime-state-persistence-into-main-loop"),
+            WorkspaceMatchStrength::Strong,
+            "session_registry",
+        )],
+    );
+
+    let preflight =
+        run_loop_apply_launch_workspace_report(&config, &issue, &mut handoff, &report).unwrap();
+
+    assert_eq!(handoff.workspace_path, planned_path);
+    assert!(preflight.evidence.iter().any(|line| {
+        line.contains("ignored_missing_workspace") && line.contains("namespace=jade-symphony")
+    }));
+    assert!(preflight
+        .evidence
+        .iter()
+        .any(|line| line.contains("workspace_preflight action=prepare")));
+}
+
+#[test]
+fn launch_workspace_preflight_reuses_single_clean_matching_worktree() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut config = test_config();
+    config.workspace.root = temp.path().join("worktrees");
+    std::fs::create_dir_all(&config.workspace.root).unwrap();
+    let issue = tracker_issue("In Progress");
+    let mut handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+    let worktree = config.workspace.root.join("manual-issue-29");
+    init_clean_git_workspace(&worktree);
+    git_ok(
+        &worktree,
+        &[
+            "checkout",
+            "-b",
+            "feature/issue-29-wire-runtime-state-persistence-into-main-loop",
+        ],
+    );
+    let report = workspace_report(
+        &issue,
+        vec![workspace_candidate(
+            worktree.clone(),
+            Some("feature/issue-29-wire-runtime-state-persistence-into-main-loop"),
+            WorkspaceMatchStrength::Strong,
+            "git_worktree",
+        )],
+    );
+
+    let preflight =
+        run_loop_apply_launch_workspace_report(&config, &issue, &mut handoff, &report).unwrap();
+
+    assert_eq!(handoff.workspace_path, worktree);
+    assert_eq!(handoff.workspace_key, "manual-issue-29");
+    assert!(preflight
+        .evidence
+        .iter()
+        .any(|line| line.contains("workspace_preflight action=reuse")));
+}
+
+#[test]
+fn launch_workspace_preflight_blocks_ambiguous_live_candidates() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut config = test_config();
+    config.workspace.root = temp.path().join("worktrees");
+    std::fs::create_dir_all(&config.workspace.root).unwrap();
+    let issue = tracker_issue("In Progress");
+    let mut handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+    let first = config.workspace.root.join("issue-29-a");
+    let second = config.workspace.root.join("issue-29-b");
+    std::fs::create_dir_all(&first).unwrap();
+    std::fs::create_dir_all(&second).unwrap();
+    let report = workspace_report(
+        &issue,
+        vec![
+            workspace_candidate(
+                first,
+                Some("feature/issue-29-a"),
+                WorkspaceMatchStrength::Strong,
+                "git_worktree",
+            ),
+            workspace_candidate(
+                second,
+                Some("feature/issue-29-b"),
+                WorkspaceMatchStrength::Strong,
+                "git_worktree",
+            ),
+        ],
+    );
+
+    let error =
+        run_loop_apply_launch_workspace_report(&config, &issue, &mut handoff, &report).unwrap_err();
+
+    assert!(matches!(
+        error,
+        HandoffError::WorkspacePreflightBlocked { reason, .. }
+            if reason.contains("multiple strong live workspace candidates")
+    ));
+}
+
+#[test]
+fn launch_workspace_preflight_blocks_dirty_candidate_before_runtime() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut config = test_config();
+    config.workspace.root = temp.path().join("worktrees");
+    std::fs::create_dir_all(&config.workspace.root).unwrap();
+    let issue = tracker_issue("In Progress");
+    let mut handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+    let worktree = config.workspace.root.join("dirty-issue-29");
+    init_clean_git_workspace(&worktree);
+    git_ok(
+        &worktree,
+        &[
+            "checkout",
+            "-b",
+            "feature/issue-29-wire-runtime-state-persistence-into-main-loop",
+        ],
+    );
+    std::fs::write(worktree.join("scratch.txt"), "dirty").unwrap();
+    let report = workspace_report(
+        &issue,
+        vec![workspace_candidate(
+            worktree,
+            Some("feature/issue-29-wire-runtime-state-persistence-into-main-loop"),
+            WorkspaceMatchStrength::Strong,
+            "git_worktree",
+        )],
+    );
+
+    let error =
+        run_loop_apply_launch_workspace_report(&config, &issue, &mut handoff, &report).unwrap_err();
+
+    assert!(matches!(
+        error,
+        HandoffError::WorkspacePreflightBlocked { reason, .. }
+            if reason.contains("dirty") && reason.contains("stop before app-server launch")
+    ));
+}
+
+#[test]
 fn run_loop_handoff_workpad_records_planned_pr_evidence() {
     let config = test_config();
     let issue = tracker_issue("In Progress");
@@ -108,6 +269,38 @@ fn run_loop_handoff_workpad_records_planned_pr_evidence() {
     assert!(workpad.contains("PR title: `#29: Wire runtime state persistence into main loop`"));
     assert!(workpad.contains("Handoff verification: `skipped:not_configured`"));
     assert!(workpad.contains("Live PR: `https://github.com/Alive24/shea-symphony/pull/45`"));
+}
+
+fn workspace_report(
+    issue: &TrackerIssue,
+    candidates: Vec<IssueWorkspaceCandidate>,
+) -> IssueWorkspaceReport {
+    IssueWorkspaceReport {
+        issue_ref: issue.identifier.clone(),
+        title: issue.title.clone(),
+        branch_hints: Vec::new(),
+        candidates,
+        canonical_index: None,
+        warnings: Vec::new(),
+    }
+}
+
+fn workspace_candidate(
+    path: PathBuf,
+    branch: Option<&str>,
+    strength: WorkspaceMatchStrength,
+    source: &str,
+) -> IssueWorkspaceCandidate {
+    IssueWorkspaceCandidate {
+        path,
+        branch: branch.map(str::to_string),
+        head: Some("abc123".into()),
+        strength,
+        evidence: vec![WorkspaceEvidence {
+            source: source.into(),
+            detail: "test evidence".into(),
+        }],
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Implements #399: Recover stale issue worktrees before Main app-server launch.

## Branch Target Evidence
- Branch target role: `Subissue`
- PR base branch: `integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s`
- Native parent issue: `#400`
- Parent integration branch: `integration/issue-400-harden-operator-trust-for-supervised-dogfood-before-persistent-s`
- Parent final PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #399
