### PR TITLE
#385: Add parent-batch evidence briefing to Human Review entrypoint

### DIFF
--- a/.codex/skills/shea-symphony-human-review/SKILL.md
+++ b/.codex/skills/shea-symphony-human-review/SKILL.md
@@ -136,6 +136,14 @@ Before any PR-specific UAT, verify that the reviewed PR branch contains the
 latest `origin/main`. Run this only from the linked PR/issue worktree, never
 from the canonical `main` checkout.
 
+This gate is a required Human Review preflight, not an operator-owned UAT
+decision. After the orientation brief, run the freshness check automatically
+from the PR worktree before asking the operator to run or accept PR-specific
+UAT. Do not ask for operator permission merely to run `git fetch`, the
+`merge-base` check, or the safe mechanical repair path described below.
+Operator confirmation is still required before final decision evidence or
+Project state mutation.
+
 Shea Symphony write-mode lane commands may now fast-forward the canonical
 checkout before tracker mutation. That is separate control-surface
 synchronization and is not evidence that the reviewed PR branch is fresh.
@@ -168,8 +176,10 @@ that is not obviously mechanical, stop before UAT and recommend `Request Rework`
 with the smallest actionable finding.
 
 If the PR worktree cannot be found, do not run the freshness check from the
-canonical `main` checkout. First select or create a PR branch worktree. If that
-cannot be done safely, record the missing worktree as a UAT blocker.
+canonical `main` checkout. First try to select an existing PR branch worktree.
+If no safe worktree can be selected or created from existing issue/PR evidence,
+record the missing worktree as a UAT blocker and ask the operator for the
+smallest missing workspace choice.
 
 If `gh pr view` reports a non-clean merge state, treat that as corroborating
 freshness or mergeability risk. The local `merge-base` check is still required
@@ -178,9 +188,11 @@ unknown.
 
 ## Brief The Operator
 
-Before any UAT command, freshness repair, decision-note drafting, or state
-mutation, start with a plain-language orientation brief. The operator should be
-able to understand what they are reviewing without opening GitHub first.
+Before any freshness repair, operator-owned UAT command, decision-note drafting,
+or state mutation, start with a plain-language orientation brief. The operator
+should be able to understand what they are reviewing without opening GitHub
+first. After that brief, required PR freshness checks run automatically under
+the PR Freshness Repair Gate; they are not confirmation prompts.
 
 Give a concise Human Review brief with:
 
@@ -234,11 +246,17 @@ After the briefing, guide the operator one step at a time.
 
 - Do not dump the whole UAT checklist as a single todo list unless the operator
   explicitly asks for the full list.
+- For an unmerged PR, automatically complete the PR Freshness Repair Gate from
+  the PR worktree before presenting the first operator-owned UAT action.
+- Report the freshness result succinctly before UAT: fresh, mechanically
+  refreshed, blocked by missing worktree, or blocked by non-mechanical
+  conflict/verification failure.
 - Give exactly one next action, explain why it is the next action, and tell the
   operator what feedback to provide after running it.
 - Tell the operator which directory to run the action from. For PR UAT, this is
   normally the reviewed PR/issue worktree, not the canonical `main` checkout.
-- Wait for the operator's result before moving to the next UAT action.
+- Wait for the operator's result before moving to the next operator-owned UAT
+  action.
 - After each operator result, classify it as `pass`, `fail`, `deferred`, or
   `needs clarification`, then choose the next action.
 - Keep a running Human Review note draft in the conversation so the final
@@ -273,8 +291,9 @@ First resolve the correct execution directory.
   run from the linked PR/issue worktree or another checkout of that PR branch.
 - Do not ask the operator to run PR-specific UAT from the canonical `main`
   checkout unless the PR has already been merged into `main`.
-- Before PR-specific UAT, apply the PR Freshness Repair Gate. Do not stop only
-  because the PR branch is stale; first try the safe refresh/small-repair path.
+- Before PR-specific UAT, apply the PR Freshness Repair Gate automatically. Do
+  not stop only because the PR branch is stale; first try the safe
+  refresh/small-repair path.
 - Prefer the worktree recorded in the issue workpad or `project issue` readback.
   If no usable worktree is available, ask the operator whether to create or
   select one before continuing.

--- a/skills/shea-symphony/suite/shea-symphony-human-review/SKILL.md
+++ b/skills/shea-symphony/suite/shea-symphony-human-review/SKILL.md
@@ -153,6 +153,14 @@ Before any PR-specific UAT, verify that the reviewed PR branch contains the
 latest `origin/main`. Run this only from the linked PR/issue worktree, never
 from the canonical `main` checkout.
 
