### PR TITLE
#407: Separate handoff progress from local worktree modification times

### DIFF
--- a/app/src-tauri/src/read_surfaces.rs
+++ b/app/src-tauri/src/read_surfaces.rs
@@ -550,25 +550,59 @@ fn completed_issue_worktrees(
             let Some(worktree) = worktrees_by_issue.get(&issue) else {
                 continue;
             };
-            let updated_at = session.get("updated_at_ms").cloned().unwrap_or(Value::Null);
+            let session_source = session
+                .get("session_source")
+                .and_then(Value::as_str)
+                .unwrap_or("session_registry");
+            let is_project_readback_cache = session_source == "project_readback_cache";
+            let updated_at = if is_project_readback_cache {
+                Value::Null
+            } else {
+                session.get("updated_at_ms").cloned().unwrap_or(Value::Null)
+            };
+            let title = session.get("issue_title").cloned().unwrap_or(Value::Null);
+            let state = if is_project_readback_cache {
+                session.get("project_state").cloned().unwrap_or(Value::Null)
+            } else {
+                Value::String("Done".into())
+            };
+            let url = session.get("project_url").cloned().unwrap_or(Value::Null);
+            let last_progress_source = if updated_at.is_null() {
+                Value::String("unavailable".into())
+            } else {
+                Value::String("session_registry.updated_at_ms".into())
+            };
             completed.insert(
                 issue.clone(),
                 json!({
                     "issue": issue,
-                    "title": session.get("issue_title").cloned().unwrap_or(Value::Null),
-                    "state": "Done",
+                    "title": title,
+                    "state": state,
                     "lane": session.get("lane").cloned().unwrap_or(Value::Null),
+                    "url": url,
                     "completedAt": updated_at,
                     "createdAt": session.get("started_at_ms").cloned().unwrap_or_else(|| worktree.get("createdAt").cloned().unwrap_or(Value::Null)),
-                    "lastProgressAt": session.get("updated_at_ms").cloned().unwrap_or(Value::Null),
+                    "lastProgressAt": updated_at,
+                    "lastProgressSource": last_progress_source,
                     "path": worktree.get("path").cloned().unwrap_or(Value::Null),
                     "branch": worktree.get("branch").cloned().unwrap_or(Value::Null),
                     "head": worktree.get("head").cloned().unwrap_or(Value::Null),
                     "lastModified": worktree.get("lastModified").cloned().unwrap_or(Value::Null),
+                    "lastModifiedSource": "git_worktree_filesystem",
                     "treeState": worktree.get("treeState").cloned().unwrap_or(Value::Null),
                     "diskBytes": worktree.get("diskBytes").cloned().unwrap_or(Value::Null),
                     "evidence": session.get("evidence").cloned().unwrap_or(Value::Null),
-                    "artifactSource": "session_registry",
+                    "artifactSource": if is_project_readback_cache { "project_readback_cache" } else { "session_registry" },
+                    "timestampSources": {
+                        "lastProgress": {
+                            "source": if is_project_readback_cache { "unavailable" } else { "session_registry.updated_at_ms" },
+                            "meaning": if is_project_readback_cache { "No durable handoff progress evidence is available from the local read surface." } else { "Session registry lane progress timestamp." }
+                        },
+                        "lastModified": {
+                            "source": "git_worktree_filesystem",
+                            "meaning": "Latest counted local worktree file modification time."
+                        }
+                    },
                 }),
             );
         }
@@ -582,6 +616,19 @@ fn completed_issue_worktrees(
             continue;
         };
         let previous = completed.get(issue);
