### PR TITLE
#326: Make prompt injection workflow-configurable and centralize CLI runtime envelopes

### DIFF
--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -2,8 +2,9 @@ use std::path::PathBuf;
 
 use shea_symphony::config::RuntimeConfig;
 use shea_symphony::progress::run_with_progress_heartbeat;
+use shea_symphony::prompt_runtime::{PROMPT_RENDERER_MODE, RUNTIME_ENVELOPES};
 use shea_symphony::tracker::adapter_from_config;
-use shea_symphony::workflow::WorkflowDefinition;
+use shea_symphony::workflow::{AgentLane, WorkflowDefinition};
 
 use crate::commands::gate::evaluate_issue_for_current_source;
 use crate::commands::project::{filter_issues_by_state, render_state_summary};
@@ -22,6 +23,32 @@ pub(crate) fn validate(workflow_path: PathBuf) -> Result<(), Box<dyn std::error:
     println!("backend={}", config.backend.kind);
     println!("workspace_root={}", config.workspace.root.display());
     println!("prompt_template_bytes={}", workflow.prompt_template.len());
+    println!("prompt_renderer={PROMPT_RENDERER_MODE}");
+    for lane in [
+        AgentLane::MainAgent,
+        AgentLane::ReviewAgent,
+        AgentLane::MergeAgent,
+    ] {
+        let source = workflow.prompt_source_for_lane(lane);
+        let path = source
+            .path
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| "<none>".into());
+        println!(
+            "prompt_source.{}={} path={} bytes={}",
+            lane.config_key(),
+            source.kind.as_str(),
+            path,
+            workflow.prompt_for_lane(lane).len()
+        );
+    }
+    for envelope in RUNTIME_ENVELOPES {
+        println!(
+            "runtime_envelope={} lane={} backend={} path={} purpose={}",
+            envelope.id, envelope.lane, envelope.backend, envelope.path, envelope.purpose
+        );
+    }
     println!("status=valid");
     Ok(())
 }

--- a/src/lanes/claim.rs
+++ b/src/lanes/claim.rs
@@ -4,6 +4,7 @@ use shea_symphony::lane_claim::{
 };
 use shea_symphony::model::{native_subissue_gate_blocker, normalize_state, TrackerIssue};
 use shea_symphony::prompt::{render_prompt, PromptError};
