### PR TITLE
Fix Codex rollout transcript rendering

### DIFF
--- a/app/src/app.css
+++ b/app/src/app.css
@@ -2760,6 +2760,22 @@ a {
   background: var(--subtle-bg);
 }
 
+.transcript-pagination {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--muted);
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.transcript-pagination > div {
+  display: flex;
+  gap: var(--space-2);
+}
+
 .transcript-timeline {
   display: grid;
   gap: var(--space-2);
@@ -2809,6 +2825,13 @@ a {
 
 .transcript-event-meta small {
   color: var(--muted);
+  font-size: var(--text-xs);
+  overflow-wrap: anywhere;
+}
+
+.transcript-event-meta time {
+  color: var(--fg-2);
+  font-family: var(--font-mono);
   font-size: var(--text-xs);
   overflow-wrap: anywhere;
 }

--- a/app/src/lib/LaneViews.svelte
+++ b/app/src/lib/LaneViews.svelte
@@ -37,6 +37,9 @@
   let transcriptError = '';
   let transcriptResponse: any = transcriptUnavailable('Transcript has not been loaded yet.');
   let transcriptLoadKey = '';
+  let transcriptPage = 1;
+  let transcriptPaginationKey = '';
+  const transcriptPageSize = 25;
 
   $: laneWorkers = view?.laneWorkers ?? {};
   $: queueIssues = view?.queueIssues ?? [];
@@ -52,8 +55,12 @@
   $: heartbeatSummary = selectedIssue ? classifyHeartbeat($autoloopStateStore, selectedLaneKey, selectedIssue.id) : null;
   $: eventLogPath = localEventLogPath(view);
   $: transcriptParsed = parseCodexTranscriptJsonl(transcriptResponse?.content ?? '');
+  $: transcriptPageCount = Math.max(1, Math.ceil(transcriptParsed.events.length / transcriptPageSize));
+  $: updateTranscriptPagination(`${transcriptResponse?.path ?? 'none'}:${transcriptParsed.summary.rawRecords}:${transcriptParsed.summary.readableEvents}`, transcriptPageCount);
+  $: transcriptPageStart = (transcriptPage - 1) * transcriptPageSize;
+  $: transcriptPageEvents = transcriptParsed.events.slice(transcriptPageStart, transcriptPageStart + transcriptPageSize);
   $: transcriptStatusLabel = transcriptResponse?.status === 'available'
-    ? `${transcriptParsed.status} · ${transcriptParsed.events.length} events`
+    ? `${transcriptParsed.status} · ${transcriptParsed.summary.readableEvents} events`
     : transcriptResponse?.reason ?? 'Transcript unavailable';
   $: maybeLoadTranscript(selectedIssue);
   $: laneColumns = laneOrder.map((lane) => {
@@ -438,6 +445,20 @@
     return new Date(ms).toLocaleString([], { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' });
   }
 
+  function updateTranscriptPagination(key: string, pageCount: number) {
+    if (key !== transcriptPaginationKey) {
+      transcriptPaginationKey = key;
+      transcriptPage = pageCount;
+      return;
+    }
+    if (transcriptPage > pageCount) transcriptPage = pageCount;
+    if (transcriptPage < 1) transcriptPage = 1;
+  }
+
+  function setTranscriptPage(page: number) {
+    transcriptPage = Math.min(transcriptPageCount, Math.max(1, page));
+  }
+
   function relativeAge(value: unknown) {
     const ms = dateMs(value);
     if (!ms) return 'unknown';
@@ -599,6 +620,9 @@
         <JsonLogView value={transcriptResponse?.content} fallbackLabel="Codex transcript JSONL" />
       {:else}
         <div class="transcript-summary">
+          <span>{transcriptParsed.summary.rawRecords} raw records</span>
+          <span>{transcriptParsed.summary.readableEvents} readable</span>
+          <span>{transcriptParsed.summary.unsupportedRecords} unsupported</span>
           <span>{transcriptParsed.summary.userTurns} user</span>
           <span>{transcriptParsed.summary.assistantTurns} assistant</span>
           <span>{transcriptParsed.summary.toolCalls} tool calls</span>
@@ -608,12 +632,25 @@
           {/if}
         </div>
 
+        {#if transcriptParsed.events.length > transcriptPageSize}
+          <div class="transcript-pagination" aria-label="Transcript pagination">
+            <span>Page {transcriptPage} of {transcriptPageCount}</span>
+            <div>
+              <button class="btn btn-ghost" type="button" on:click={() => setTranscriptPage(transcriptPage - 1)} disabled={transcriptPage <= 1}>Previous</button>
+              <button class="btn btn-ghost" type="button" on:click={() => setTranscriptPage(transcriptPage + 1)} disabled={transcriptPage >= transcriptPageCount}>Next</button>
+            </div>
+          </div>
+        {/if}
+
         <div class="transcript-timeline">
           {#if transcriptParsed.events.length}
-            {#each transcriptParsed.events as event}
+            {#each transcriptPageEvents as event}
               <article class="transcript-event {event.kind} {event.tone}">
                 <div class="transcript-event-meta">
                   <span>{event.kind.replace('_', ' ')}</span>
+                  {#if event.timestamp}
+                    <time>{formatTime(event.timestamp)}</time>
+                  {/if}
                   {#if event.detail}
                     <small>{event.detail}</small>
                   {/if}

--- a/app/src/lib/viewModel/codexTranscript.ts
+++ b/app/src/lib/viewModel/codexTranscript.ts
@@ -15,6 +15,7 @@ export type TranscriptEvent = {
   title: string;
   body: string;
   detail?: string;
+  timestamp?: string;
   tone: TranscriptTone;
   raw?: unknown;
 };
@@ -30,6 +31,9 @@ export type TranscriptParseResult = {
     toolCalls: number;
     diagnostics: number;
     tokenUsage: string | null;
+    rawRecords: number;
+    readableEvents: number;
+    unsupportedRecords: number;
   };
 };
 
@@ -99,7 +103,7 @@ export function parseCodexTranscriptJsonl(text: unknown): TranscriptParseResult 
     }
 
     const mapped = transcriptEventFromRecord(record, index);
-    if (mapped) events.push(mapped);
+    if (mapped && !isDuplicateEvent(events[events.length - 1], mapped)) events.push(mapped);
   });
 
   const summary = {
@@ -107,7 +111,10 @@ export function parseCodexTranscriptJsonl(text: unknown): TranscriptParseResult 
     assistantTurns: events.filter((event) => event.kind === 'assistant' || event.kind === 'final').length,
     toolCalls: events.filter((event) => event.kind === 'tool_call').length,
     diagnostics: events.filter((event) => event.kind === 'diagnostic').length,
-    tokenUsage: latestUsage(events)
+    tokenUsage: latestUsage(events),
+    rawRecords: rawRecords.length,
+    readableEvents: events.length,
+    unsupportedRecords: Math.max(0, rawRecords.length - events.length)
   };
   const status = !lines.length
     ? 'empty'
@@ -134,41 +141,75 @@ function transcriptEventFromRecord(record: any, index: number): TranscriptEvent 
   const protocol = protocolMessage(record);
   if (protocol) return transcriptEventFromProtocol(protocol, index, record);
 
-  const item = record?.item ?? record?.payload?.item ?? record?.message ?? record;
-  const type = text(record?.type ?? item?.type ?? record?.event ?? record?.kind);
+  const wrapper = text(record?.type);
+  const payload = record?.payload;
+  const item = record?.item ?? payload?.item ?? payload ?? record?.message ?? record;
+  const type = text(item?.type ?? record?.event ?? record?.kind ?? record?.type);
   const role = text(item?.role ?? record?.role);
   const status = text(item?.status ?? record?.status);
   const name = text(item?.name ?? item?.tool_name ?? record?.name ?? record?.tool_name);
-  const usage = record?.usage ?? record?.token_usage ?? record?.response?.usage;
+  const timestamp = eventTimestamp(record);
+  const usage = item?.usage ?? item?.response?.usage ?? record?.usage ?? record?.token_usage ?? record?.response?.usage ?? item?.info?.total_token_usage ?? item?.info?.last_token_usage;
+
+  if (wrapper === 'session_meta') {
+    return event(index, 'diagnostic', 'Session metadata', summarizeObject({
+      id: item?.id,
+      cwd: item?.cwd,
+      model: item?.model ?? item?.model_provider,
+      source: item?.source,
+      cli: item?.cli_version
+    }), 'neutral', 'session_meta', record, timestamp);
+  }
+  if (wrapper === 'turn_context') return null;
+  if (wrapper === 'event_msg') {
+    if (type === 'user_message') {
+      return event(index, 'user', 'User', previewText(item?.message), 'neutral', type, record, timestamp);
+    }
+    if (type === 'agent_message') {
+      const phase = text(item?.phase);
+      const final = phase === 'final_answer';
+      return event(index, final ? 'final' : 'assistant', final ? 'Final answer' : 'Assistant', previewText(item?.message), final ? 'success' : 'neutral', phase || type, record, timestamp);
+    }
+    if (type === 'token_count') {
+      const tokenUsage = item?.info?.total_token_usage ?? item?.info?.last_token_usage ?? item?.info;
+      return event(index, 'usage', 'Token usage', usageSummary(tokenUsage), 'neutral', type, record, timestamp);
+    }
+    if (/error|cancel|interrupt|input|required|failed|task_started/.test(`${type} ${status}`)) {
+      const title = type === 'task_started' ? 'Task started' : diagnosticTitle(type, status);
+      return event(index, 'diagnostic', title, previewText(item?.message ?? item?.error ?? item), /error|failed/.test(`${type} ${status}`) ? 'danger' : 'warn', type || status || undefined, record, timestamp);
+    }
+    return null;
+  }
 
   if (usage && !role && !item?.content && !record?.content) {
-    return event(index, 'usage', 'Token usage', usageSummary(usage), 'neutral', undefined, record);
+    return event(index, 'usage', 'Token usage', usageSummary(usage), 'neutral', undefined, record, timestamp);
   }
+  if (role && role !== 'user' && role !== 'assistant') return null;
 
   if (role === 'user' || type === 'user_message') {
-    return event(index, 'user', 'User', contentText(item || record), 'neutral', type || undefined, record);
+    return event(index, 'user', 'User', contentText(item || record), 'neutral', type || undefined, record, timestamp);
   }
-  if (role === 'assistant' || type === 'assistant_message' || type === 'message') {
+  if (role === 'assistant' || type === 'assistant_message' || (type === 'message' && !role)) {
     const body = contentText(item || record);
     const final = /final|answer/i.test(type) || record?.is_final === true;
-    return event(index, final ? 'final' : 'assistant', final ? 'Final answer' : 'Assistant', body, final ? 'success' : 'neutral', status || undefined, record);
+    return event(index, final ? 'final' : 'assistant', final ? 'Final answer' : 'Assistant', body, final ? 'success' : 'neutral', status || undefined, record, timestamp);
   }
   if (/final|response\.completed/.test(type)) {
     const body = contentText(item || record) || text(record?.response?.output_text);
-    if (body) return event(index, 'final', 'Final answer', body, 'success', status || undefined, record);
+    if (body) return event(index, 'final', 'Final answer', body, 'success', status || undefined, record, timestamp);
   }
   if (type.includes('function_call_output') || type.includes('tool_output') || item?.output) {
-    return event(index, 'tool_output', name || 'Tool output', previewText(item?.output ?? record?.output ?? record?.result), status === 'failed' ? 'danger' : 'neutral', status || undefined, record);
+    return event(index, 'tool_output', name || 'Tool output', previewText(item?.output ?? record?.output ?? record?.result), status === 'failed' ? 'danger' : 'neutral', status || undefined, record, timestamp);
   }
   if (type.includes('function_call') || type.includes('tool_call') || item?.arguments || item?.input) {
     const args = item?.arguments ?? item?.input ?? record?.arguments ?? record?.input;
-    return event(index, 'tool_call', name || 'Tool call', summarizeArguments(args), 'neutral', status || 'started', record);
+    return event(index, 'tool_call', name || 'Tool call', summarizeArguments(args), 'neutral', status || 'started', record, timestamp);
   }
   if (/error|cancel|interrupt|input|required|failed/.test(`${type} ${status}`)) {
-    return event(index, 'diagnostic', diagnosticTitle(type, status), previewText(record?.error ?? record?.message ?? record), /error|failed/.test(`${type} ${status}`) ? 'danger' : 'warn', status || undefined, record);
+    return event(index, 'diagnostic', diagnosticTitle(type, status), previewText(record?.error ?? record?.message ?? record), /error|failed/.test(`${type} ${status}`) ? 'danger' : 'warn', status || undefined, record, timestamp);
   }
   if (usage) {
-    return event(index, 'usage', 'Token usage', usageSummary(usage), 'neutral', undefined, record);
+    return event(index, 'usage', 'Token usage', usageSummary(usage), 'neutral', undefined, record, timestamp);
   }
   return null;
 }
@@ -202,48 +243,55 @@ function transcriptEventFromProtocol(protocol: any, index: number, raw: unknown)
   const item = params.item ?? {};
 
   if (protocol.error) {
-    return event(index, 'diagnostic', method || 'Protocol error', previewText(protocol.error), 'danger', protocol.direction, raw);
+    return event(index, 'diagnostic', method || 'Protocol error', previewText(protocol.error), 'danger', protocol.direction, raw, eventTimestamp(raw));
   }
   if (method === 'turn/start') {
     const input = Array.isArray(params.input)
       ? params.input.map((entry: any) => text(entry?.text ?? entry?.content ?? entry)).filter(Boolean).join('\n\n')
       : contentText(params.input);
-    return input ? event(index, 'user', 'User', input, 'neutral', 'turn/start', raw) : null;
+    return input ? event(index, 'user', 'User', input, 'neutral', 'turn/start', raw, eventTimestamp(raw)) : null;
   }
   if (method === 'item/started' && item.type === 'commandExecution') {
-    return event(index, 'tool_call', item.command || 'Command execution', summarizeArguments({ cwd: item.cwd, command: item.command }), 'neutral', item.status || 'started', raw);
+    return event(index, 'tool_call', item.command || 'Command execution', summarizeArguments({ cwd: item.cwd, command: item.command }), 'neutral', item.status || 'started', raw, eventTimestamp(raw));
   }
   if (method === 'item/completed' && item.type === 'commandExecution') {
-    return event(index, 'tool_output', item.command || 'Command output', previewText(item.aggregatedOutput ?? item.output ?? item.exitCode), item.status === 'failed' || item.exitCode ? 'danger' : 'neutral', item.status || 'completed', raw);
+    return event(index, 'tool_output', item.command || 'Command output', previewText(item.aggregatedOutput ?? item.output ?? item.exitCode), item.status === 'failed' || item.exitCode ? 'danger' : 'neutral', item.status || 'completed', raw, eventTimestamp(raw));
   }
   if (method === 'item/completed' && item.type === 'agentMessage') {
     const phase = text(item.phase);
     const final = phase === 'final_answer';
-    return event(index, final ? 'final' : 'assistant', final ? 'Final answer' : 'Assistant', previewText(item.text), final ? 'success' : 'neutral', phase || 'agentMessage', raw);
+    return event(index, final ? 'final' : 'assistant', final ? 'Final answer' : 'Assistant', previewText(item.text), final ? 'success' : 'neutral', phase || 'agentMessage', raw, eventTimestamp(raw));
   }
   if (method === 'thread/tokenUsage/updated') {
     const usage = params.tokenUsage?.total ?? params.tokenUsage?.last ?? params.tokenUsage;
-    return event(index, 'usage', 'Token usage', usageSummary(usage), 'neutral', undefined, raw);
+    return event(index, 'usage', 'Token usage', usageSummary(usage), 'neutral', undefined, raw, eventTimestamp(raw));
   }
   if (method === 'configWarning') {
-    return event(index, 'diagnostic', 'Config warning', previewText(params.summary ?? params.details ?? params), 'warn', method, raw);
+    return event(index, 'diagnostic', 'Config warning', previewText(params.summary ?? params.details ?? params), 'warn', method, raw, eventTimestamp(raw));
   }
   if (/input|required|cancel|error|failed/.test(`${method} ${previewText(params, 120)}`)) {
-    return event(index, 'diagnostic', diagnosticTitle(method, ''), previewText(params), /error|failed/.test(method) ? 'danger' : 'warn', method, raw);
+    return event(index, 'diagnostic', diagnosticTitle(method, ''), previewText(params), /error|failed/.test(method) ? 'danger' : 'warn', method, raw, eventTimestamp(raw));
   }
   return null;
 }
 
-function event(index: number, kind: TranscriptEventKind, title: string, body: string, tone: TranscriptTone, detail?: string, raw?: unknown): TranscriptEvent {
+function event(index: number, kind: TranscriptEventKind, title: string, body: string, tone: TranscriptTone, detail?: string, raw?: unknown, timestamp?: string): TranscriptEvent {
   return {
     id: `${kind}-${index}`,
     kind,
     title,
     body: body || '(empty)',
     detail,
+    timestamp,
     tone,
     raw
   };
+}
+
+function isDuplicateEvent(previous: TranscriptEvent | undefined, next: TranscriptEvent) {
+  return previous?.kind === next.kind
+    && previous?.timestamp === next.timestamp
+    && previous?.body === next.body;
 }
 
 function heartbeat(
@@ -343,6 +391,12 @@ function usageSummary(usage: any) {
     output != null ? `output ${output}` : null,
     total ? `total ${total}` : null
   ].filter(Boolean).join(' · ') || previewText(usage);
+}
+
+function eventTimestamp(record: unknown) {
+  if (!record || typeof record !== 'object') return undefined;
+  const value = (record as any).timestamp ?? (record as any).time ?? (record as any).created_at ?? (record as any).payload?.timestamp ?? (record as any).payload?.started_at;
+  return text(value) || undefined;
 }
 
 function latestUsage(events: TranscriptEvent[]) {

--- a/app/test/operator-view.test.mjs
+++ b/app/test/operator-view.test.mjs
@@ -584,9 +584,87 @@ test('Codex transcript parser renders conversation turns, tool calls, outputs, f
   assert.equal(parsed.summary.assistantTurns, 2);
   assert.equal(parsed.summary.toolCalls, 1);
   assert.equal(parsed.summary.tokenUsage, 'input 10 · output 5 · total 15');
+  assert.equal(parsed.summary.rawRecords, 6);
+  assert.equal(parsed.summary.unsupportedRecords, 0);
+  assert.equal(parsed.events[0].timestamp, undefined);
   assert.equal(parsed.events.find((event) => event.kind === 'tool_call').title, 'functions.exec_command');
   assert.match(parsed.events.find((event) => event.kind === 'tool_call').body, /cmd: git status --short/);
   assert.match(parsed.events.find((event) => event.kind === 'tool_output').body, /modified file|## branch/);
+});
+
+test('Codex transcript parser renders rollout payload wrapper records with timestamps and unsupported counts', () => {
+  const transcript = [
+    JSON.stringify({
+      timestamp: '2026-06-02T11:34:36.243Z',
+      type: 'session_meta',
+      payload: {
+        id: '019e881d-344f-7cb2-bfbd-8c13b39f2a92',
+        cwd: '/tmp/issue-410',
+        cli_version: '0.0.0',
+        source: 'codex',
+        model_provider: 'openai'
+      }
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-02T11:34:38.860Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'developer', content: [{ type: 'input_text', text: 'hidden instructions' }] }
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-02T11:34:38.863Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message: 'You are working on Shea Symphony issue #410.' }
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-02T11:34:49.527Z',
+      type: 'event_msg',
+      payload: { type: 'agent_message', phase: 'commentary', message: 'I am inspecting the transcript parser.' }
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-02T11:34:49.566Z',
+      type: 'response_item',
+      payload: { type: 'function_call', name: 'functions.exec_command', arguments: JSON.stringify({ cmd: 'rg transcript app/src' }), call_id: 'call_1' }
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-02T11:34:49.642Z',
+      type: 'response_item',
+      payload: { type: 'function_call_output', call_id: 'call_1', output: 'app/src/lib/viewModel/codexTranscript.ts' }
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-02T11:34:49.643Z',
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: {
+          total_token_usage: { input_tokens: 100, output_tokens: 25, total_tokens: 125 }
+        }
+      }
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-02T11:34:50.000Z',
+      type: 'turn_context',
+      payload: { cwd: '/tmp/issue-410', model: 'gpt-5' }
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-02T11:42:09.799Z',
+      type: 'event_msg',
+      payload: { type: 'agent_message', phase: 'final_answer', message: 'Implemented locally.' }
+    })
+  ].join('\n');
+
+  const parsed = parseCodexTranscriptJsonl(transcript);
+
+  assert.equal(parsed.status, 'available');
+  assert.equal(parsed.summary.rawRecords, 9);
+  assert.equal(parsed.summary.readableEvents, 7);
+  assert.equal(parsed.summary.unsupportedRecords, 2);
+  assert.equal(parsed.summary.userTurns, 1);
+  assert.equal(parsed.summary.assistantTurns, 2);
+  assert.equal(parsed.summary.toolCalls, 1);
+  assert.equal(parsed.summary.tokenUsage, 'input 100 · output 25 · total 125');
+  assert.equal(parsed.events.find((event) => event.kind === 'assistant').timestamp, '2026-06-02T11:34:49.527Z');
+  assert.equal(parsed.events.find((event) => event.kind === 'final').title, 'Final answer');
+  assert.equal(parsed.events.some((event) => /hidden instructions/.test(event.body)), false);
 });
 
 test('Codex transcript parser renders app-server protocol JSONL without token delta noise', () => {
@@ -667,6 +745,16 @@ test('Codex transcript parser marks malformed still-growing JSONL as partial', (
   assert.equal(parsed.status, 'partial');
   assert.equal(parsed.malformedLines, 1);
   assert.equal(parsed.events.some((event) => event.title === 'Malformed JSONL line'), true);
+});
+
+test('Codex transcript conversation source includes timestamps, counts, and final-page pagination', () => {
+  const laneViews = readFileSync(new URL('../src/lib/LaneViews.svelte', import.meta.url), 'utf8');
+
+  assert.match(laneViews, /transcriptPage = pageCount/);
+  assert.match(laneViews, /summary\.rawRecords/);
+  assert.match(laneViews, /summary\.unsupportedRecords/);
+  assert.match(laneViews, /event\.timestamp/);
+  assert.match(laneViews, /transcriptPageEvents/);
 });
 
 test('missing transcript state is local-only and explicit', () => {


### PR DESCRIPTION
## Summary
- parse real Codex rollout JSONL wrapper records including session_meta, event_msg, response_item, and token_count payloads
- show transcript timestamps plus raw/readable/unsupported counts in the Conversation view
- paginate transcript events and default new transcript loads to the latest page

## Verification
- npm test
- npm run check
- npm run build
- cd app/src-tauri && cargo test

Closes #428