+        let last_progress_at = previous
+            .and_then(|entry| entry.get("lastProgressAt"))
+            .cloned()
+            .unwrap_or(Value::Null);
+        let last_progress_source = previous
+            .and_then(|entry| entry.get("lastProgressSource"))
+            .cloned()
+            .unwrap_or_else(|| Value::String("unavailable".into()));
+        let project_updated_at = project_issue
+            .get("updatedAt")
+            .or_else(|| project_issue.get("updated_at"))
+            .cloned()
+            .unwrap_or(Value::Null);
         completed.insert(
             issue.to_string(),
             json!({
@@ -590,17 +637,41 @@ fn completed_issue_worktrees(
                 "state": project_issue.get("state").cloned().unwrap_or(Value::Null),
                 "lane": previous.and_then(|entry| entry.get("lane")).cloned().unwrap_or(Value::Null),
                 "url": project_issue.get("url").cloned().unwrap_or(Value::Null),
-                "completedAt": previous.and_then(|entry| entry.get("completedAt")).cloned().unwrap_or_else(|| worktree.get("lastModified").cloned().unwrap_or(Value::Null)),
+                "completedAt": previous.and_then(|entry| entry.get("completedAt")).cloned().unwrap_or(Value::Null),
                 "createdAt": previous.and_then(|entry| entry.get("createdAt")).cloned().unwrap_or_else(|| worktree.get("createdAt").cloned().unwrap_or(Value::Null)),
-                "lastProgressAt": previous.and_then(|entry| entry.get("lastProgressAt")).cloned().unwrap_or_else(|| project_issue.get("updatedAt").or_else(|| project_issue.get("updated_at")).cloned().unwrap_or(Value::Null)),
+                "lastProgressAt": last_progress_at,
+                "lastProgressSource": last_progress_source,
+                "projectUpdatedAt": project_updated_at,
+                "projectUpdatedAtSource": "github_project_issue.updatedAt",
                 "path": worktree.get("path").cloned().unwrap_or(Value::Null),
                 "branch": worktree.get("branch").cloned().unwrap_or(Value::Null),
                 "head": worktree.get("head").cloned().unwrap_or(Value::Null),
                 "lastModified": worktree.get("lastModified").cloned().unwrap_or(Value::Null),
+                "lastModifiedSource": "git_worktree_filesystem",
                 "treeState": worktree.get("treeState").cloned().unwrap_or(Value::Null),
                 "diskBytes": worktree.get("diskBytes").cloned().unwrap_or(Value::Null),
-                "evidence": previous.and_then(|entry| entry.get("evidence")).cloned().unwrap_or_else(|| Value::String("project issue readback + git worktree".into())),
-                "artifactSource": previous.and_then(|entry| entry.get("artifactSource")).cloned().unwrap_or_else(|| Value::String("project_issue".into())),
+                "evidence": previous.and_then(|entry| entry.get("evidence")).cloned().unwrap_or_else(|| Value::String("project issue readback supplies title/state/url; no handoff progress evidence found".into())),
+                "artifactSource": previous.and_then(|entry| entry.get("artifactSource")).cloned().unwrap_or_else(|| Value::String("project_issue_readback".into())),
+                "timestampSources": {
+                    "lastProgress": {
+                        "source": previous
+                            .and_then(|entry| entry.pointer("/timestampSources/lastProgress/source"))
+                            .cloned()
+                            .unwrap_or_else(|| Value::String("unavailable".into())),
+                        "meaning": previous
+                            .and_then(|entry| entry.pointer("/timestampSources/lastProgress/meaning"))
+                            .cloned()
+                            .unwrap_or_else(|| Value::String("No durable handoff progress evidence is available from the local read surface.".into()))
+                    },
+                    "lastModified": {
+                        "source": "git_worktree_filesystem",
+                        "meaning": "Latest counted local worktree file modification time."
+                    },
+                    "projectUpdatedAt": {
+                        "source": "github_project_issue.updatedAt",
+                        "meaning": "Broad Project/GitHub issue readback timestamp retained as metadata only; it must not drive Last Progress."
+                    }
+                },
             }),
         );
     }
@@ -1118,6 +1189,134 @@ mod tests {
         );
         assert_eq!(parsed["projectStateAccess"], "paused");
         assert_eq!(parsed["failureKind"], "rate_limit");
