### PR TITLE
Simplify lane board queued-item metadata

### DIFF
--- a/app/src/lib/viewModel/laneThroughput.ts
+++ b/app/src/lib/viewModel/laneThroughput.ts
@@ -136,14 +136,75 @@ const transientTitleLabels = new Set([
 ]);
 
 function issueMeta(issue: any) {
-  return [
-    issue.state,
-    issue.workerStatus,
-    issue.workerDetail,
-    issue.evidence,
-    issue.recommended
-  ].filter(Boolean).join(' · ');
+  const state = cleanMetaPart(issue.state);
+  const workerStatus = cleanMetaPart(issue.workerStatus);
+  const workerDetail = cleanMetaPart(issue.workerDetail);
+  const recommended = cleanMetaPart(issue.recommended);
+  const evidenceParts = evidenceMetaParts(issue.evidence, state);
+  const parts = [
+    quietDefaultState(state) ? null : state,
+    quietDefaultWorkerStatus(workerStatus) ? null : workerStatus,
+    quietDefaultWorkerDetail(workerDetail) ? null : workerDetail,
+    ...evidenceParts,
+    quietDefaultRecommendation(recommended, state) ? null : recommended
+  ].filter(Boolean);
+  return dedupeMetaParts(parts).join(' · ');
 }
+
+function cleanMetaPart(value: any) {
+  if (typeof value !== 'string') return null;
+  const text = value.trim();
+  return text ? text : null;
+}
+
+function evidenceMetaParts(value: any, state: string | null) {
+  const text = cleanMetaPart(value);
+  if (!text) return [];
+  const parts = text.split(' · ').map((part) => part.trim()).filter(Boolean);
+  const filtered = parts.filter((part) => {
+    if (sameMeta(part, state)) return false;
+    return !defaultEvidenceSourceLabels.has(part.toLowerCase());
+  });
+  return filtered.length ? filtered : [];
+}
+
+function quietDefaultState(state: string | null) {
+  return sameMeta(state, 'Todo');
+}
+
+function quietDefaultWorkerStatus(status: string | null) {
+  return sameMeta(status, 'No worker visible');
+}
+
+function quietDefaultWorkerDetail(detail: string | null) {
+  return sameMeta(detail, 'Project is waiting in this lane; no current worker session is visible.');
+}
+
+function quietDefaultRecommendation(recommended: string | null, state: string | null) {
+  return sameMeta(state, 'Todo') && sameMeta(recommended, 'Run Issue Quality Gate before dispatch.');
+}
+
+function dedupeMetaParts(parts: (string | null)[]) {
+  const seen = new Set();
+  return parts.filter((part) => {
+    if (!part) return false;
+    const key = part.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function sameMeta(left: string | null, right: string | null) {
+  return String(left ?? '').trim().toLowerCase() === String(right ?? '').trim().toLowerCase();
+}
+
+const defaultEvidenceSourceLabels = new Set([
+  'github queue',
+  'project state',
+  'runtime state',
+  'autopilot plan'
+]);
 
 function laneStatusRow(snapshot: any) {
   const status = String(snapshot?.status ?? '').toLowerCase();

--- a/app/test/operator-view.test.mjs
+++ b/app/test/operator-view.test.mjs
@@ -564,6 +564,81 @@ test('lane throughput board keeps independent running and queued lane work visib
   assert.deepEqual(merge.issues.map((issue) => issue.id), ['#430']);
 });
 
+test('lane throughput board suppresses default queued Todo metadata', () => {
+  const board = buildLaneThroughputBoard({
+    queueIssues: [
+      {
+        id: '#428',
+        title: 'Fix Codex transcript rendering with timestamps and pagination',
+        lane: 'Main',
+        state: 'Todo',
+        workerStatus: 'No worker visible',
+        workerDetail: 'Project is waiting in this lane; no current worker session is visible.',
+        evidence: 'project state · Todo',
+        recommended: 'Run Issue Quality Gate before dispatch.',
+        tone: 'neutral'
+      }
+    ]
+  });
+
+  const mainIssue = board.find((lane) => lane.laneKey === 'main').issues.find((issue) => issue.id === '#428');
+
+  assert.equal(mainIssue.title, 'Fix Codex transcript rendering with timestamps and pagination');
+  assert.equal(mainIssue.meta, '');
+});
+
+test('lane throughput board keeps concise queued exception metadata visible', () => {
+  const board = buildLaneThroughputBoard({
+    queueIssues: [
+      {
+        id: '#431',
+        title: 'Repair review finding',
+        lane: 'Main',
+        state: 'Rework',
+        workerStatus: 'No worker visible',
+        workerDetail: 'Project is waiting in this lane; no current worker session is visible.',
+        evidence: 'project state · Rework',
+        recommended: 'Main lane can resume after checking rework evidence.',
+        tone: 'warn'
+      },
+      {
+        id: '#432',
+        title: 'Investigate blocked dispatch',
+        lane: 'Main',
+        state: 'Blocked',
+        workerStatus: 'Worker read unavailable',
+        workerDetail: 'Worker session surface is unavailable; match status is unknown.',
+        evidence: 'project state · Blocked · stale session',
+        recommended: 'Inspect issue and diagnostics before choosing a lane.',
+        tone: 'danger'
+      },
+      {
+        id: '#433',
+        title: 'Recover parked run',
+        lane: 'Main',
+        state: 'Todo',
+        workerStatus: 'No worker visible',
+        workerDetail: 'Recovered lane event needs operator attention.',
+        evidence: 'project state · Todo · Recovered',
+        recommended: 'Inspect recovered run evidence.',
+        tone: 'warn'
+      }
+    ]
+  });
+
+  const main = board.find((lane) => lane.laneKey === 'main');
+  const rework = main.issues.find((issue) => issue.id === '#431');
+  const blocked = main.issues.find((issue) => issue.id === '#432');
+  const recovered = main.issues.find((issue) => issue.id === '#433');
+
+  assert.equal(rework.meta, 'Rework · Main lane can resume after checking rework evidence.');
+  assert.equal(
+    blocked.meta,
+    'Blocked · Worker read unavailable · Worker session surface is unavailable; match status is unknown. · stale session · Inspect issue and diagnostics before choosing a lane.'
+  );
+  assert.equal(recovered.meta, 'Recovered lane event needs operator attention. · Recovered · Inspect recovered run evidence.');
+});
+
 test('lane throughput board keeps issue identity ahead of transient worker labels', () => {
   const board = buildLaneThroughputBoard({
     queueIssues: [


### PR DESCRIPTION
## Summary
- Suppress default queued Todo metadata on lane board cards.
- Deduplicate default project-state evidence and hide default worker absence / Quality Gate recommendation copy.
- Preserve concise exception metadata for Rework, Blocked, worker-unavailable, and recovered cases.

## Verification
- npm test
- npm run check
- npm run build

Closes #430