+This gate is a required Human Review preflight, not an operator-owned UAT
+decision. After the orientation brief, run the freshness check automatically
+from the PR worktree before asking the operator to run or accept PR-specific
+UAT. Do not ask for operator permission merely to run `git fetch`, the
+`merge-base` check, or the safe mechanical repair path described below.
+Operator confirmation is still required before final decision evidence or
+Project state mutation.
+
 Shea Symphony write-mode lane commands may now fast-forward the canonical
 checkout before tracker mutation. That is separate control-surface
 synchronization and is not evidence that the reviewed PR branch is fresh.
@@ -185,8 +193,10 @@ that is not obviously mechanical, stop before UAT and recommend `Request Rework`
 with the smallest actionable finding.
 
 If the PR worktree cannot be found, do not run the freshness check from the
-canonical `main` checkout. First select or create a PR branch worktree. If that
-cannot be done safely, record the missing worktree as a UAT blocker.
+canonical `main` checkout. First try to select an existing PR branch worktree.
+If no safe worktree can be selected or created from existing issue/PR evidence,
+record the missing worktree as a UAT blocker and ask the operator for the
+smallest missing workspace choice.
 
 If `gh pr view` reports a non-clean merge state, treat that as corroborating
 freshness or mergeability risk. The local `merge-base` check is still required
@@ -195,9 +205,11 @@ unknown.
 
 ## Brief The Operator
 
-Before any UAT command, freshness repair, decision-note drafting, or state
-mutation, start with a plain-language orientation brief. The operator should be
-able to understand what they are reviewing without opening GitHub first.
+Before any freshness repair, operator-owned UAT command, decision-note drafting,
+or state mutation, start with a plain-language orientation brief. The operator
+should be able to understand what they are reviewing without opening GitHub
+first. After that brief, required PR freshness checks run automatically under
+the PR Freshness Repair Gate; they are not confirmation prompts.
 
 Give a concise Human Review brief with:
 
@@ -287,11 +299,17 @@ After the briefing, guide the operator one step at a time.
 
 - Do not dump the whole UAT checklist as a single todo list unless the operator
   explicitly asks for the full list.
+- For an unmerged PR, automatically complete the PR Freshness Repair Gate from
+  the PR worktree before presenting the first operator-owned UAT action.
+- Report the freshness result succinctly before UAT: fresh, mechanically
+  refreshed, blocked by missing worktree, or blocked by non-mechanical
+  conflict/verification failure.
 - Give exactly one next action, explain why it is the next action, and tell the
   operator what feedback to provide after running it.
 - Tell the operator which directory to run the action from. For PR UAT, this is
   normally the reviewed PR/issue worktree, not the canonical `main` checkout.
-- Wait for the operator's result before moving to the next UAT action.
+- Wait for the operator's result before moving to the next operator-owned UAT
+  action.
 - After each operator result, classify it as `pass`, `fail`, `deferred`, or
   `needs clarification`, then choose the next action.
 - Keep a running Human Review note draft in the conversation so the final
@@ -326,8 +344,9 @@ First resolve the correct execution directory.
   run from the linked PR/issue worktree or another checkout of that PR branch.
 - Do not ask the operator to run PR-specific UAT from the canonical `main`
   checkout unless the PR has already been merged into `main`.
-- Before PR-specific UAT, apply the PR Freshness Repair Gate. Do not stop only
-  because the PR branch is stale; first try the safe refresh/small-repair path.
+- Before PR-specific UAT, apply the PR Freshness Repair Gate automatically. Do
+  not stop only because the PR branch is stale; first try the safe
+  refresh/small-repair path.
 - Prefer the worktree recorded in the issue workpad or `project issue` readback.
   If no usable worktree is available, ask the operator whether to create or
   select one before continuing.

