### PR TITLE
#381: Fix native subissue Review PASS routing when Human Review exception is absent

### DIFF
--- a/src/doctor/tests/topology.rs
+++ b/src/doctor/tests/topology.rs
@@ -119,6 +119,47 @@ fn reports_parent_human_review_before_subissues_done() {
 }
 
 #[test]
+fn reports_native_subissue_in_human_review_without_real_exception() {
+    let parent_branch = "integration/issue-400-native-subissue-batch";
+    let parent = with_parent_branch(
+        with_native_subissues(issue("#400", "Agent Review"), &["#399"]),
+        parent_branch,
+    );
+    let mut subissue = with_native_parent(issue("#399", "Human Review"), "#400");
+    subissue.description = Some(
+        "Related Parent Issue or Context: native subissue under #400.\nSubissue Human Review Exception: None."
+            .into(),
+    );
+
+    let report = audit_project_issues(&[parent, subissue]);
+
+    assert!(report.violations.iter().any(|violation| {
+        violation.code == "subissue_human_review_without_exception"
+            && violation.severity == AuditSeverity::Blocker
+            && violation.issue_ref == "#399"
+    }));
+}
+
+#[test]
+fn accepts_native_subissue_in_human_review_with_real_exception() {
+    let parent_branch = "integration/issue-400-native-subissue-batch";
+    let parent = with_parent_branch(
+        with_native_subissues(issue("#400", "Agent Review"), &["#399"]),
+        parent_branch,
+    );
+    let mut subissue = with_native_parent(issue("#399", "Human Review"), "#400");
+    subissue.description =
+        Some("Subissue Human Review Exception: operator must inspect live credentials.".into());
+
+    let report = audit_project_issues(&[parent, subissue]);
+
+    assert!(!report
+        .violations
+        .iter()
+        .any(|violation| violation.code == "subissue_human_review_without_exception"));
+}
+
+#[test]
 fn reports_body_only_parent_hierarchy_as_warning() {
     let mut subissue = issue("#274", "Todo");
     subissue.description =

--- a/src/doctor/topology.rs
+++ b/src/doctor/topology.rs
@@ -1,4 +1,4 @@
-use crate::model::{normalize_state, TrackerIssue};
+use crate::model::{native_subissue_human_review_exception, normalize_state, TrackerIssue};
 
 use super::{
     bool_project_field, find_issue_by_ref, issue_refs_match, string_project_field, violation,
@@ -58,6 +58,7 @@ pub(super) fn audit_parent_subissue_topology(
         let Some(parent_ref) = native_parent_ref(subissue) else {
             continue;
         };
+        audit_subissue_human_review_without_exception(subissue, violations);
         let Some(parent) = find_issue_by_ref(issues, &parent_ref) else {
             continue;
         };
@@ -75,6 +76,25 @@ pub(super) fn audit_parent_subissue_topology(
         audit_subissue_pr_target(subissue, parent_branch, violations);
         audit_subissue_done_merge_evidence(subissue, parent_branch, violations);
     }
+}
+
+fn audit_subissue_human_review_without_exception(
+    subissue: &TrackerIssue,
+    violations: &mut Vec<ProjectAuditViolation>,
+) {
+    if subissue.normalized_state() != "human review"
+        || native_subissue_human_review_exception(subissue)
+    {
+        return;
+    }
+
+    violations.push(violation(
+        subissue,
+        AuditSeverity::Blocker,
+        "subissue_human_review_without_exception",
+        "Native subissue is in Human Review without a real subissue Human Review exception.",
+        "Route routine native subissue Review PASS results to Merging; keep direct child Human Review only for a meaningful `Subissue Human Review Exception: <reason>`.",
+    ));
 }
 
 fn audit_body_only_parent_hierarchy(

--- a/src/model.rs
+++ b/src/model.rs
@@ -113,14 +113,7 @@ pub fn native_subissue_human_review_exception(issue: &TrackerIssue) -> bool {
     issue
         .description
         .as_deref()
-        .map(|description| {
-            let text = description.to_ascii_lowercase();
-            text.contains("subissue human review exception:")
-                || text.contains("direct human review exception:")
-                || text.contains("direct human review required: yes")
-                || text.contains("requires direct human review: yes")
-                || text.contains("requires routine direct human review: yes")
-        })
+        .map(description_has_truthy_subissue_human_review_exception)
         .unwrap_or(false)
 }
 
@@ -240,16 +233,84 @@ fn explicit_truthy_project_field(issue: &TrackerIssue, field: &str) -> bool {
         .get(field)
         .is_some_and(|value| match value {
             serde_json::Value::Bool(value) => *value,
-            serde_json::Value::String(value) => {
-                let normalized = value.trim().to_ascii_lowercase();
-                !normalized.is_empty()
-                    && !matches!(
-                        normalized.as_str(),
-                        "false" | "no" | "none" | "n/a" | "not required"
-                    )
-            }
+            serde_json::Value::String(value) => exception_value_is_truthy(value),
             _ => false,
         })
+}
+
+fn description_has_truthy_subissue_human_review_exception(description: &str) -> bool {
+    const EXCEPTION_LABELS: &[&str] = &[
+        "Subissue Human Review Exception",
+        "Direct Human Review Exception",
+        "Direct Human Review Required",
+        "Requires Direct Human Review",
+        "Requires Routine Direct Human Review",
+    ];
+
+    description.lines().any(|line| {
+        EXCEPTION_LABELS
+            .iter()
+            .filter_map(|label| field_value_after_label(line, label))
+            .any(exception_value_is_truthy)
+    })
+}
+
+fn field_value_after_label<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+    let lower = line.to_ascii_lowercase();
+    let label = label.to_ascii_lowercase();
+    let start = lower.find(&label)?;
+    let after_label = line[start + label.len()..].trim_start();
+    let value = after_label
+        .strip_prefix(':')
+        .or_else(|| after_label.strip_prefix('：'))
+        .or_else(|| after_label.strip_prefix('='))
+        .or_else(|| after_label.strip_prefix('-'))?
+        .trim();
+    Some(value)
+}
+
+fn exception_value_is_truthy(value: &str) -> bool {
+    let normalized = normalize_exception_value(value);
+    !normalized.is_empty()
+        && !matches!(
+            normalized.as_str(),
+            "false"
+                | "no"
+                | "none"
+                | "n/a"
+                | "na"
+                | "not applicable"
+                | "not required"
+                | "not needed"
+                | "null"
+                | "nil"
+                | "无"
+                | "沒有"
+                | "没有"
+        )
+}
+
+fn normalize_exception_value(value: &str) -> String {
+    value
+        .trim_matches(|character: char| {
+            character.is_whitespace()
+                || matches!(
+                    character,
+                    '`' | '*'
+                        | '_'
+                        | '"'
+                        | '\''
+                        | '.'
+                        | ','
+                        | ';'
+                        | ':'
+                        | '。'
+                        | '，'
+                        | '；'
+                        | '：'
+                )
+        })
+        .to_lowercase()
 }
 
 fn push_native_subissue_status(

--- a/src/review.rs
+++ b/src/review.rs
@@ -623,7 +623,7 @@ fn terminal_review_failure_marker_matches(value: &str, worker_key: &str) -> bool
 }
 
 pub fn render_review_workpad(issue: &TrackerIssue, job: &ReviewJob) -> String {
-    let decision = review_gate_decision_for_actor(job, ReviewActor::IndependentReviewAgent);
+    let decision = review_gate_decision_for_issue(job, issue);
     let mut attempt_details = Vec::new();
     if let Some(error) = &job.error {
         attempt_details.push(render_attempt_error(error));
@@ -1722,6 +1722,63 @@ mod tests {
     }
 
     #[test]
+    fn review_agent_passed_native_subissue_with_none_exception_routes_to_merging() {
+        let backend = FakeReviewBackend::new(FakeReviewOutcome::Pass);
+        let temp = tempfile::tempdir().unwrap();
+        let request = review_request_with_temp_roots(&temp);
+        let job = backend.poll(backend.start(request).unwrap()).unwrap();
+        let mut issue = native_subissue(issue());
+        issue.description = Some(
+            "Related Parent Issue or Context: native subissue under #400.\nSubissue Human Review Exception: None."
+                .into(),
+        );
+        let decision = review_gate_decision_for_issue(&job, &issue);
+
+        assert_eq!(review_pass_target_state(&issue), "merging");
+        assert_eq!(decision.outcome, ReviewOutcome::PassedToMerging);
+        assert_eq!(decision.target_state, Some("merging"));
+    }
+
+    #[test]
+    fn review_agent_passed_native_subissue_with_negative_exception_values_routes_to_merging() {
+        for value in ["No", "False", "N/A", "na", "无", "没有", ""] {
+            let backend = FakeReviewBackend::new(FakeReviewOutcome::Pass);
+            let temp = tempfile::tempdir().unwrap();
+            let request = review_request_with_temp_roots(&temp);
+            let job = backend.poll(backend.start(request).unwrap()).unwrap();
+            let mut issue = native_subissue(issue());
+            issue.description = Some(format!("Subissue Human Review Exception: {value}"));
+            let decision = review_gate_decision_for_issue(&job, &issue);
+
+            assert_eq!(review_pass_target_state(&issue), "merging", "{value:?}");
+            assert_eq!(
+                decision.outcome,
+                ReviewOutcome::PassedToMerging,
+                "{value:?}"
+            );
+            assert_eq!(decision.target_state, Some("merging"), "{value:?}");
+        }
+    }
+
+    #[test]
+    fn review_agent_passed_native_subissue_with_negative_project_field_routes_to_merging() {
+        let backend = FakeReviewBackend::new(FakeReviewOutcome::Pass);
+        let temp = tempfile::tempdir().unwrap();
+        let request = review_request_with_temp_roots(&temp);
+        let job = backend.poll(backend.start(request).unwrap()).unwrap();
+        let mut issue = native_subissue(issue());
+        issue.project_fields.insert(
+            "Subissue Human Review Exception".into(),
+            serde_json::json!("None."),
+        );
+        let decision = review_gate_decision_for_issue(&job, &issue);
+
+        assert_eq!(review_pass_target_state(&issue), "merging");
+        assert_eq!(decision.outcome, ReviewOutcome::PassedToMerging);
+        assert_eq!(decision.target_state, Some("merging"));
+    }
+
+    #[test]
     fn review_agent_passed_native_subissue_exception_routes_to_human_review() {
         let backend = FakeReviewBackend::new(FakeReviewOutcome::Pass);
         let temp = tempfile::tempdir().unwrap();
@@ -1734,6 +1791,25 @@ mod tests {
 
         assert_eq!(decision.outcome, ReviewOutcome::PassedToHumanReview);
         assert_eq!(decision.target_state, Some("human_review"));
+    }
+
+    #[test]
+    fn review_workpad_for_native_subissue_none_exception_records_merging_result() {
+        let mut issue = native_subissue(issue());
+        issue.description = Some("Subissue Human Review Exception: None.".into());
+        let job = completed_gemini_review("Review Result: PASS\n\nNo confirmed findings.");
+
+        let workpad = render_review_workpad(&issue, &job);
+
+        assert!(
+            workpad.contains("- Target state after review routing: `merging`"),
+            "{workpad}"
+        );
+        assert!(workpad.contains("- Result: `PassedToMerging`"), "{workpad}");
+        assert!(
+            workpad.contains("parent issue owns final Human Review and UAT"),
+            "{workpad}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Implements #381: Fix native subissue Review PASS routing when Human Review exception is absent.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #381
