### PR TITLE
#408: Refresh Lane Overview local worktree state independently

### DIFF
--- a/app/src/App.svelte
+++ b/app/src/App.svelte
@@ -10,10 +10,15 @@
     requestOperatorLocalArtifactsRefresh,
     requestOperatorOverviewRefresh
   } from './lib/operatorOverviewStore.ts';
+  import {
+    localArtifactRefreshEventDetail,
+    shouldRequestLaneOverviewLocalRefresh
+  } from './lib/localArtifactRefresh.ts';
   import { REFRESH_REQUEST_EVENT } from './lib/uiState.ts';
   import OperatorDesk from './OperatorDesk.svelte';
 
   let currentPath = '/';
+  let lastLaneOverviewLocalRefreshMs = 0;
   $: operatorView = $operatorOverviewStore.view;
 
   function normalizePath(pathname: string) {
@@ -25,11 +30,26 @@
     currentPath = normalizePath(window.location.pathname);
   }
 
+  function refreshRouteFromLocation() {
+    setRouteFromLocation();
+    requestLaneOverviewLocalRefresh('lane-overview-route');
+  }
+
   function navigate(event: CustomEvent<{ href: string }>) {
     const href = event.detail?.href ?? '/';
     if (href === currentPath) return;
     window.history.pushState({}, '', href);
     currentPath = href;
+    requestLaneOverviewLocalRefresh('lane-overview-route');
+  }
+
+  function requestLaneOverviewLocalRefresh(source = 'lane-overview-route') {
+    const nowMs = Date.now();
+    if (!shouldRequestLaneOverviewLocalRefresh(currentPath, nowMs, lastLaneOverviewLocalRefreshMs)) return;
+    lastLaneOverviewLocalRefreshMs = nowMs;
+    window.dispatchEvent(new CustomEvent(REFRESH_REQUEST_EVENT, {
+      detail: localArtifactRefreshEventDetail(source)
+    }));
   }
 
   function scheduleRefresh(force = false, includeSlowReads = true, source = 'manual', publishStatus = true) {
@@ -59,13 +79,17 @@
       }
       scheduleRefresh(detail.force ?? true, true, detail.source ?? 'manual');
     };
-    window.addEventListener('popstate', setRouteFromLocation);
+    const focusListener = () => requestLaneOverviewLocalRefresh('lane-overview-focus');
+    window.addEventListener('popstate', refreshRouteFromLocation);
     window.addEventListener('shea-navigate', navigate as EventListener);
     window.addEventListener(REFRESH_REQUEST_EVENT, refreshRequestListener);
+    window.addEventListener('focus', focusListener);
+    requestLaneOverviewLocalRefresh('lane-overview-route');
     return () => {
-      window.removeEventListener('popstate', setRouteFromLocation);
+      window.removeEventListener('popstate', refreshRouteFromLocation);
       window.removeEventListener('shea-navigate', navigate as EventListener);
       window.removeEventListener(REFRESH_REQUEST_EVENT, refreshRequestListener);
+      window.removeEventListener('focus', focusListener);
     };
   });
 </script>

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -2480,6 +2480,24 @@ a {
   font-size: var(--text-sm);
 }
 