--- a/skills/shea-symphony/suite/shea-symphony-human-review/SKILL.md
+++ b/skills/shea-symphony/suite/shea-symphony-human-review/SKILL.md
@@ -41,6 +41,12 @@ Canonical decision note template:
 workflows/template/workpad/human-review.md
 ```
 
+Canonical parent-batch briefing template:
+
+```bash
+workflows/template/workpad/parent-batch-human-review-brief.md
+```
+
 ## Core Boundary
 
 - Do not modify implementation code, except for the narrow PR branch freshness
@@ -126,6 +132,17 @@ Inspect the issue body and workpad for:
 - Review Agent pass evidence and any explicitly unchecked review items;
 - linked PR identity, readiness, base branch, and check/review state;
 - missing evidence, stale assumptions, or blockers that should prevent approval.
+
+For native parent issues, also read the current parent/subissue evidence before
+briefing:
+
+- native child issue list and each child's current Project state;
+- child PR identity, target branch, and merge evidence into the parent
+  integration branch;
+- parent integration branch and parent final PR base/head evidence;
+- parent Review Agent PASS evidence and any explicitly missing review evidence;
+- remaining parent UAT checklist items that still need Human Review-owned
+  pass/fail/deferred notes.
 
 Do not drown the operator in raw JSON. Summarize the decision-relevant facts and
 include exact issue and PR references.
@@ -217,6 +234,42 @@ Available decisions: Approve for Merging / Request Rework / Need Human Input / D
 For parent issues with native subissues, explicitly summarize the parent/child
 shape: which child issues are Done, which child PRs landed, which parent PR is
 being accepted, and what combined behavior the parent UAT is meant to validate.
+
+## Parent-Batch Brief
+
+For native parent issues, the first Human Review action is to prepare a compact
+parent-batch evidence brief from current readbacks before any UAT command,
+freshness repair, decision-note drafting, timeline comment, or Project state
+mutation.
+
+Use `workflows/template/workpad/parent-batch-human-review-brief.md` as the
+reusable brief shape. Keep it separate from
+`workflows/template/workpad/human-review.md`; the parent-batch brief is not the
+final Human Review decision note and must not replace or weaken the explicit
+operator-confirmation boundary.
+
+The parent-batch brief is read-only and advisory. Do not write tracker comments,
+decision notes, Project state, PR state, issue bodies, workpads, or child
+evidence while preparing it.
+
+Build the brief in this order:
+
+1. remaining parent UAT;
+2. parent PR and readiness;
+3. child batch table;
+4. Review Agent evidence;
+5. risks, stale assumptions, or missing evidence.
+
+The brief must distinguish evidence already checked by Main, Review, and Merge
+lanes from Human Review-owned UAT and acceptance. Child `Done`, child PR merge
+evidence, and parent Review Agent PASS are inputs to Human Review; they are not
+proof that parent UAT passed and they do not authorize approval without the
+operator's explicit decision.
+
+For the #400 evidence shape, the brief should be able to show remaining parent
+UAT, parent PR #421 readiness, child #399/#383/#384 status and child PR merge
+evidence, parent Review PASS evidence, and any risks or missing evidence before
+asking the operator to run or confirm parent UAT.
 
 If the issue is not in `Human Review`, or if Review Agent pass evidence or a
 reliable linked PR is missing, stop before UAT and recommend the smallest safe

--- a/src/status_surface.rs
+++ b/src/status_surface.rs
@@ -182,7 +182,7 @@ fn render_skipped(snapshot: &RuntimeSnapshot, lines: &mut Vec<String>) {
     }
     let remaining = snapshot.skipped.len().saturating_sub(sample_limit);
     if remaining > 0 {
-        lines.push(format!("- ... {} more skipped issue(s) omitted", remaining));
+        lines.push(format!("- ... {remaining} more skipped issue(s) omitted"));
     }
 }
 

--- a/tests/skill_suite.rs
+++ b/tests/skill_suite.rs
@@ -50,6 +50,10 @@ fn skill_suite_documents_app_server_first_manual_boundaries() {
 
     assert!(human_review.contains("Match the operator-facing language"));
     assert!(human_review.contains("Do not force English"));
+    assert!(human_review.contains("run the freshness check automatically"));
+    assert!(human_review.contains("not an operator-owned UAT"));
+    assert!(human_review.contains("decision. After the orientation brief"));
+    assert!(human_review.contains("Do not ask for operator permission"));
     assert!(manual_main.contains("cargo run -- project state workflows/shea-symphony.md"));
     assert!(manual_main.contains("main_lane.backend: codex"));
     assert!(manual_main.contains("codex.command: codex app-server -c 'service_tier=\"fast\"'"));

--- a/tests/skill_suite.rs
+++ b/tests/skill_suite.rs
@@ -73,6 +73,52 @@ fn human_review_template_supports_all_decisions() {
 }
 
 #[test]
+fn parent_batch_human_review_brief_preserves_order_and_boundaries() {
+    let skill = repo_file("skills/shea-symphony/suite/shea-symphony-human-review/SKILL.md");
+    let brief = repo_file("workflows/template/workpad/parent-batch-human-review-brief.md");
+    let decision = repo_file("workflows/template/workpad/human-review.md");
+
+    assert!(skill.contains("first Human Review action is to prepare a compact"));
+    assert!(skill.contains("parent-batch evidence brief from current readbacks"));
+    assert!(skill.contains("workflows/template/workpad/parent-batch-human-review-brief.md"));
+    assert!(skill.contains("read-only and advisory"));
+    assert!(skill.contains("Do not write tracker comments"));
+    assert!(skill.contains("Child `Done`, child PR merge"));
+    assert!(skill.contains("parent Review Agent PASS are inputs to Human Review"));
+    assert!(skill.contains("proof that parent UAT passed"));
+    assert!(skill.contains("operator's explicit decision"));
+    assert!(skill.contains("parent PR #421"));
+    assert!(skill.contains("child #399/#383/#384"));
+
+    assert!(brief.contains("## Shea Symphony Parent-Batch Human Review Brief"));
+    assert!(brief.contains("This brief is read-only and advisory"));
+    assert!(brief.contains("not a Human Review decision note"));
+    assert!(brief.contains("must not write tracker comments"));
+    assert!(brief.contains("Human Review-owned"));
+    assert!(brief.contains("does not prove parent acceptance"));
+    assert!(brief.contains("parent PR #421"));
+
+    let required_order = [
+        "### 1. Remaining Parent UAT",
+        "### 2. Parent PR And Readiness",
+        "### 3. Child Batch Table",
+        "### 4. Review Agent Evidence",
+        "### 5. Risks, Stale Assumptions, Or Missing Evidence",
+    ];
+    let mut last_index = 0;
+    for heading in required_order {
+        let index = brief
+            .find(heading)
+            .unwrap_or_else(|| panic!("missing parent-batch heading {heading}"));
+        assert!(index >= last_index, "heading out of order: {heading}");
+        last_index = index;
+    }
+
+    assert!(decision.contains("## Shea Symphony Human Review Decision"));
+    assert!(!decision.contains("## Shea Symphony Parent-Batch Human Review Brief"));
+}
+
+#[test]
 fn autopilot_dogfood_docs_prefer_foreground_loop() {
     let command_reference = repo_file("docs/cli-command-reference.md");
     let operator_dogfood = repo_file("docs/operator-dogfood.md");

--- a/workflows/template/workpad/parent-batch-human-review-brief.md
+++ b/workflows/template/workpad/parent-batch-human-review-brief.md
@@ -1,0 +1,72 @@
+## Shea Symphony Parent-Batch Human Review Brief
+
+This brief is read-only and advisory. It prepares the operator for UAT on a
+native parent issue, but it is not a Human Review decision note, does not record
+approval, and must not write tracker comments, Project state, PR state, issue
+bodies, workpads, or child evidence.
+
+- Parent issue: #<parent-issue> <title>
+- Parent PR: #<parent-pr> <url>
+- Parent integration branch: `<branch>`
+- Parent final PR base/head: `<base>` <- `<head>`
+- Current Project state: `Human Review`
+- Brief prepared from current readbacks at: <YYYY-MM-DD HH:MM timezone>
+
+### 1. Remaining Parent UAT
+
+List the parent UAT checklist items that still need Human Review-owned
+pass/fail/deferred evidence. Do not mark parent UAT complete based only on child
+`Done`, Main lane evidence, Merge lane evidence, or Review Agent PASS.
+
+| Parent UAT item | Current evidence | Human-owned next action |
+| --- | --- | --- |
+| <unchecked or unconfirmed parent UAT item> | <none / current readback> | <operator action needed> |
+
+### 2. Parent PR And Readiness
+
+Summarize the parent final PR being accepted for `main`, using current PR and
+worktree readbacks rather than stale workpad text alone.
+
+- Parent PR identity:
+- Base/head branch:
+- Draft state:
+- Mergeability or freshness:
+- Status checks / review state:
+- Ready enough for UAT: yes / no / blocked because <reason>
+
+### 3. Child Batch Table
+
+Summarize the native child set and lane evidence already produced by Main,
+Review, and Merge lanes. Child `Done` means the child slice landed in the
+parent integration branch; it does not prove parent acceptance.
+
+| Child issue | Project state | Child PR | PR target / merge evidence | Lane evidence checked |
+| --- | --- | --- | --- | --- |
+| #<child> <title> | `Done` / other | #<pr> | <merged into parent branch / missing> | <Main / Review / Merge evidence> |
+
+### 4. Review Agent Evidence
+
+Summarize parent Review Agent evidence for the parent final PR. Keep this
+separate from Human Review-owned UAT and acceptance.
+
+- Review Agent result:
+- Evidence location:
+- Checks covered:
+- Explicitly unchecked or deferred review items:
+
+### 5. Risks, Stale Assumptions, Or Missing Evidence
+
+List only issues that should block or shape the Human Review decision.
+
+- Missing child status, child PR merge evidence, or native relationship:
+- Parent PR freshness, draft, checks, or mergeability risk:
+- Parent UAT evidence still missing:
+- Stale assumptions that need current readback:
+- Recommended next Human Review step:
+
+### #400 Spot-Check Shape
+
+For a parent issue shaped like #400, the brief should be able to show remaining
+parent UAT, parent PR #421 readiness, child #399/#383/#384 status and child PR
+merge evidence, parent Review PASS evidence, and any preserved risks without
+requiring the operator to open every child issue before UAT starts.


### PR DESCRIPTION
## Summary
- Implements #385: Add parent-batch evidence briefing to Human Review entrypoint.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #385