+    }
+
+    #[test]
+    fn project_updated_at_does_not_populate_completed_worktree_progress() {
+        let snapshot = json!({ "sessions": [] });
+        let issue_worktrees = json!([
+            {
+                "issue": "#244",
+                "path": "/tmp/issue-244",
+                "branch": "feature/issue-244",
+                "head": "abc1234",
+                "createdAt": 1_000,
+                "lastModified": 2_000,
+                "treeState": "clean",
+                "diskBytes": 128
+            }
+        ]);
+        let project_issues = json!([
+            {
+                "identifier": "#244",
+                "title": "Old completed issue",
+                "state": "Done",
+                "url": "https://github.com/Alive24/shea-symphony/issues/244",
+                "updatedAt": "2026-06-03T09:00:00Z"
+            }
+        ]);
+
+        let completed = completed_issue_worktrees(&snapshot, &issue_worktrees, &project_issues);
+        let rows = completed.as_array().unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["state"], "Done");
+        assert!(rows[0]["lastProgressAt"].is_null());
+        assert_eq!(rows[0]["lastProgressSource"], "unavailable");
+        assert_eq!(rows[0]["projectUpdatedAt"], "2026-06-03T09:00:00Z");
+        assert_eq!(rows[0]["lastModified"], 2_000);
+        assert_eq!(
+            rows[0]["timestampSources"]["projectUpdatedAt"]["meaning"],
+            "Broad Project/GitHub issue readback timestamp retained as metadata only; it must not drive Last Progress."
+        );
+    }
+
+    #[test]
+    fn session_registry_progress_takes_precedence_over_project_readback_metadata() {
+        let snapshot = json!({
+            "sessions": [
+                {
+                    "status": "completed",
+                    "issue_identifier": "#251",
+                    "issue_title": "Session-backed completed issue",
+                    "lane": "main",
+                    "started_at_ms": 900,
+                    "updated_at_ms": 1_500,
+                    "evidence": "Main handoff evidence"
+                }
+            ]
+        });
+        let issue_worktrees = json!([
+            {
+                "issue": "#251",
+                "path": "/tmp/issue-251",
+                "branch": "feature/issue-251",
+                "head": "def5678",
+                "createdAt": 1_000,
+                "lastModified": 3_000,
+                "treeState": "dirty",
+                "diskBytes": 256
+            }
+        ]);
+        let project_issues = json!([
+            {
+                "identifier": "#251",
+                "title": "Project title",
+                "state": "Done",
+                "url": "https://github.com/Alive24/shea-symphony/issues/251",
+                "updatedAt": "2026-06-03T09:00:00Z"
+            }
+        ]);
+
+        let completed = completed_issue_worktrees(&snapshot, &issue_worktrees, &project_issues);
+        let rows = completed.as_array().unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["lastProgressAt"], 1_500);
+        assert_eq!(rows[0]["lastProgressSource"], "session_registry.updated_at_ms");
+        assert_eq!(rows[0]["projectUpdatedAt"], "2026-06-03T09:00:00Z");
+        assert_eq!(rows[0]["lastModified"], 3_000);
+    }
+
+    #[test]
+    fn project_readback_cache_does_not_create_handoff_progress() {
+        let snapshot = json!({
+            "sessions": [
+                {
+                    "status": "recorded",
+                    "session_source": "project_readback_cache",
+                    "issue_identifier": "#248",
+                    "issue_title": "Cached project readback",
+                    "project_state": "Done",
+                    "project_url": "https://github.com/Alive24/shea-symphony/issues/248",
+                    "lane": "project",
+                    "started_at_ms": 4_000,
+                    "updated_at_ms": 5_000
+                }
+            ]
+        });
+        let issue_worktrees = json!([
+            {
+                "issue": "#248",
+                "path": "/tmp/issue-248",
+                "branch": "feature/issue-248",
+                "head": "feed248",
+                "createdAt": 1_000,
+                "lastModified": 2_000,
+                "treeState": "clean",
+                "diskBytes": 512
+            }
+        ]);
+
+        let completed = completed_issue_worktrees(&snapshot, &issue_worktrees, &json!([]));
+        let rows = completed.as_array().unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["state"], "Done");
+        assert!(rows[0]["lastProgressAt"].is_null());
+        assert_eq!(rows[0]["lastProgressSource"], "unavailable");
+        assert_eq!(rows[0]["artifactSource"], "project_readback_cache");
+        assert_eq!(rows[0]["lastModified"], 2_000);
     }
 
     #[test]

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -2530,6 +2530,11 @@ a {
   font-size: var(--text-xs);
 }
 
+.lane-completed-age.unknown {
+  color: color-mix(in oklab, var(--warn), var(--muted) 46%);
+  font-weight: 700;
+}
+
 .lane-completed-row code {
   display: block;
   padding: 2px 0;

--- a/app/src/lib/LaneViews.svelte
+++ b/app/src/lib/LaneViews.svelte
@@ -7,6 +7,9 @@
     parseCodexTranscriptJsonl,
     transcriptUnavailable
   } from './viewModel/codexTranscript.ts';
+  import {
+    completedProgressDisplay
+  } from './viewModel/completedWorktrees.ts';
 
   export let view: any;
   export let route = '/lanes';