+.lane-completed-head small {
+  max-width: 64ch;
+  color: var(--muted);
+  font-size: var(--text-xs);
+}
+
+.lane-completed-head small.error {
+  color: var(--danger);
+}
+
+.lane-completed-actions {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
 .segmented-control {
   flex: none;
   display: inline-flex;
@@ -6175,6 +6193,11 @@ button[disabled] {
 
   .lane-completed-headsha {
     text-align: left;
+  }
+
+  .lane-completed-actions {
+    width: 100%;
+    flex-wrap: wrap;
   }
 
   .human-todo-head h2,

--- a/app/src/lib/LaneViews.svelte
+++ b/app/src/lib/LaneViews.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import JsonLogView from './shell/JsonLogView.svelte';
   import { autoloopStateStore, REFRESH_REQUEST_EVENT } from './uiState.ts';
+  import { operatorOverviewStore } from './operatorOverviewStore.ts';
+  import {
+    localArtifactRefreshEventDetail,
+    localRefreshStatusLabel
+  } from './localArtifactRefresh.ts';
   import { getCodexTranscript } from './tauriAutoloop.ts';
   import {
     classifyHeartbeat,
@@ -40,6 +45,8 @@
   $: completedLocalIssues = buildCompletedLocalIssues(view, issueRows);
   $: filteredCompletedLocalIssues = filterCompletedByWindow(completedLocalIssues, completedWindowHours);
   $: selectedIssue = selectedIssueRef ? findIssueForDetail(selectedIssueRef, issueRows, completedLocalIssues, view) : null;
+  $: localArtifactsRefresh = $operatorOverviewStore.localArtifactsRefresh;
+  $: localArtifactsRefreshLabel = localRefreshStatusLabel(localArtifactsRefresh, formatTime);
   $: lifecycleEvents = selectedIssue ? buildLifecycleEvents(selectedIssue, view) : [];
   $: selectedLaneKey = laneKeyForIssue(selectedIssue);
   $: heartbeatSummary = selectedIssue ? classifyHeartbeat($autoloopStateStore, selectedLaneKey) : null;
@@ -330,7 +337,7 @@
 
   function refreshLocalArtifacts() {
     window.dispatchEvent(new CustomEvent(REFRESH_REQUEST_EVENT, {
-      detail: { source: 'local-artifacts', force: true, localOnly: true }
+      detail: localArtifactRefreshEventDetail('lane-overview-local')
     }));
     reloadTranscript();
   }
@@ -486,7 +493,9 @@
 
     <div class="pagination">
       <span class="section-note">{view?.generatedAtLabel ?? 'not checked'}</span>
-      <button class="btn btn-ghost" type="button" on:click={refreshLocalArtifacts}>Refresh local artifacts</button>
+      <button class="btn btn-ghost" type="button" on:click={refreshLocalArtifacts} disabled={localArtifactsRefresh?.running}>
+        {localArtifactsRefresh?.running ? 'Refreshing local artifacts' : 'Refresh local artifacts'}
+      </button>
       <a class="btn btn-ghost" href="/lanes" on:click={(event) => navigate(event, '/lanes')}>Back</a>
     </div>
   </section>
@@ -686,17 +695,23 @@
       <div>
         <span class="mini-label">Local worktrees</span>
         <strong>{filteredCompletedLocalIssues.length} visible</strong>
+        <small class:error={localArtifactsRefresh?.error}>{localArtifactsRefreshLabel}</small>
       </div>
-      <div class="segmented-control compact" role="group" aria-label="Local worktree time window">
-        {#each completedWindows as window}
-          <button
-            class:active={completedWindowHours === window.hours}
-            type="button"
-            on:click={() => completedWindowHours = window.hours}
-          >
-            {window.label}
-          </button>
-        {/each}
+      <div class="lane-completed-actions">
+        <button class="btn btn-ghost" type="button" on:click={refreshLocalArtifacts} disabled={localArtifactsRefresh?.running}>
+          {localArtifactsRefresh?.running ? 'Refreshing' : 'Refresh local'}
+        </button>
+        <div class="segmented-control compact" role="group" aria-label="Local worktree time window">
+          {#each completedWindows as window}
+            <button
+              class:active={completedWindowHours === window.hours}
+              type="button"
+              on:click={() => completedWindowHours = window.hours}
+            >
+              {window.label}
+            </button>
+          {/each}
+        </div>
       </div>
     </div>
 

--- a/app/src/lib/localArtifactRefresh.ts
+++ b/app/src/lib/localArtifactRefresh.ts
@@ -1,0 +1,38 @@
+export const LOCAL_ARTIFACT_READ_SURFACES = ['sessions', 'status'] as const;
+export const LANE_OVERVIEW_LOCAL_REFRESH_INTERVAL_MS = 15_000;
+
+export type LocalArtifactRefreshStatus = {
+  running: boolean;
+  remaining: number;
+  startedAt: string | null;
+  lastRefreshedAt: string | null;
+  error: string;
+  source: string;
+};
+
+export function localArtifactRefreshEventDetail(source = 'lane-overview-local') {
+  return {
+    source,
+    force: true,
+    localOnly: true
+  };
+}
+
+export function shouldRequestLaneOverviewLocalRefresh(
+  route: string,
+  nowMs: number,
+  lastRequestedAtMs: number,
+  minIntervalMs = LANE_OVERVIEW_LOCAL_REFRESH_INTERVAL_MS
+) {
+  return route === '/lanes' && nowMs - lastRequestedAtMs >= minIntervalMs;
+}
+
+export function localRefreshStatusLabel(status: LocalArtifactRefreshStatus | null | undefined, formatTime: (value: unknown) => string) {
+  if (status?.running) {
+    const remaining = Number(status.remaining ?? 0);
+    return `Refreshing local artifacts${remaining > 0 ? ` · ${remaining} remaining` : ''}`;
+  }
+  if (status?.error) return `Local refresh failed · ${status.error}`;
+  if (status?.lastRefreshedAt) return `Local artifacts refreshed ${formatTime(status.lastRefreshedAt)}`;
+  return 'Local artifacts not refreshed this session';
+}

--- a/app/src/lib/operatorOverviewStore.ts
+++ b/app/src/lib/operatorOverviewStore.ts
@@ -4,6 +4,10 @@ import { writable } from 'svelte/store';
 import { loadOverview, loadReadSurface } from './operatorReads.ts';
 import { mergeReadSurface } from './operatorReadModel.ts';
 import { buildViewModel } from './operatorViewModel.ts';
+import {
+  LOCAL_ARTIFACT_READ_SURFACES,
+  type LocalArtifactRefreshStatus
+} from './localArtifactRefresh.ts';
 import { refreshStatusStore } from './uiState.ts';
 
 const slowSurfaces = ['githubQueue', 'skills', 'sessions', 'status'];
@@ -12,6 +16,15 @@ const projectReadSurfaces = new Set(['autopilot', 'doctor', 'review', 'githubQue
 export const defaultBackgroundReadSurfaces = [...slowSurfaces];
 export const projectCooldownReadSurfaces = [...projectReadSurfaces];
 
+const idleLocalArtifactsRefresh: LocalArtifactRefreshStatus = {
+  running: false,
+  remaining: 0,
+  startedAt: null,
+  lastRefreshedAt: null,
+  error: '',
+  source: 'idle'
+};
+
 export const operatorOverviewStore = writable({
   view: buildViewModel(null),
   loading: true,
@@ -19,10 +32,12 @@ export const operatorOverviewStore = writable({
   backgroundRefreshing: false,
   slowReadsRemaining: 0,
   liveError: '',
+  localArtifactsRefresh: idleLocalArtifactsRefresh,
   projectReadCooldown: null
 });
 
 let readGeneration = 0;
+let localArtifactsGeneration = 0;
 let initialized = false;
 let backgroundReadsInFlight = false;
 let projectReadCooldownUntilMs = 0;
@@ -110,14 +125,15 @@ export async function requestOperatorOverviewRefresh(
 }
 
 export function requestOperatorLocalArtifactsRefresh(source = 'local-artifacts', publishStatus = true) {
-  const generation = ++readGeneration;
-  const artifactSurfaces = ['sessions', 'status'];
+  const generation = ++localArtifactsGeneration;
+  const artifactSurfaces = [...LOCAL_ARTIFACT_READ_SURFACES];
+  const startedAt = new Date().toISOString();
 
   if (publishStatus) {
     refreshStatusStore.set({
       running: true,
       remaining: artifactSurfaces.length,
-      startedAt: new Date().toISOString(),
+      startedAt,
       finishedAt: null,
       source,
       detail: 'Refreshing local artifacts'
@@ -127,13 +143,20 @@ export function requestOperatorLocalArtifactsRefresh(source = 'local-artifacts',
   operatorOverviewStore.update((state) => ({
     ...state,
     liveError: '',
-    slowReadsRemaining: artifactSurfaces.length
+    localArtifactsRefresh: {
+      running: true,
+      remaining: artifactSurfaces.length,
+      startedAt,
+      lastRefreshedAt: state.localArtifactsRefresh?.lastRefreshedAt ?? null,
+      error: '',
+      source
+    }
   }));
 
   for (const name of artifactSurfaces) {
     loadReadSurface(name, true, false)
       .then((surface) => {
-        if (generation !== readGeneration) return;
+        if (generation !== localArtifactsGeneration) return;
         operatorOverviewStore.update((state) => ({
           ...state,
           view: buildViewModel(mergeReadSurface(state.view.raw, surface)),
@@ -141,23 +164,46 @@ export function requestOperatorLocalArtifactsRefresh(source = 'local-artifacts',
         }));
       })
       .catch((error) => {
-        if (generation !== readGeneration) return;
+        if (generation !== localArtifactsGeneration) return;
         const message = error instanceof Error ? error.message : String(error ?? 'unknown error');
-        operatorOverviewStore.update((state) => ({ ...state, liveError: message }));
-      })
-      .finally(() => {
-        if (generation !== readGeneration) return;
-        const nextRemaining = Math.max(0, get(operatorOverviewStore).slowReadsRemaining - 1);
         operatorOverviewStore.update((state) => ({
           ...state,
-          slowReadsRemaining: nextRemaining
+          localArtifactsRefresh: {
+            ...(state.localArtifactsRefresh ?? {}),
+            running: false,
+            remaining: state.localArtifactsRefresh?.remaining ?? 0,
+            startedAt: state.localArtifactsRefresh?.startedAt ?? null,
+            lastRefreshedAt: state.localArtifactsRefresh?.lastRefreshedAt ?? null,
+            error: message,
+            source
+          }
+        }));
+      })
+      .finally(() => {
+        if (generation !== localArtifactsGeneration) return;
+        const currentLocalStatus = get(operatorOverviewStore).localArtifactsRefresh;
+        const nextRemaining = Math.max(0, Number(currentLocalStatus?.remaining ?? 0) - 1);
+        const finishedAt = nextRemaining === 0 ? new Date().toISOString() : null;
+        operatorOverviewStore.update((state) => ({
+          ...state,
+          localArtifactsRefresh: {
+            ...(state.localArtifactsRefresh ?? {}),
+            running: nextRemaining > 0,
+            remaining: nextRemaining,
+            startedAt: state.localArtifactsRefresh?.startedAt ?? null,
+            lastRefreshedAt: finishedAt && !state.localArtifactsRefresh?.error
+              ? finishedAt
+              : state.localArtifactsRefresh?.lastRefreshedAt ?? null,
+            error: state.localArtifactsRefresh?.error ?? '',
+            source
+          }
         }));
         if (publishStatus) {
           refreshStatusStore.update((status) => ({
             ...status,
             running: nextRemaining > 0,
             remaining: nextRemaining,
-            finishedAt: nextRemaining === 0 ? new Date().toISOString() : status.finishedAt,
+            finishedAt: finishedAt ?? status.finishedAt,
             detail: nextRemaining === 0 ? 'Local artifacts refreshed' : `Loading ${nextRemaining} local surface${nextRemaining === 1 ? '' : 's'}`
           }));
         }

--- a/app/test/operator-view.test.mjs
+++ b/app/test/operator-view.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { get } from 'svelte/store';
 
 import {
   buildFixtureOverview,
@@ -23,8 +24,15 @@ import {
 } from '../src/lib/viewModel/codexTranscript.ts';
 import {
   defaultBackgroundReadSurfaces,
-  projectCooldownReadSurfaces
+  operatorOverviewStore,
+  projectCooldownReadSurfaces,
+  requestOperatorLocalArtifactsRefresh
 } from '../src/lib/operatorOverviewStore.ts';
+import {
+  LOCAL_ARTIFACT_READ_SURFACES,
+  localArtifactRefreshEventDetail,
+  shouldRequestLaneOverviewLocalRefresh
+} from '../src/lib/localArtifactRefresh.ts';
 import {
   buildLaneThroughputBoard
 } from '../src/lib/viewModel/laneThroughput.ts';
@@ -404,6 +412,46 @@ test('default background refresh defers doctor surface', () => {
   assert.equal(projectCooldownReadSurfaces.includes('doctor'), true);
 });
 
+test('lane overview route local refresh is bounded to the overview route', () => {
+  assert.equal(shouldRequestLaneOverviewLocalRefresh('/lanes', 20_000, 0, 15_000), true);
+  assert.equal(shouldRequestLaneOverviewLocalRefresh('/lanes', 24_000, 20_000, 15_000), false);
+  assert.equal(shouldRequestLaneOverviewLocalRefresh('/lanes/408', 40_000, 0, 15_000), false);
+  assert.equal(shouldRequestLaneOverviewLocalRefresh('/doctor', 40_000, 0, 15_000), false);
+});
+
+test('button-triggered local artifact refresh emits a local-only request', () => {
+  assert.deepEqual(localArtifactRefreshEventDetail('lane-overview-local'), {
+    source: 'lane-overview-local',
+    force: true,
+    localOnly: true
+  });
+});
+
+test('local artifact refresh surfaces do not include Project or GitHub reads', () => {
+  assert.deepEqual(LOCAL_ARTIFACT_READ_SURFACES, ['sessions', 'status']);
+  assert.equal(LOCAL_ARTIFACT_READ_SURFACES.some((surface) => projectCooldownReadSurfaces.includes(surface)), false);
+  assert.equal(LOCAL_ARTIFACT_READ_SURFACES.includes('githubQueue'), false);
+  assert.equal(LOCAL_ARTIFACT_READ_SURFACES.includes('autopilot'), false);
+  assert.equal(LOCAL_ARTIFACT_READ_SURFACES.includes('doctor'), false);
+  assert.equal(LOCAL_ARTIFACT_READ_SURFACES.includes('review'), false);
+});
+
+test('local artifact refresh records in-flight and last-refreshed status', async () => {
+  requestOperatorLocalArtifactsRefresh('test-lane-overview-local', false);
+
+  assert.equal(get(operatorOverviewStore).localArtifactsRefresh.running, true);
+  assert.equal(get(operatorOverviewStore).localArtifactsRefresh.remaining, 2);
+
+  await waitFor(() => !get(operatorOverviewStore).localArtifactsRefresh.running);
+
+  const status = get(operatorOverviewStore).localArtifactsRefresh;
+  assert.equal(status.source, 'test-lane-overview-local');
+  assert.equal(status.error, '');
+  assert.equal(status.remaining, 0);
+  assert.match(status.lastRefreshedAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(get(operatorOverviewStore).liveError, '');
+});
+
 test('completed worktree progress display is unknown without durable progress evidence', () => {
   const display = completedProgressDisplay(
     {
@@ -739,3 +787,11 @@ test('offline fallback does not present fake Project or worker work', () => {
   assert.ok(view.attentionTasks.every((task) => task.type === 'Diagnostics'));
   assert.ok(view.laneSummaries.every((lane) => lane.active === 0));
 });
+
+async function waitFor(predicate, timeoutMs = 1000) {
+  const startedAt = Date.now();
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error('Timed out waiting for condition.');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}


### PR DESCRIPTION
## Summary
- Implements #408: Refresh Lane Overview local worktree state independently.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #408
