### PR TITLE
#414: Browse lane heartbeat and Codex session transcripts in app

### DIFF
--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -17,7 +17,8 @@ fn main() {
             read_surfaces::get_runtime_snapshot,
             github::get_github_user,
             read_surfaces::get_operator_overview,
-            read_surfaces::get_read_surface
+            read_surfaces::get_read_surface,
+            read_surfaces::get_codex_transcript
         ])
         .run(tauri::generate_context!())
         .expect("error while running Shea Symphony App");

--- a/app/src-tauri/src/read_surfaces.rs
+++ b/app/src-tauri/src/read_surfaces.rs
@@ -66,6 +66,18 @@ pub async fn get_read_surface(
     .map_err(|error| format!("read surface task failed: {error}"))?
 }
 
+#[tauri::command]
+pub async fn get_codex_transcript(
+    issue_ref: String,
+    session_id: Option<String>,
+) -> Result<Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        build_codex_transcript(&issue_ref, session_id.as_deref())
+    })
+    .await
+    .map_err(|error| format!("transcript read task failed: {error}"))?
+}
+
 fn build_read_surface(name: &str, allow_project_fallback: bool) -> Result<Value, String> {
     let args = read_surface_args(name).ok_or_else(|| format!("unknown read surface: {name}"))?;
     let result = if project_backed_surface(name) {
@@ -98,6 +110,241 @@ fn build_read_surface(name: &str, allow_project_fallback: bool) -> Result<Value,
             String::new()
         },
     ))