@@ -148,29 +151,39 @@
         byId.set(id, normalizeCompletedEntry({ ...entry, state: row?.state, completedAt: entry.lastModified }, rows, model));
       }
     }
-    return [...byId.values()].sort((left, right) => dateMs(right.completedAt ?? right.updatedAt) - dateMs(left.completedAt ?? left.updatedAt));
+    return [...byId.values()].sort((left, right) => completedLocalSortMs(right) - completedLocalSortMs(left));
   }
 
   function normalizeCompletedEntry(entry: any, rows: any[], model: any) {
     const id = normalizeIssueRef(entry.issue ?? entry.issueRef ?? entry.id);
     const row = rows.find((issue) => issue.id === id) ?? (model?.issueIndex ?? []).find((issue: any) => normalizeIssueRef(issue.id ?? issue.identifier) === id);
     const issueUrl = entry.url ?? row?.url ?? githubIssueUrl(id);
-    const completedAt = entry.completedAt ?? entry.lastProgressAt ?? entry.updatedAt ?? entry.lastModified ?? row?.updatedAt ?? model?.generatedAt;
+    const lastProgressAt = entry.lastProgressAt ?? null;
+    const completedAt = entry.completedAt ?? lastProgressAt ?? null;
+    const lastModified = entry.lastModified ?? null;
+    const timestampSources = entry.timestampSources ?? {};
+    const lastProgressSource = entry.lastProgressSource ??
+      timestampSources?.lastProgress?.source ??
+      (lastProgressAt ? 'read_surface.lastProgressAt' : 'unavailable');
     return {
       id,
       title: entry.title ?? row?.title ?? 'Project read unavailable',
-      state: entry.state ?? row?.state ?? 'Unknown',
+      state: entry.state ?? row?.state ?? 'Done',
       lane: entry.lane ?? row?.lane ?? 'Merge',
       url: issueUrl,
       completedAt,
-      updatedAt: entry.updatedAt ?? completedAt,
+      updatedAt: entry.updatedAt ?? entry.projectUpdatedAt ?? row?.updatedAt,
+      projectUpdatedAt: entry.projectUpdatedAt ?? entry.updatedAt,
       worktree: {
         path: entry.path ?? entry.worktreePath,
         branch: entry.branch,
         head: entry.head,
         createdAt: entry.createdAt,
-        lastProgressAt: entry.lastProgressAt ?? entry.updatedAt ?? completedAt,
-        lastModified: entry.lastModified ?? completedAt,
+        lastProgressAt,
+        lastProgressSource,
+        lastModified,
+        lastModifiedSource: entry.lastModifiedSource ?? timestampSources?.lastModified?.source,
+        timestampSources,
         treeState: entry.treeState ?? 'unknown',
         diskBytes: entry.diskBytes,
         evidence: entry.evidence
@@ -182,9 +195,13 @@
     if (hours == null) return issues;
     const cutoff = Date.now() - hours * 60 * 60 * 1000;
     return issues.filter((issue) => {
-      const timestamp = dateMs(issue.completedAt ?? issue.updatedAt);
+      const timestamp = completedLocalSortMs(issue);
       return timestamp && timestamp >= cutoff;
     });
+  }
+
+  function completedLocalSortMs(issue: any) {
+    return dateMs(issue.completedAt) || dateMs(issue.worktree?.lastModified);
   }
 
   function findIssueForDetail(issueRef: string, rows: any[], completedIssues: any[], model: any) {
@@ -417,6 +434,10 @@
     return `${Math.round(hours / 24)}d ago`;
   }
 
+  function progressAge(issue: any) {
+    return completedProgressDisplay(issue, relativeAge);
+  }
+
   function formatMsTime(value: unknown) {
     const ms = typeof value === 'number' ? value : Number(value);
     if (!Number.isFinite(ms)) return 'unknown';
@@ -482,7 +503,7 @@
       </div>
       <div>
         <span class="mini-label">Last event</span>
-        <strong>{formatTime(selectedIssue.completedAt ?? selectedIssue.updatedAt)}</strong>
+        <strong>{formatTime(selectedIssue.worktree?.lastProgressAt ?? selectedIssue.worktree?.lastModified ?? selectedIssue.completedAt)}</strong>
       </div>
       <div>
         <span class="mini-label">Disk size</span>
@@ -700,7 +721,11 @@
             <span class="issue-tag">{issue.id}</span>
             <strong class="lane-completed-title">{issue.title}</strong>
             <span>{formatTime(issue.worktree?.createdAt)}</span>
-            <span class="lane-completed-age">{relativeAge(issue.worktree?.lastProgressAt ?? issue.completedAt ?? issue.updatedAt)}</span>
+            <span
+              class:unknown={!progressAge(issue).known}
+              class="lane-completed-age"
+              title={progressAge(issue).title}
+            >{progressAge(issue).label}</span>
             <span class="lane-completed-age">{relativeAge(issue.worktree?.lastModified)}</span>
             <span class:dirty={treeStateLabel(issue.worktree?.treeState) === 'Dirty'} class="lane-tree-state">{treeStateLabel(issue.worktree?.treeState)}</span>
             <code class="lane-completed-branch">{issue.worktree?.branch ?? 'branch unknown'}</code>

--- a/app/src/lib/viewModel/completedWorktrees.ts
+++ b/app/src/lib/viewModel/completedWorktrees.ts
@@ -1,0 +1,24 @@
+export type RelativeAgeFormatter = (value: unknown) => string;
+
+export function completedProgressDisplay(issue: any, relativeAge: RelativeAgeFormatter) {
+  const source = issue?.worktree?.lastProgressSource ??
+    issue?.lastProgressSource ??
+    issue?.worktree?.timestampSources?.lastProgress?.source ??
+    issue?.timestampSources?.lastProgress?.source ??
+    'unavailable';
+  const value = issue?.worktree?.lastProgressAt ?? issue?.lastProgressAt;
+  if (!value || source === 'unavailable') {
+    return {
+      label: 'Unknown',
+      title: 'No durable handoff progress evidence is visible locally.',
+      source,
+      known: false
+    };
+  }
+  return {
+    label: relativeAge(value),
+    title: `Progress source: ${source}`,
+    source,
+    known: true
+  };
+}

--- a/app/test/operator-view.test.mjs
+++ b/app/test/operator-view.test.mjs
@@ -28,6 +28,9 @@ import {
 import {
   buildLaneThroughputBoard
 } from '../src/lib/viewModel/laneThroughput.ts';
+import {
+  completedProgressDisplay
+} from '../src/lib/viewModel/completedWorktrees.ts';
 import { appendAutoloopLine, defaultLoopState, laneWorkerFromAutoloop } from '../src/lib/tauriAutoloop.ts';
 
 test('browser fallback uses fixture data instead of a Node API bridge', async () => {
@@ -326,6 +329,44 @@ test('default background refresh defers doctor surface', () => {
   assert.equal(defaultBackgroundReadSurfaces.includes('autopilot'), false);
   assert.equal(defaultBackgroundReadSurfaces.includes('review'), false);
   assert.equal(projectCooldownReadSurfaces.includes('doctor'), true);
+});
+
+test('completed worktree progress display is unknown without durable progress evidence', () => {
+  const display = completedProgressDisplay(
+    {
+      state: 'Done',
+      updatedAt: '2026-06-03T09:00:00Z',
+      projectUpdatedAt: '2026-06-03T09:00:00Z',
+      worktree: {
+        lastProgressAt: null,
+        lastProgressSource: 'unavailable',
+        lastModified: 1_780_000_000_000
+      }
+    },
+    () => 'fresh-looking'
+  );
+
+  assert.equal(display.label, 'Unknown');
+  assert.equal(display.known, false);
+  assert.match(display.title, /No durable handoff progress evidence/);
+});
+
+test('completed worktree progress display uses session provenance when present', () => {
+  const display = completedProgressDisplay(
+    {
+      state: 'Done',
+      worktree: {
+        lastProgressAt: 1_780_000_000_000,
+        lastProgressSource: 'session_registry.updated_at_ms',
+        lastModified: 1_780_000_050_000
+      }
+    },
+    (value) => `age:${value}`
+  );
+
+  assert.equal(display.label, 'age:1780000000000');
+  assert.equal(display.known, true);
+  assert.match(display.title, /session_registry\.updated_at_ms/);
 });
 
 test('lane throughput board surfaces blocked idle and completed lane results', () => {


### PR DESCRIPTION
## Summary
- Implements #407: Separate handoff progress from local worktree modification times.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #407