+use shea_symphony::prompt_runtime::render_assigned_lane_claim_envelope;
 use shea_symphony::tracker::{ProjectFieldAssignment, TrackerAdapter};
 
 use crate::orchestration::{
@@ -125,11 +126,7 @@ pub(crate) fn render_prompt_with_claim(
 ) -> Result<String, PromptError> {
     let mut prompt = render_prompt(template, issue, attempt)?;
     if let Some(claim) = claim {
-        prompt.push_str("\n\n## Assigned Lane Claim\n\n");
-        prompt.push_str("- Preserve this `run=` value in handoff evidence and summaries.\n");
-        prompt.push_str(&format!("- Run: `{}`\n", claim.run));
-        prompt.push_str(&format!("- Claim: `{}`\n", claim.render()));
-        prompt.push_str(&format!("- Registry pointer: `{}`\n", claim.registry));
+        prompt.push_str(&render_assigned_lane_claim_envelope(claim));
     }
     Ok(prompt)
 }

--- a/src/lanes/main_loop/execution.rs
+++ b/src/lanes/main_loop/execution.rs
@@ -9,6 +9,9 @@ use shea_symphony::lane_claim::LaneClaim;
 use shea_symphony::model::TrackerIssue;
 use shea_symphony::profiles::selected_execution_profile;
 use shea_symphony::progress::run_with_progress_heartbeat;
+use shea_symphony::prompt_runtime::{
+    CODEX_APP_SERVER_CONTINUE_PROMPT, CODEX_APP_SERVER_HANDOFF_BOUNDARY,
+};
 use shea_symphony::workflow::{AgentLane, WorkflowDefinition};
 use shea_symphony::workspace::{
     apply_local_git_identity, prepare_workspace, profile_scoped_identifier, run_after_run,
@@ -17,17 +20,6 @@ use shea_symphony::workspace::{
 
 use crate::lanes::claim::render_prompt_with_claim;
 use crate::orchestration::{current_git_branch, current_time_ms, progress_spec_with_event_log};
-
-const CODEX_APP_SERVER_HANDOFF_BOUNDARY: &str = "\n\n## Codex App-Server Runtime Boundary\n\n\
-This run is executing inside the Codex app-server backend. Treat the app-server \
-turn as the implementation and local-verification worker only. Do not run \
-GitHub Project reads or mutations, do not create or update pull requests, and \
-do not attempt final Project state transitions from inside this child turn. \
-Leave a concise terminal summary of changed files, verification commands, and \
-any blocker. The outer Shea Symphony CLI will commit eligible worktree changes, \
-publish or update the PR, write durable workpad evidence, verify linked PR \
-readback, and perform the final `Agent Review` handoff.\n";
-const CODEX_APP_SERVER_CONTINUE_PROMPT: &str = "Continue";
 
 use super::RunLoopLiveHandoff;
 

--- a/src/lanes/merge/repair/agent_contract.rs
+++ b/src/lanes/merge/repair/agent_contract.rs
@@ -1,10 +1,13 @@
 use shea_symphony::git_handoff::CommandOutput;
 use shea_symphony::lane_claim::LaneClaim;
 use shea_symphony::model::{AgentEvent, TrackerIssue};
+use shea_symphony::prompt_runtime::{
+    render_merge_conflict_repair_task_envelope, MergeConflictRepairEnvelope,
+    MERGE_REQUIRED_OUTPUT_MARKER_ENVELOPE_TEXT,
+};
 use shea_symphony::workflow::{AgentLane, WorkflowDefinition};
 
 use crate::lanes::claim::render_prompt_with_claim;
-use crate::orchestration::single_line;
 
 #[allow(clippy::too_many_arguments)]
 pub(super) fn merge_agent_conflict_repair_prompt(
@@ -23,25 +26,16 @@ pub(super) fn merge_agent_conflict_repair_prompt(
         None,
         Some(claim),
     )?;
-    prompt.push_str(
-        "\n\n## Merge-Agent Conflict Repair Task\n\n\
-You are repairing the existing approved PR branch in place. Preserve the intent that already passed Agent Review and Human Review. Resolve only conflicts caused by merging the target base into this PR branch. Do not create a replacement PR, do not switch workspaces, and do not route through Rework.\n\n",
-    );
-    prompt.push_str(&format!("- Pull request: `{pr_ref}`\n"));
-    prompt.push_str(&format!("- Head branch: `{head_ref_name}`\n"));
-    prompt.push_str(&format!("- Expected base: `{expected_base}`\n"));
-    prompt.push_str(&format!("- Conflict summary: {conflict_summary}\n"));
-    prompt.push_str(&format!(
-        "- Mechanical merge stderr: `{}`\n",
-        single_line(&mechanical_output.stderr)
+    prompt.push_str(&render_merge_conflict_repair_task_envelope(
+        MergeConflictRepairEnvelope {
+            pr_ref,
+            head_ref_name,
+            expected_base,
+            conflict_summary,
+            mechanical_stderr: &mechanical_output.stderr,
+        },
     ));
-    prompt.push_str(
-        "\n### Required Output Marker\n\n\
-End your final response with one of these exact markers:\n\
-- `MERGE_AGENT_DECISION: repaired` only if the resolution preserves reviewed intent and verification can proceed.\n\
-- `MERGE_AGENT_DECISION: needs_human_input` if there is semantic uncertainty, unrelated drift, unsafe branch/worktree state, or missing verification confidence.\n\n\
-Also include `RESOLUTION_SUMMARY:` and `SEMANTIC_SAFETY:` lines. Leave the merge resolution staged or ready for `git add -A`; the merge lane will commit, verify cleanliness, push, and keep the issue in `Merging` for the next tick.\n",
-    );
+    prompt.push_str(MERGE_REQUIRED_OUTPUT_MARKER_ENVELOPE_TEXT);
     Ok(prompt)
 }
 

--- a/src/lanes/review/automatic.rs
+++ b/src/lanes/review/automatic.rs
@@ -11,6 +11,7 @@ use shea_symphony::lane_claim::{
 use shea_symphony::model::TrackerIssue;
 use shea_symphony::progress::{run_with_progress_heartbeat, ProgressHeartbeatSpec};
 use shea_symphony::prompt::render_prompt;
+use shea_symphony::prompt_runtime::AUTOMATIC_HEADLESS_REVIEW_BOUNDARY;
 use shea_symphony::review::{
     gemini_cli_headless_args, gemini_prelaunch_health_diagnostic, gemini_review_health_diagnostic,
     poll_review_job_until_terminal, render_repeated_review_failure_workpad, render_review_workpad,
@@ -865,29 +866,7 @@ pub(crate) fn render_automatic_review_prompt(
         issue,
         None,
     )?;
-    prompt.push_str(
-        "\n\n## Automatic Headless Review Boundary\n\n\
-This Gemini process is running under Shea Symphony automatic `review loop` or `review once`.\n\
-Shea Symphony CLI has already claimed or will own any Review Agent claim, timeline comment write,\n\
-issue body update, and Project state transition outside this process.\n\n\
-Do not run mutating Shea Symphony or GitHub commands, including `review claim`, `review pass`,\n\
-`review reject`, `project set-state`, `project workpad`, `forge`, `gh issue edit`, `gh issue comment`, raw\n\
-Project GraphQL mutations, or Project UI changes. Do not activate or follow any manual review\n\
-skill that tells you to mutate Project state.\n\n\
-Return review evidence in stdout only. Start with exactly one line: `Review Result: PASS`,\n\
-`Review Result: REWORK`, or `Review Result: NEEDS_CONTEXT`. Use `PASS` only when there are no\n\
-blocking findings. Use `REWORK` only when confirmed implementation defects require Main Agent\n\
-changes. Use `NEEDS_CONTEXT` when missing evidence or ambiguity prevents an independent decision.\n\n\
-UAT is Human Review-owned unless this issue explicitly asks the Main Agent to implement a UAT\n\
-harness, fixture, rehearsal path, or workflow capability. Missing Human-owned UAT execution is\n\
-not a confirmed implementation defect and must not by itself produce `Review Result: REWORK`.\n\
-Report UAT readiness or Human Review follow-up separately under `Evidence`.\n\n\
-Only use `[Confirmed]`, `[Plausible]`, `[Rejected]`, or `[Needs Context]` for actual review\n\
-findings. Do not use those bracketed finding tags for positive verification evidence, checklist\n\
-items, or things that were implemented correctly; put positive observations under an `Evidence`\n\
-heading with plain bullets instead. Leave routing and evidence persistence to the Shea Symphony\n\
-wrapper after this process exits.\n",
-    );
+    prompt.push_str(AUTOMATIC_HEADLESS_REVIEW_BOUNDARY);
     Ok(prompt)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod presentation;
 pub mod profiles;
 pub mod progress;
 pub mod prompt;
+pub mod prompt_runtime;
 pub mod quality_gate;
 pub mod review;
 pub mod review_status;

--- a/src/prompt_runtime.rs
+++ b/src/prompt_runtime.rs
@@ -1,0 +1,223 @@
+use crate::lane_claim::LaneClaim;
+
+pub const PROMPT_RENDERER_MODE: &str = "strict-liquid-subset";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeEnvelopeSpec {
+    pub id: &'static str,
+    pub lane: &'static str,
+    pub backend: &'static str,
+    pub path: &'static str,
+    pub purpose: &'static str,
+}
+
+pub const ASSIGNED_LANE_CLAIM_ENVELOPE: RuntimeEnvelopeSpec = RuntimeEnvelopeSpec {
+    id: "assigned_lane_claim",
+    lane: "main,merge",
+    backend: "all",
+    path: "claim/render_prompt_with_claim",
+    purpose: "claim identity and run evidence",
+};
+
+pub const CODEX_APP_SERVER_HANDOFF_ENVELOPE: RuntimeEnvelopeSpec = RuntimeEnvelopeSpec {
+    id: "codex_app_server_handoff_boundary",
+    lane: "main",
+    backend: "codex app-server",
+    path: "main_loop/execution",
+    purpose: "app-server child-turn mutation boundary",
+};
+
+pub const AUTOMATIC_HEADLESS_REVIEW_ENVELOPE: RuntimeEnvelopeSpec = RuntimeEnvelopeSpec {
+    id: "automatic_headless_review_boundary",
+    lane: "review",
+    backend: "gemini-cli",
+    path: "review/automatic",
+    purpose: "headless review safety and stdout protocol",
+};
+
+pub const MERGE_CONFLICT_REPAIR_TASK_ENVELOPE: RuntimeEnvelopeSpec = RuntimeEnvelopeSpec {
+    id: "merge_conflict_repair_task",
+    lane: "merge",
+    backend: "merge agent",
+    path: "merge/repair/agent_contract",
+    purpose: "merge repair scope and conflict context",
+};
+
+pub const MERGE_REQUIRED_OUTPUT_MARKER_ENVELOPE: RuntimeEnvelopeSpec = RuntimeEnvelopeSpec {
+    id: "merge_required_output_markers",
+    lane: "merge",
+    backend: "merge agent",
+    path: "merge/repair/agent_contract",
+    purpose: "required merge-agent routing markers",
+};
+
+pub const RUNTIME_ENVELOPES: &[RuntimeEnvelopeSpec] = &[
+    ASSIGNED_LANE_CLAIM_ENVELOPE,
+    CODEX_APP_SERVER_HANDOFF_ENVELOPE,
+    AUTOMATIC_HEADLESS_REVIEW_ENVELOPE,
+    MERGE_CONFLICT_REPAIR_TASK_ENVELOPE,
+    MERGE_REQUIRED_OUTPUT_MARKER_ENVELOPE,
+];
+
+pub const CODEX_APP_SERVER_CONTINUE_PROMPT: &str = "Continue";
+
+pub const CODEX_APP_SERVER_HANDOFF_BOUNDARY: &str = "\n\n## Codex App-Server Runtime Boundary\n\n\
+This run is executing inside the Codex app-server backend. Treat the app-server \
+turn as the implementation and local-verification worker only. Do not run \
+GitHub Project reads or mutations, do not create or update pull requests, and \
+do not attempt final Project state transitions from inside this child turn. \
+Leave a concise terminal summary of changed files, verification commands, and \
+any blocker. The outer Shea Symphony CLI will commit eligible worktree changes, \
+publish or update the PR, write durable workpad evidence, verify linked PR \
+readback, and perform the final `Agent Review` handoff.\n";
+
+pub const AUTOMATIC_HEADLESS_REVIEW_BOUNDARY: &str =
+    "\n\n## Automatic Headless Review Boundary\n\n\
+This Gemini process is running under Shea Symphony automatic `review loop` or `review once`.\n\
+Shea Symphony CLI has already claimed or will own any Review Agent claim, timeline comment write,\n\
+issue body update, and Project state transition outside this process.\n\n\
+Do not run mutating Shea Symphony or GitHub commands, including `review claim`, `review pass`,\n\
+`review reject`, `project set-state`, `project workpad`, `forge`, `gh issue edit`, `gh issue comment`, raw\n\
+Project GraphQL mutations, or Project UI changes. Do not activate or follow any manual review\n\
+skill that tells you to mutate Project state.\n\n\
+Return review evidence in stdout only. Start with exactly one line: `Review Result: PASS`,\n\
+`Review Result: REWORK`, or `Review Result: NEEDS_CONTEXT`. Use `PASS` only when there are no\n\
+blocking findings. Use `REWORK` only when confirmed implementation defects require Main Agent\n\
+changes. Use `NEEDS_CONTEXT` when missing evidence or ambiguity prevents an independent decision.\n\n\
+UAT is Human Review-owned unless this issue explicitly asks the Main Agent to implement a UAT\n\
+harness, fixture, rehearsal path, or workflow capability. Missing Human-owned UAT execution is\n\
+not a confirmed implementation defect and must not by itself produce `Review Result: REWORK`.\n\
+Report UAT readiness or Human Review follow-up separately under `Evidence`.\n\n\
+Only use `[Confirmed]`, `[Plausible]`, `[Rejected]`, or `[Needs Context]` for actual review\n\
+findings. Do not use those bracketed finding tags for positive verification evidence, checklist\n\
+items, or things that were implemented correctly; put positive observations under an `Evidence`\n\
+heading with plain bullets instead. Leave routing and evidence persistence to the Shea Symphony\n\
+wrapper after this process exits.\n";
+
+pub fn render_assigned_lane_claim_envelope(claim: &LaneClaim) -> String {
+    format!(
+        "\n\n## Assigned Lane Claim\n\n\
+- Preserve this `run=` value in handoff evidence and summaries.\n\
+- Run: `{}`\n\
+- Claim: `{}`\n\
+- Registry pointer: `{}`\n",
+        claim.run,
+        claim.render(),
+        claim.registry
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MergeConflictRepairEnvelope<'a> {
+    pub pr_ref: &'a str,
+    pub head_ref_name: &'a str,
+    pub expected_base: &'a str,
+    pub conflict_summary: &'a str,
+    pub mechanical_stderr: &'a str,
+}
+
+pub fn render_merge_conflict_repair_task_envelope(
+    input: MergeConflictRepairEnvelope<'_>,
+) -> String {
+    format!(
+        "\n\n## Merge-Agent Conflict Repair Task\n\n\
+You are repairing the existing approved PR branch in place. Preserve the intent that already passed Agent Review and Human Review. Resolve only conflicts caused by merging the target base into this PR branch. Do not create a replacement PR, do not switch workspaces, and do not route through Rework.\n\n\
+- Pull request: `{}`\n\
+- Head branch: `{}`\n\
+- Expected base: `{}`\n\
+- Conflict summary: {}\n\
+- Mechanical merge stderr: `{}`\n",
+        input.pr_ref,
+        input.head_ref_name,
+        input.expected_base,
+        input.conflict_summary,
+        single_line(input.mechanical_stderr)
+    )
+}
+
+pub const MERGE_REQUIRED_OUTPUT_MARKER_ENVELOPE_TEXT: &str =
+    "\n### Required Output Marker\n\n\
+End your final response with one of these exact markers:\n\
+- `MERGE_AGENT_DECISION: repaired` only if the resolution preserves reviewed intent and verification can proceed.\n\
+- `MERGE_AGENT_DECISION: needs_human_input` if there is semantic uncertainty, unrelated drift, unsafe branch/worktree state, or missing verification confidence.\n\n\
+Also include `RESOLUTION_SUMMARY:` and `SEMANTIC_SAFETY:` lines. Leave the merge resolution staged or ready for `git add -A`; the merge lane will commit, verify cleanliness, push, and keep the issue in `Merging` for the next tick.\n";
+
+fn single_line(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_names_current_cli_runtime_envelopes() {
+        let ids = RUNTIME_ENVELOPES
+            .iter()
+            .map(|envelope| envelope.id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ids,
+            vec![
+                "assigned_lane_claim",
+                "codex_app_server_handoff_boundary",
+                "automatic_headless_review_boundary",
+                "merge_conflict_repair_task",
+                "merge_required_output_markers",
+            ]
+        );
+        assert!(RUNTIME_ENVELOPES
+            .iter()
+            .all(|envelope| !envelope.path.trim().is_empty()));
+    }
+
+    #[test]
+    fn merge_repair_envelope_preserves_required_protocol() {
+        let envelope = render_merge_conflict_repair_task_envelope(MergeConflictRepairEnvelope {
+            pr_ref: "#326",
+            head_ref_name: "feature/issue-326",
+            expected_base: "main",
+            conflict_summary: "src/main.rs conflict",
+            mechanical_stderr: "line one\nline two",
+        }) + MERGE_REQUIRED_OUTPUT_MARKER_ENVELOPE_TEXT;
+
+        assert!(envelope.contains("Merge-Agent Conflict Repair Task"));
+        assert!(envelope.contains("- Pull request: `#326`"));
+        assert!(envelope.contains("- Mechanical merge stderr: `line one line two`"));
+        assert!(envelope.contains("MERGE_AGENT_DECISION: repaired"));
+        assert!(envelope.contains("MERGE_AGENT_DECISION: needs_human_input"));
+        assert!(envelope.contains("RESOLUTION_SUMMARY:"));
+        assert!(envelope.contains("SEMANTIC_SAFETY:"));
+    }
+
+    #[test]
+    fn runtime_boundary_headings_stay_in_registry_module() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        for path in [
+            src.join("lanes/claim.rs"),
+            src.join("lanes/main_loop/execution.rs"),
+            src.join("lanes/review/automatic.rs"),
+            src.join("lanes/merge/repair/agent_contract.rs"),
+        ] {
+            let content = std::fs::read_to_string(&path).unwrap();
+            for heading in [
+                "## Assigned Lane Claim",
+                "## Codex App-Server Runtime Boundary",
+                "## Automatic Headless Review Boundary",
+                "## Merge-Agent Conflict Repair Task",
+                "### Required Output Marker",
+            ] {
+                if content.contains(heading) {
+                    offenders.push(format!("{} contains {heading}", path.display()));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "runtime envelope text must live in prompt_runtime.rs: {offenders:?}"
+        );
+    }
+}

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -11,6 +11,7 @@ pub struct WorkflowDefinition {
     pub workflow_index: String,
     pub prompt_template: String,
     pub lane_prompts: LanePromptTemplates,
+    pub lane_prompt_sources: LanePromptSources,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -18,6 +19,25 @@ pub struct LanePromptTemplates {
     pub main_agent: String,
     pub review_agent: String,
     pub merge_agent: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanePromptSources {
+    pub main_agent: PromptTemplateSource,
+    pub review_agent: PromptTemplateSource,
+    pub merge_agent: PromptTemplateSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptTemplateSource {
+    pub kind: PromptTemplateSourceKind,
+    pub path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptTemplateSourceKind {
+    WorkflowPromptFile,
+    InlineWorkflowFallback,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,14 +90,15 @@ impl WorkflowDefinition {
         let (front_matter, prompt) = split_front_matter(content);
         let config = parse_front_matter(&front_matter)?;
         let workflow_index = prompt.trim().to_string();
-        let lane_prompts = load_lane_prompts(path.as_ref(), &config, &workflow_index)?;
+        let lane_prompt_bundle = load_lane_prompts(path.as_ref(), &config, &workflow_index)?;
 
         Ok(Self {
             path: path.as_ref().to_path_buf(),
             config,
-            prompt_template: lane_prompts.main_agent.clone(),
+            prompt_template: lane_prompt_bundle.templates.main_agent.clone(),
             workflow_index,
-            lane_prompts,
+            lane_prompts: lane_prompt_bundle.templates,
+            lane_prompt_sources: lane_prompt_bundle.sources,
         })
     }
 
@@ -88,6 +109,39 @@ impl WorkflowDefinition {
             AgentLane::MergeAgent => &self.lane_prompts.merge_agent,
         }
     }
+
+    pub fn prompt_source_for_lane(&self, lane: AgentLane) -> &PromptTemplateSource {
+        match lane {
+            AgentLane::MainAgent => &self.lane_prompt_sources.main_agent,
+            AgentLane::ReviewAgent => &self.lane_prompt_sources.review_agent,
+            AgentLane::MergeAgent => &self.lane_prompt_sources.merge_agent,
+        }
+    }
+}
+
+impl AgentLane {
+    pub fn config_key(self) -> &'static str {
+        match self {
+            Self::MainAgent => "main_agent",
+            Self::ReviewAgent => "review_agent",
+            Self::MergeAgent => "merge_agent",
+        }
+    }
+}
+
+impl PromptTemplateSourceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WorkflowPromptFile => "workflow_prompt_file",
+            Self::InlineWorkflowFallback => "inline_workflow_fallback",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LanePromptBundle {
+    templates: LanePromptTemplates,
+    sources: LanePromptSources,
 }
 
 impl WorkflowStore {
@@ -172,12 +226,23 @@ fn load_lane_prompts(
     workflow_path: &Path,
     config: &Value,
     inline_prompt: &str,
-) -> Result<LanePromptTemplates, WorkflowError> {
+) -> Result<LanePromptBundle, WorkflowError> {
     let Some(prompt_config) = config.get("prompts") else {
-        return Ok(LanePromptTemplates {
-            main_agent: inline_prompt.to_string(),
-            review_agent: inline_prompt.to_string(),
-            merge_agent: inline_prompt.to_string(),
+        let source = PromptTemplateSource {
+            kind: PromptTemplateSourceKind::InlineWorkflowFallback,
+            path: Some(workflow_path.to_path_buf()),
+        };
+        return Ok(LanePromptBundle {
+            templates: LanePromptTemplates {
+                main_agent: inline_prompt.to_string(),
+                review_agent: inline_prompt.to_string(),
+                merge_agent: inline_prompt.to_string(),
+            },
+            sources: LanePromptSources {
+                main_agent: source.clone(),
+                review_agent: source.clone(),
+                merge_agent: source,
+            },
         });
     };
 
@@ -185,18 +250,35 @@ fn load_lane_prompts(
         WorkflowError::InvalidLanePromptConfig("prompts must be a map/object".into())
     })?;
 
-    Ok(LanePromptTemplates {
-        main_agent: read_lane_prompt(workflow_path, prompt_config, "main_agent")?,
-        review_agent: read_lane_prompt(workflow_path, prompt_config, "review_agent")?,
-        merge_agent: read_lane_prompt(workflow_path, prompt_config, "merge_agent")?,
+    let main_agent = read_lane_prompt(workflow_path, prompt_config, "main_agent")?;
+    let review_agent = read_lane_prompt(workflow_path, prompt_config, "review_agent")?;
+    let merge_agent = read_lane_prompt(workflow_path, prompt_config, "merge_agent")?;
+
+    Ok(LanePromptBundle {
+        templates: LanePromptTemplates {
+            main_agent: main_agent.template,
+            review_agent: review_agent.template,
+            merge_agent: merge_agent.template,
+        },
+        sources: LanePromptSources {
+            main_agent: main_agent.source,
+            review_agent: review_agent.source,
+            merge_agent: merge_agent.source,
+        },
     })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LoadedLanePrompt {
+    template: String,
+    source: PromptTemplateSource,
 }
 
 fn read_lane_prompt(
     workflow_path: &Path,
     prompt_config: &serde_json::Map<String, Value>,
     lane: &'static str,
-) -> Result<String, WorkflowError> {
+) -> Result<LoadedLanePrompt, WorkflowError> {
     let relative_path = prompt_config
         .get(lane)
         .and_then(Value::as_str)
@@ -209,6 +291,13 @@ fn read_lane_prompt(
     let path = resolve_workflow_relative_path(workflow_path, relative_path);
     fs::read_to_string(&path)
         .map(|content| content.trim().to_string())
+        .map(|template| LoadedLanePrompt {
+            template,
+            source: PromptTemplateSource {
+                kind: PromptTemplateSourceKind::WorkflowPromptFile,
+                path: Some(path.clone()),
+            },
+        })
         .map_err(|source| WorkflowError::MissingLanePrompt { lane, path, source })
 }
 
@@ -259,6 +348,13 @@ mod tests {
             workflow.prompt_for_lane(AgentLane::MergeAgent),
             "Only prompt"
         );
+        assert_eq!(
+            workflow
+                .prompt_source_for_lane(AgentLane::MainAgent)
+                .kind
+                .as_str(),
+            "inline_workflow_fallback"
+        );
     }
 
     #[test]
@@ -302,6 +398,21 @@ mod tests {
             "Merge {{ issue.identifier }}"
         );
         assert_eq!(workflow.prompt_template, "Main {{ issue.identifier }}");
+        assert_eq!(
+            workflow
+                .prompt_source_for_lane(AgentLane::MainAgent)
+                .kind
+                .as_str(),
+            "workflow_prompt_file"
+        );
+        assert_eq!(
+            workflow
+                .prompt_source_for_lane(AgentLane::ReviewAgent)
+                .path
+                .as_ref()
+                .unwrap(),
+            &temp.path().join("prompts/review.md")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Implements #326: Make prompt injection workflow-configurable and centralize CLI runtime envelopes.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #326