+}
+
+fn build_codex_transcript(issue_ref: &str, session_id: Option<&str>) -> Result<Value, String> {
+    let local_status = run_shea_read(&read_surface_args("local").unwrap_or_default());
+    let snapshot = parse_json_output(&local_status.stdout);
+    let normalized_issue = normalize_issue_ref(issue_ref);
+    let candidates = transcript_candidates(&snapshot, normalized_issue.as_deref(), session_id);
+
+    for candidate in &candidates {
+        let Some(path) = candidate.get("path").and_then(Value::as_str) else {
+            continue;
+        };
+        let path = PathBuf::from(path);
+        if !path.exists() || !path.is_file() {
+            continue;
+        }
+        let metadata = fs::metadata(&path).ok();
+        let modified_at_ms = metadata
+            .as_ref()
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis() as u64);
+        let content = fs::read_to_string(&path)
+            .map_err(|error| format!("failed to read local Codex transcript: {error}"))?;
+        return Ok(json!({
+            "status": "available",
+            "localOnly": true,
+            "path": path.display().to_string(),
+            "content": content,
+            "candidates": candidates,
+            "metadata": {
+                "bytes": metadata.map(|metadata| metadata.len()).unwrap_or(0),
+                "modifiedAtMs": modified_at_ms,
+            },
+        }));
+    }
+
+    Ok(json!({
+        "status": "unavailable",
+        "localOnly": true,
+        "reason": if candidates.is_empty() {
+            "No local Codex transcript candidate was found from session registry, runtime metadata, or .codex/sessions fallback search."
+        } else {
+            "Local Codex transcript candidates were found, but no readable JSONL file exists at those paths."
+        },
+        "path": Value::Null,
+        "content": "",
+        "candidates": candidates,
+    }))
+}
+
+fn transcript_candidates(
+    snapshot: &Value,
+    issue_ref: Option<&str>,
+    session_id: Option<&str>,
+) -> Vec<Value> {
+    let mut candidates = Vec::new();
+    push_registry_transcript_candidates(&mut candidates, snapshot, issue_ref, session_id);
+    if let Some(session_id) = session_id {
+        push_session_store_candidates(&mut candidates, session_id, "runtime_session_id");
+    }
+    if let Some(issue_ref) = issue_ref {
+        for session in snapshot
+            .get("sessions")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            if normalize_issue_ref(
+                session
+                    .get("issue_identifier")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default(),
+            )
+            .as_deref()
+                != Some(issue_ref)
+            {
+                continue;
+            }
+            for key in ["session_id", "session_name", "run_id", "instance_name"] {
+                if let Some(value) = session.get(key).and_then(Value::as_str) {
+                    push_session_store_candidates(&mut candidates, value, key);
+                }
+            }
+        }
+    }
+    dedupe_candidates(candidates)
+}
+
+fn push_registry_transcript_candidates(
+    candidates: &mut Vec<Value>,
+    snapshot: &Value,
+    issue_ref: Option<&str>,
+    session_id: Option<&str>,
+) {
+    for session in snapshot
+        .get("sessions")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let session_issue = normalize_issue_ref(
+            session
+                .get("issue_identifier")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+        );
+        let issue_matches = issue_ref.is_some_and(|issue| session_issue.as_deref() == Some(issue));
+        let session_matches = session_id.is_some_and(|id| {
+            ["session_id", "session_name", "run_id", "instance_name"]
+                .iter()
+                .any(|key| {
+                    session
+                        .get(key)
+                        .and_then(Value::as_str)
+                        .is_some_and(|value| value.contains(id) || id.contains(value))
+                })
+        });
+        if !issue_matches && !session_matches {
+            continue;
+        }
+        for key in [
+            "transcript_path",
+            "codex_transcript_path",
+            "jsonl_path",
+            "protocol_artifact_path",
+            "log_path",
+        ] {
+            if let Some(path) = session
+                .get(key)
+                .and_then(Value::as_str)
+                .filter(|path| path.ends_with(".jsonl"))
+            {
+                candidates.push(json!({
+                    "source": format!("session_registry.{key}"),
+                    "path": path,
+                    "session": session.get("session_name").or_else(|| session.get("run_id")).cloned().unwrap_or(Value::Null),
+                    "issue": session_issue,
+                }));
+            }
+        }
+    }
+}
+
+fn push_session_store_candidates(candidates: &mut Vec<Value>, needle: &str, source: &str) {
+    let Some(root) = codex_sessions_root() else {
+        return;
+    };
+    let needle = needle.trim();
+    if needle.is_empty() {
+        return;
+    }
+    for path in find_rollout_jsonl(&root, needle, 40) {
+        candidates.push(json!({
+            "source": source,
+            "path": path.display().to_string(),
+            "session": needle,
+        }));
+    }
+}
+
+fn find_rollout_jsonl(root: &Path, needle: &str, limit: usize) -> Vec<PathBuf> {
+    let mut matches = Vec::new();
+    collect_rollout_jsonl(root, needle, limit, &mut matches);
+    matches.sort_by_key(|path| {
+        fs::metadata(path)
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| std::cmp::Reverse(duration.as_millis()))
+    });
+    matches.truncate(limit);
+    matches
+}
+
+fn collect_rollout_jsonl(root: &Path, needle: &str, limit: usize, matches: &mut Vec<PathBuf>) {
+    if matches.len() >= limit {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rollout_jsonl(&path, needle, limit, matches);
+        } else if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| {
+                name.starts_with("rollout-") && name.ends_with(".jsonl") && name.contains(needle)
+            })
+        {
+            matches.push(path);
+        }
+        if matches.len() >= limit {
+            return;
+        }
+    }
+}
+
+fn codex_sessions_root() -> Option<PathBuf> {
+    std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".codex")))
+        .map(|path| path.join("sessions"))
+}
+
+fn dedupe_candidates(candidates: Vec<Value>) -> Vec<Value> {
+    let mut seen = BTreeMap::new();
+    for candidate in candidates {
+        let key = candidate
+            .get("path")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        if key.is_empty() || seen.contains_key(&key) {
+            continue;
+        }
+        seen.insert(key, candidate);
+    }
+    seen.into_values().collect()
+}
+
+fn normalize_issue_ref(value: &str) -> Option<String> {
+    let digits: String = value
+        .chars()
+        .skip_while(|ch| !ch.is_ascii_digit())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    if digits.is_empty() {
+        None
+    } else {
+        Some(format!("#{digits}"))
+    }
 }
 
 fn build_operator_overview(scope: &str) -> Result<Value, String> {
@@ -871,5 +1118,22 @@ mod tests {
         );
         assert_eq!(parsed["projectStateAccess"], "paused");
         assert_eq!(parsed["failureKind"], "rate_limit");
+    }
+
+    #[test]
+    fn finds_rollout_jsonl_by_session_id_under_codex_sessions_tree() {
+        let root =
+            std::env::temp_dir().join(format!("shea-transcript-test-{}", unix_timestamp_ms()));
+        let day = root.join("2026").join("06").join("02");
+        fs::create_dir_all(&day).unwrap();
+        let wanted = day.join("rollout-2026-06-02T17-30-00-019f-session-match.jsonl");
+        let ignored = day.join("rollout-2026-06-02T17-31-00-other.jsonl");
+        fs::write(&wanted, "{}\n").unwrap();
+        fs::write(&ignored, "{}\n").unwrap();
+
+        let matches = find_rollout_jsonl(&root, "019f-session-match", 10);
+
+        assert_eq!(matches, vec![wanted]);
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -2606,6 +2606,168 @@ a {
   font-size: var(--text-xs);
 }
 
+.lane-session-panel,
+.transcript-panel {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--card-bg);
+}
+
+.lane-session-head,
+.transcript-panel-head,
+.transcript-actions {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.lane-session-head h3,
+.transcript-panel-head h3 {
+  margin: 0;
+  color: var(--fg-2);
+  font-size: var(--text-md);
+}
+
+.lane-session-grid {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-2);
+}
+
+.lane-session-grid > div {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+  padding: var(--space-3);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--subtle-bg);
+}
+
+.lane-session-grid span,
+.transcript-summary span {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.lane-session-grid strong {
+  min-width: 0;
+  color: var(--fg-2);
+  font-size: var(--text-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lane-session-grid small {
+  min-width: 0;
+  color: var(--muted);
+  font-size: var(--text-xs);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transcript-actions {
+  flex: none;
+}
+
+.transcript-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.transcript-summary span {
+  padding: 4px 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--subtle-bg);
+}
+
+.transcript-timeline {
+  display: grid;
+  gap: var(--space-2);
+  max-height: 560px;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.transcript-event {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 116px minmax(0, 1fr);
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: var(--subtle-bg);
+}
+
+.transcript-event.final,
+.transcript-event.success {
+  border-color: color-mix(in oklab, var(--success), var(--border) 62%);
+}
+
+.transcript-event.warn {
+  border-color: color-mix(in oklab, var(--warning), var(--border) 58%);
+}
+
+.transcript-event.danger {
+  border-color: color-mix(in oklab, var(--danger), var(--border) 58%);
+}
+
+.transcript-event-meta,
+.transcript-event-body {
+  min-width: 0;
+  display: grid;
+  align-content: start;
+  gap: 3px;
+}
+
+.transcript-event-meta span {
+  color: var(--accent);
+  font-size: var(--text-xs);
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.transcript-event-meta small {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  overflow-wrap: anywhere;
+}
+
+.transcript-event-body strong {
+  min-width: 0;
+  color: var(--fg-2);
+  font-size: var(--text-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.transcript-event-body p {
+  min-width: 0;
+  max-width: 100%;
+  margin: 0;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--leading-snug);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 .lane-lifecycle-row {
   min-width: 0;
   display: grid;

--- a/app/src/lib/LaneViews.svelte
+++ b/app/src/lib/LaneViews.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  import { REFRESH_REQUEST_EVENT } from './uiState.ts';
+  import JsonLogView from './shell/JsonLogView.svelte';
+  import { autoloopStateStore, REFRESH_REQUEST_EVENT } from './uiState.ts';
+  import { getCodexTranscript } from './tauriAutoloop.ts';
+  import {
+    classifyHeartbeat,
+    parseCodexTranscriptJsonl,
+    transcriptUnavailable
+  } from './viewModel/codexTranscript.ts';
 
   export let view: any;
   export let route = '/lanes';
@@ -17,6 +24,11 @@
   ];
 
   let completedWindowHours = null;
+  let transcriptMode = 'conversation';
+  let transcriptLoading = false;
+  let transcriptError = '';
+  let transcriptResponse: any = transcriptUnavailable('Transcript has not been loaded yet.');
+  let transcriptLoadKey = '';
 
   $: laneWorkers = view?.laneWorkers ?? {};
   $: queueIssues = view?.queueIssues ?? [];
@@ -26,6 +38,13 @@
   $: filteredCompletedLocalIssues = filterCompletedByWindow(completedLocalIssues, completedWindowHours);
   $: selectedIssue = selectedIssueRef ? findIssueForDetail(selectedIssueRef, issueRows, completedLocalIssues, view) : null;
   $: lifecycleEvents = selectedIssue ? buildLifecycleEvents(selectedIssue, view) : [];
+  $: selectedLaneKey = laneKeyForIssue(selectedIssue);
+  $: heartbeatSummary = selectedIssue ? classifyHeartbeat($autoloopStateStore, selectedLaneKey) : null;
+  $: transcriptParsed = parseCodexTranscriptJsonl(transcriptResponse?.content ?? '');
+  $: transcriptStatusLabel = transcriptResponse?.status === 'available'
+    ? `${transcriptParsed.status} · ${transcriptParsed.events.length} events`
+    : transcriptResponse?.reason ?? 'Transcript unavailable';
+  $: maybeLoadTranscript(selectedIssue);
   $: laneColumns = laneOrder.map((lane) => {
     const issues = lane === 'Human Todo'
       ? issueRows.filter((issue) => humanStates.has(normalizeState(issue.state)))
@@ -296,6 +315,46 @@
     window.dispatchEvent(new CustomEvent(REFRESH_REQUEST_EVENT, {
       detail: { source: 'local-artifacts', force: true, localOnly: true }
     }));
+    reloadTranscript();
+  }
+
+  function maybeLoadTranscript(issue: any) {
+    const key = issue ? `${issue.id}|${sessionIdForIssue(issue) ?? ''}` : '';
+    if (!key || key === transcriptLoadKey) return;
+    transcriptLoadKey = key;
+    loadTranscript(issue);
+  }
+
+  async function loadTranscript(issue: any) {
+    transcriptLoading = true;
+    transcriptError = '';
+    transcriptResponse = transcriptUnavailable('Loading local Codex transcript.');
+    try {
+      transcriptResponse = await getCodexTranscript(issue.id, sessionIdForIssue(issue)) ??
+        transcriptUnavailable('Codex transcript reads are only available in the desktop shell.');
+    } catch (error) {
+      transcriptError = error instanceof Error ? error.message : String(error);
+      transcriptResponse = transcriptUnavailable(transcriptError);
+    } finally {
+      transcriptLoading = false;
+    }
+  }
+
+  function reloadTranscript() {
+    if (!selectedIssue) return;
+    transcriptLoadKey = '';
+    maybeLoadTranscript(selectedIssue);
+  }
+
+  function sessionIdForIssue(issue: any) {
+    return issue?.worker?.session ?? issue?.worktree?.session ?? issue?.session ?? null;
+  }
+
+  function laneKeyForIssue(issue: any) {
+    const lane = String(issue?.lane ?? '').toLowerCase();
+    if (lane.includes('review')) return 'review';
+    if (lane.includes('merge')) return 'merge';
+    return 'main';
   }
 
   function routeIssueRef(path: string) {
@@ -356,6 +415,12 @@
     const hours = Math.round(minutes / 60);
     if (hours < 48) return `${hours}h ago`;
     return `${Math.round(hours / 24)}d ago`;
+  }
+
+  function formatMsTime(value: unknown) {
+    const ms = typeof value === 'number' ? value : Number(value);
+    if (!Number.isFinite(ms)) return 'unknown';
+    return new Date(ms).toLocaleString([], { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' });
   }
 
   function shortHead(value: unknown) {
@@ -432,6 +497,100 @@
         <code>{selectedIssue.worktree.path}</code>
       </div>
     {/if}
+
+    <section class="lane-session-panel" aria-label={`${selectedIssue.id} session observability`}>
+      <div class="lane-session-head">
+        <div>
+          <span class="mini-label">Heartbeat / session</span>
+          <h3>{heartbeatSummary?.label ?? 'Heartbeat unavailable'}</h3>
+        </div>
+        <span class="status-pill {heartbeatSummary?.tone ?? 'warn'}">{heartbeatSummary?.state ?? 'unavailable'}</span>
+      </div>
+
+      <div class="lane-session-grid">
+        <div>
+          <span>Last heartbeat</span>
+          <strong>{formatMsTime(heartbeatSummary?.lastHeartbeatMs)}</strong>
+          <small>{heartbeatSummary?.lastHeartbeatAge ?? 'unknown'}</small>
+        </div>
+        <div>
+          <span>Latest lane event</span>
+          <strong>{heartbeatSummary?.latestLaneEvent ?? 'No lane event visible.'}</strong>
+          <small>Filtered autoloop signal</small>
+        </div>
+        <div>
+          <span>Transcript</span>
+          <strong>{transcriptLoading ? 'Loading local file' : transcriptStatusLabel}</strong>
+          <small>{transcriptResponse?.path ?? 'Local-only diagnostic surface'}</small>
+        </div>
+      </div>
+    </section>
+
+    <section class="transcript-panel" aria-label={`${selectedIssue.id} Codex transcript`}>
+      <div class="transcript-panel-head">
+        <div>
+          <span class="mini-label">Codex transcript</span>
+          <h3>{transcriptResponse?.status === 'available' ? 'Conversation timeline' : 'Unavailable locally'}</h3>
+        </div>
+        <div class="transcript-actions">
+          <div class="segmented-control compact" role="group" aria-label="Transcript view">
+            <button class:active={transcriptMode === 'conversation'} type="button" on:click={() => transcriptMode = 'conversation'}>Conversation</button>
+            <button class:active={transcriptMode === 'raw'} type="button" on:click={() => transcriptMode = 'raw'}>Raw</button>
+          </div>
+          <button class="btn btn-ghost" type="button" on:click={reloadTranscript} disabled={transcriptLoading}>
+            {transcriptLoading ? 'Reloading' : 'Reload'}
+          </button>
+        </div>
+      </div>
+
+      {#if transcriptError}
+        <div class="inline-empty compact-empty">
+          <strong>Local transcript read failed</strong>
+          <p>{transcriptError}</p>
+        </div>
+      {:else if transcriptResponse?.status !== 'available'}
+        <div class="inline-empty compact-empty">
+          <strong>No readable local transcript</strong>
+          <p>{transcriptResponse?.reason ?? 'No local Codex transcript candidate was found.'}</p>
+        </div>
+      {:else if transcriptMode === 'raw'}
+        <JsonLogView value={transcriptResponse?.content} fallbackLabel="Codex transcript JSONL" />
+      {:else}
+        <div class="transcript-summary">
+          <span>{transcriptParsed.summary.userTurns} user</span>
+          <span>{transcriptParsed.summary.assistantTurns} assistant</span>
+          <span>{transcriptParsed.summary.toolCalls} tool calls</span>
+          <span>{transcriptParsed.summary.diagnostics} diagnostics</span>
+          {#if transcriptParsed.summary.tokenUsage}
+            <span>{transcriptParsed.summary.tokenUsage}</span>
+          {/if}
+        </div>
+
+        <div class="transcript-timeline">
+          {#if transcriptParsed.events.length}
+            {#each transcriptParsed.events as event}
+              <article class="transcript-event {event.kind} {event.tone}">
+                <div class="transcript-event-meta">
+                  <span>{event.kind.replace('_', ' ')}</span>
+                  {#if event.detail}
+                    <small>{event.detail}</small>
+                  {/if}
+                </div>
+                <div class="transcript-event-body">
+                  <strong>{event.title}</strong>
+                  <p>{event.body}</p>
+                </div>
+              </article>
+            {/each}
+          {:else}
+            <div class="inline-empty compact-empty">
+              <strong>Transcript has no readable conversation events</strong>
+              <p>{transcriptParsed.status === 'empty' ? 'The local JSONL file is empty or still growing.' : 'Open Raw view for parser diagnostics.'}</p>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </section>
 
     <div class="lane-lifecycle-list">
       {#if lifecycleEvents.length}

--- a/app/src/lib/tauriAutoloop.ts
+++ b/app/src/lib/tauriAutoloop.ts
@@ -149,6 +149,12 @@ export async function getReadSurface(name: string, force = false, allowProjectFa
   return invoke<ReadSurface>('get_read_surface', { name, force, allowProjectFallback });
 }
 
+export async function getCodexTranscript(issueRef: string, sessionId: string | null = null): Promise<Record<string, unknown> | null> {
+  if (!isTauriRuntime()) return null;
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<Record<string, unknown>>('get_codex_transcript', { issueRef, sessionId });
+}
+
 export async function startAutoloop(options: StartAutoloopOptions = {}): Promise<LoopStateSnapshot> {
   if (!isTauriRuntime()) {
     throw new Error('Tauri runtime is unavailable; open Shea Symphony App in the desktop shell.');

--- a/app/src/lib/viewModel/codexTranscript.ts
+++ b/app/src/lib/viewModel/codexTranscript.ts
@@ -1,0 +1,290 @@
+export type TranscriptTone = 'neutral' | 'success' | 'warn' | 'danger';
+export type TranscriptEventKind =
+  | 'user'
+  | 'assistant'
+  | 'final'
+  | 'tool_call'
+  | 'tool_output'
+  | 'diagnostic'
+  | 'usage'
+  | 'raw';
+
+export type TranscriptEvent = {
+  id: string;
+  kind: TranscriptEventKind;
+  title: string;
+  body: string;
+  detail?: string;
+  tone: TranscriptTone;
+  raw?: unknown;
+};
+
+export type TranscriptParseResult = {
+  status: 'available' | 'partial' | 'empty' | 'malformed';
+  events: TranscriptEvent[];
+  rawRecords: unknown[];
+  malformedLines: number;
+  summary: {
+    userTurns: number;
+    assistantTurns: number;
+    toolCalls: number;
+    diagnostics: number;
+    tokenUsage: string | null;
+  };
+};
+
+export type HeartbeatSummary = {
+  state: 'running' | 'stale' | 'stopped' | 'unavailable';
+  tone: TranscriptTone;
+  label: string;
+  lastHeartbeatMs: number | null;
+  lastHeartbeatAge: string;
+  latestLaneEvent: string;
+};
+
+const staleAfterMs = 2 * 60 * 1000;
+
+export function classifyHeartbeat(
+  loopState: any,
+  laneKey: string,
+  nowMs = Date.now()
+): HeartbeatSummary {
+  const lane = loopState?.lanes?.[laneKey];
+  const lastHeartbeatMs = numberOrNull(lane?.updatedAtMs ?? latestLineAt(loopState));
+  const ageMs = lastHeartbeatMs == null ? null : Math.max(0, nowMs - lastHeartbeatMs);
+  const latestLaneEvent = usefulLaneEvent(loopState, laneKey) ?? lane?.latestLine ?? lane?.action ?? 'No lane event visible.';
+
+  if (!loopState) {
+    return heartbeat('unavailable', null, 'unavailable', 'Autoloop state is unavailable.', latestLaneEvent);
+  }
+  if (!loopState.running) {
+    return heartbeat('stopped', lastHeartbeatMs, ageLabel(ageMs), 'Loop stopped', latestLaneEvent);
+  }
+  if (lastHeartbeatMs == null) {
+    return heartbeat('unavailable', null, 'unavailable', 'Heartbeat unavailable', latestLaneEvent);
+  }
+  if (ageMs != null && ageMs > staleAfterMs) {
+    return heartbeat('stale', lastHeartbeatMs, ageLabel(ageMs), 'Heartbeat stale', latestLaneEvent);
+  }
+  return heartbeat('running', lastHeartbeatMs, ageLabel(ageMs), 'Loop running', latestLaneEvent);
+}
+
+export function parseCodexTranscriptJsonl(text: unknown): TranscriptParseResult {
+  const lines = String(text ?? '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const events: TranscriptEvent[] = [];
+  const rawRecords: unknown[] = [];
+  let malformedLines = 0;
+
+  lines.forEach((line, index) => {
+    let record: any;
+    try {
+      record = JSON.parse(line);
+      rawRecords.push(record);
+    } catch {
+      malformedLines += 1;
+      events.push({
+        id: `malformed-${index}`,
+        kind: 'diagnostic',
+        title: 'Malformed JSONL line',
+        body: line.slice(0, 240),
+        tone: 'warn'
+      });
+      return;
+    }
+
+    const mapped = transcriptEventFromRecord(record, index);
+    if (mapped) events.push(mapped);
+  });
+
+  const summary = {
+    userTurns: events.filter((event) => event.kind === 'user').length,
+    assistantTurns: events.filter((event) => event.kind === 'assistant' || event.kind === 'final').length,
+    toolCalls: events.filter((event) => event.kind === 'tool_call').length,
+    diagnostics: events.filter((event) => event.kind === 'diagnostic').length,
+    tokenUsage: latestUsage(events)
+  };
+  const status = !lines.length
+    ? 'empty'
+    : malformedLines
+      ? events.length > malformedLines
+        ? 'partial'
+        : 'malformed'
+      : 'available';
+  return { status, events, rawRecords, malformedLines, summary };
+}
+
+export function transcriptUnavailable(reason: string) {
+  return {
+    status: 'unavailable',
+    reason: reason || 'No local Codex transcript candidate was found.',
+    localOnly: true,
+    candidates: [],
+    content: '',
+    path: null
+  };
+}
+
+function transcriptEventFromRecord(record: any, index: number): TranscriptEvent | null {
+  const item = record?.item ?? record?.payload?.item ?? record?.message ?? record;
+  const type = text(record?.type ?? item?.type ?? record?.event ?? record?.kind);
+  const role = text(item?.role ?? record?.role);
+  const status = text(item?.status ?? record?.status);
+  const name = text(item?.name ?? item?.tool_name ?? record?.name ?? record?.tool_name);
+  const usage = record?.usage ?? record?.token_usage ?? record?.response?.usage;
+
+  if (usage && !role && !item?.content && !record?.content) {
+    return event(index, 'usage', 'Token usage', usageSummary(usage), 'neutral', undefined, record);
+  }
+
+  if (role === 'user' || type === 'user_message') {
+    return event(index, 'user', 'User', contentText(item || record), 'neutral', type || undefined, record);
+  }
+  if (role === 'assistant' || type === 'assistant_message' || type === 'message') {
+    const body = contentText(item || record);
+    const final = /final|answer/i.test(type) || record?.is_final === true;
+    return event(index, final ? 'final' : 'assistant', final ? 'Final answer' : 'Assistant', body, final ? 'success' : 'neutral', status || undefined, record);
+  }
+  if (/final|response\.completed/.test(type)) {
+    const body = contentText(item || record) || text(record?.response?.output_text);
+    if (body) return event(index, 'final', 'Final answer', body, 'success', status || undefined, record);
+  }
+  if (type.includes('function_call_output') || type.includes('tool_output') || item?.output) {
+    return event(index, 'tool_output', name || 'Tool output', previewText(item?.output ?? record?.output ?? record?.result), status === 'failed' ? 'danger' : 'neutral', status || undefined, record);
+  }
+  if (type.includes('function_call') || type.includes('tool_call') || item?.arguments || item?.input) {
+    const args = item?.arguments ?? item?.input ?? record?.arguments ?? record?.input;
+    return event(index, 'tool_call', name || 'Tool call', summarizeArguments(args), 'neutral', status || 'started', record);
+  }
+  if (/error|cancel|interrupt|input|required|failed/.test(`${type} ${status}`)) {
+    return event(index, 'diagnostic', diagnosticTitle(type, status), previewText(record?.error ?? record?.message ?? record), /error|failed/.test(`${type} ${status}`) ? 'danger' : 'warn', status || undefined, record);
+  }
+  if (usage) {
+    return event(index, 'usage', 'Token usage', usageSummary(usage), 'neutral', undefined, record);
+  }
+  return null;
+}
+
+function event(index: number, kind: TranscriptEventKind, title: string, body: string, tone: TranscriptTone, detail?: string, raw?: unknown): TranscriptEvent {
+  return {
+    id: `${kind}-${index}`,
+    kind,
+    title,
+    body: body || '(empty)',
+    detail,
+    tone,
+    raw
+  };
+}
+
+function heartbeat(state: HeartbeatSummary['state'], lastHeartbeatMs: number | null, lastHeartbeatAge: string, label: string, latestLaneEvent: string): HeartbeatSummary {
+  const tone = state === 'running' ? 'success' : state === 'stale' ? 'warn' : state === 'stopped' ? 'neutral' : 'warn';
+  return { state, tone, label, lastHeartbeatMs, lastHeartbeatAge, latestLaneEvent };
+}
+
+function usefulLaneEvent(loopState: any, laneKey: string) {
+  const lines = [...(loopState?.recentLines ?? [])].reverse();
+  for (const entry of lines) {
+    const event = entry?.event;
+    const payload = event?.payload ?? {};
+    const raw = text(payload.raw ?? entry.line);
+    const lane = text(payload.lane ?? payload.fields?.lane ?? event?.lane);
+    if (lane && lane !== laneKey) continue;
+    if (isNoisyLine(raw)) continue;
+    if (raw) return raw;
+  }
+  return null;
+}
+
+function latestLineAt(loopState: any) {
+  const lines = loopState?.recentLines ?? [];
+  return lines.length ? lines[lines.length - 1]?.atMs : null;
+}
+
+function isNoisyLine(raw: string) {
+  return raw === 'SHEA SYMPHONY STATUS'
+    || raw === 'integration gaps:'
+    || /^-\s+GitHub Project v2\b/.test(raw)
+    || /^canonical_checkout/.test(raw)
+    || /reason=state is not active\b/.test(raw)
+    || /reason=no_(merging|agent_review)_issue\b/.test(raw);
+}
+
+function contentText(value: any): string {
+  const content = value?.content ?? value?.text ?? value?.message ?? value?.output_text;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => text(part?.text ?? part?.content ?? part))
+      .filter(Boolean)
+      .join('\n\n');
+  }
+  return previewText(content);
+}
+
+function summarizeArguments(value: unknown) {
+  if (value == null || value === '') return 'No arguments.';
+  if (typeof value === 'string') {
+    try {
+      return summarizeObject(JSON.parse(value));
+    } catch {
+      return previewText(value);
+    }
+  }
+  return summarizeObject(value);
+}
+
+function summarizeObject(value: any) {
+  if (value == null || typeof value !== 'object') return previewText(value);
+  const entries = Object.entries(value).slice(0, 4);
+  if (!entries.length) return '{}';
+  return entries.map(([key, entry]) => `${key}: ${previewText(entry, 80)}`).join(' · ');
+}
+
+function usageSummary(usage: any) {
+  const input = usage?.input_tokens ?? usage?.prompt_tokens;
+  const output = usage?.output_tokens ?? usage?.completion_tokens;
+  const total = usage?.total_tokens ?? (Number(input) || 0) + (Number(output) || 0);
+  return [
+    input != null ? `input ${input}` : null,
+    output != null ? `output ${output}` : null,
+    total ? `total ${total}` : null
+  ].filter(Boolean).join(' · ') || previewText(usage);
+}
+
+function latestUsage(events: TranscriptEvent[]) {
+  return [...events].reverse().find((event) => event.kind === 'usage')?.body ?? null;
+}
+
+function diagnosticTitle(type: string, status: string) {
+  if (/input|required/.test(`${type} ${status}`)) return 'Input required';
+  if (/cancel|interrupt/.test(`${type} ${status}`)) return 'Session cancelled';
+  if (/error|failed/.test(`${type} ${status}`)) return 'Session error';
+  return 'Diagnostic event';
+}
+
+function ageLabel(ageMs: number | null) {
+  if (ageMs == null) return 'unknown';
+  const seconds = Math.round(ageMs / 1000);
+  if (seconds < 90) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 90) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h ago`;
+}
+
+function numberOrNull(value: unknown) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function previewText(value: unknown, max = 900): string {
+  const raw = typeof value === 'string' ? value : JSON.stringify(value ?? '', null, 2);
+  const compact = raw.trim();
+  return compact.length > max ? `${compact.slice(0, max)}...` : compact;
+}
+
+function text(value: unknown) {
+  return String(value ?? '').trim();
+}

--- a/app/test/operator-view.test.mjs
+++ b/app/test/operator-view.test.mjs
@@ -17,6 +17,11 @@ import {
   mergeReadSurface
 } from '../src/lib/operatorReadModel.ts';
 import {
+  classifyHeartbeat,
+  parseCodexTranscriptJsonl,
+  transcriptUnavailable
+} from '../src/lib/viewModel/codexTranscript.ts';
+import {
   defaultBackgroundReadSurfaces,
   projectCooldownReadSurfaces
 } from '../src/lib/operatorOverviewStore.ts';
@@ -188,6 +193,53 @@ test('lane throughput board keeps independent running and queued lane work visib
   assert.equal(merge.runningCount, 0);
   assert.equal(merge.queuedCount, 1);
   assert.deepEqual(merge.issues.map((issue) => issue.id), ['#430']);
+});
+
+test('Codex transcript parser renders conversation turns, tool calls, outputs, final answers, and usage', () => {
+  const transcript = [
+    JSON.stringify({ type: 'message', item: { role: 'user', content: [{ text: 'Please inspect status.' }] } }),
+    JSON.stringify({ type: 'function_call', item: { name: 'functions.exec_command', arguments: JSON.stringify({ cmd: 'git status --short' }), status: 'completed' } }),
+    JSON.stringify({ type: 'function_call_output', item: { name: 'functions.exec_command', output: '## branch\n M app/src/file.ts' } }),
+    JSON.stringify({ type: 'message', item: { role: 'assistant', content: 'I found one modified file.' } }),
+    JSON.stringify({ type: 'final_answer', item: { role: 'assistant', content: 'Done.' } }),
+    JSON.stringify({ type: 'response.completed', response: { usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 } } })
+  ].join('\n');
+
+  const parsed = parseCodexTranscriptJsonl(transcript);
+
+  assert.equal(parsed.status, 'available');
+  assert.equal(parsed.summary.userTurns, 1);
+  assert.equal(parsed.summary.assistantTurns, 2);
+  assert.equal(parsed.summary.toolCalls, 1);
+  assert.equal(parsed.summary.tokenUsage, 'input 10 · output 5 · total 15');
+  assert.equal(parsed.events.find((event) => event.kind === 'tool_call').title, 'functions.exec_command');
+  assert.match(parsed.events.find((event) => event.kind === 'tool_call').body, /cmd: git status --short/);
+  assert.match(parsed.events.find((event) => event.kind === 'tool_output').body, /modified file|## branch/);
+});
+
+test('Codex transcript parser marks malformed still-growing JSONL as partial', () => {
+  const parsed = parseCodexTranscriptJsonl(`${JSON.stringify({ type: 'message', item: { role: 'user', content: 'hi' } })}\n{"type":`);
+
+  assert.equal(parsed.status, 'partial');
+  assert.equal(parsed.malformedLines, 1);
+  assert.equal(parsed.events.some((event) => event.title === 'Malformed JSONL line'), true);
+});
+
+test('missing transcript state is local-only and explicit', () => {
+  const unavailable = transcriptUnavailable('No local transcript candidate was found.');
+
+  assert.equal(unavailable.status, 'unavailable');
+  assert.equal(unavailable.localOnly, true);
+  assert.match(unavailable.reason, /No local transcript/);
+});
+
+test('heartbeat classifier separates running, stale, stopped, and unavailable states', () => {
+  const now = 10_000;
+
+  assert.equal(classifyHeartbeat({ running: true, lanes: { main: { updatedAtMs: now - 15_000 } } }, 'main', now).state, 'running');
+  assert.equal(classifyHeartbeat({ running: true, lanes: { main: { updatedAtMs: now - 180_000 } } }, 'main', now).state, 'stale');
+  assert.equal(classifyHeartbeat({ running: false, lanes: { main: { updatedAtMs: now - 180_000 } } }, 'main', now).state, 'stopped');
+  assert.equal(classifyHeartbeat(null, 'main', now).state, 'unavailable');
 });
 
 test('project read cooldown preserves last stable review queue visibility', () => {


### PR DESCRIPTION
## Summary
- Implements #414: Browse lane heartbeat and Codex session transcripts in app.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #414
