### PR TITLE
#435: Make all workpad content workflow-configurable

### DIFF
--- a/src/commands/forge/rework.rs
+++ b/src/commands/forge/rework.rs
@@ -4,6 +4,7 @@ use shea_symphony::config::RuntimeConfig;
 use shea_symphony::lane_claim::{LaneClaim, LaneClaimLane};
 use shea_symphony::model::{normalize_state, TrackerIssue};
 use shea_symphony::tracker::{adapter_from_config, TrackerAdapter};
+use shea_symphony::workpad_templates::{render_workpad_template, WorkpadTemplateId};
 
 use crate::cli::ForgeStatusArg;
 use crate::commands::session::timeline_pr_summary;
@@ -303,70 +304,37 @@ fn render_forge_rework_workpad(
     evidence: &str,
     generated_readbacks: &[String],
 ) -> String {
-    let mut lines = vec![
-        "## Shea Symphony Rework Run".to_string(),
-        String::new(),
-        format!("- Generated at: `{}`", current_gmt_timestamp()),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        "- Lane: `main`".into(),
-        "- Actor role: `human_review_revision`".into(),
-        "- Actor: `operator`".into(),
-        "- Run ID: `forge-rework`".into(),
-        "- Run type: `human_review_rework_revision`".into(),
-        "- Input state: `Human Review`".into(),
-        "- Target state after run: `Rework`".into(),
-        "- Result: `rework_revision_recorded`".into(),
-        format!("- PR: `{}`", timeline_pr_summary(issue)),
-        format!("- Replacement Rework title/status: `{rework_title}` / `Rework`"),
-        format!("- Operator confirmation: {operator_confirmation:?}"),
-        "- Evidence summary: operator confirmation, replacement contract, and readback evidence recorded.".into(),
-        "- Source state validated as `Human Review` before mutation.".into(),
-        "- Terminal lane claims, when present, were preserved as audit pointers.".into(),
-        "- Active lane claims in `Human Review` are rejected before content or status writes."
-            .into(),
-        "- Replacement body was written and read back before the final Project status mutation."
-            .into(),
-        "- Final Project status mutation is `Rework`.".into(),
-        String::new(),
-        "### Rework Direction".into(),
-        String::new(),
-        evidence.trim().to_string(),
-        String::new(),
-        "### Verification Readback".into(),
-        String::new(),
-    ];
-    push_markdown_bullets(&mut lines, generated_readbacks);
-    lines.extend([
-        String::new(),
-        "### Role Boundary".into(),
-        String::new(),
-        "- Main Agent may claim `Rework`, repair the revised contract, and stop at `Agent Review`."
-            .into(),
-        "- `Human Review` remains reserved for independent Review Agent pass evidence.".into(),
-    ]);
-    lines.join("\n")
+    let mut readback_lines = Vec::new();
+    push_markdown_bullets(&mut readback_lines, generated_readbacks);
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::ForgeReworkRun,
+        &[
+            ("generated_at", current_gmt_timestamp()),
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("pr", timeline_pr_summary(issue)),
+            ("rework_title", rework_title.into()),
+            (
+                "operator_confirmation",
+                format!("{operator_confirmation:?}"),
+            ),
+            ("evidence", evidence.trim().into()),
+            ("readbacks", readback_lines.join("\n")),
+        ],
+    )
 }
 
 fn render_forge_rework_blocked_workpad(issue: &TrackerIssue, reason: &str) -> String {
-    [
-        "## Shea Symphony Rework Run".to_string(),
-        String::new(),
-        format!("- Generated at: `{}`", current_gmt_timestamp()),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        "- Lane: `main`".into(),
-        "- Actor role: `human_review_revision`".into(),
-        "- Actor: `operator`".into(),
-        "- Run ID: `forge-rework`".into(),
-        "- Run type: `human_review_rework_revision`".into(),
-        "- Source state: `Human Review`".into(),
-        "- Target state after run: `unchanged`".into(),
-        "- Result: `blocked`".into(),
-        format!("- PR: `{}`", timeline_pr_summary(issue)),
-        format!("- Blocker: {reason}"),
-        "- Evidence summary: blocked rework revision recorded before any state mutation.".into(),
-        "- No replacement body was written.".into(),
-        "- Project status was not changed to `Rework`.".into(),
-        "- Resolve or supersede the active lane claim before retrying `forge rework`.".into(),
-    ]
-    .join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::ForgeReworkBlocked,
+        &[
+            ("generated_at", current_gmt_timestamp()),
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("pr", timeline_pr_summary(issue)),
+            ("reason", reason.into()),
+        ],
+    )
 }

--- a/src/commands/gate.rs
+++ b/src/commands/gate.rs
@@ -8,6 +8,7 @@ use shea_symphony::quality_gate::{
     evaluate_issue_with_source_alignment, LlmGateMode, LlmGateOptions,
 };
 use shea_symphony::tracker::adapter_from_config;
+use shea_symphony::workpad_templates::{render_workpad_template, WorkpadTemplateId};
 
 use crate::orchestration::{
     append_tracker_mutation_audit, live_github_tracker, load_config, progress_spec_for_config,
@@ -141,45 +142,39 @@ fn expected_target_repository(config: &RuntimeConfig) -> Option<String> {
 }
 
 pub(crate) fn gate_workpad(issue: &TrackerIssue, decision: &GateDecision) -> String {
-    let mut lines = vec![
-        "## Shea Symphony Workpad".to_string(),
-        String::new(),
-        "### Context".to_string(),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        format!("- Current state: {}", issue.state),
-        String::new(),
-        "### Decisions / Assumptions".to_string(),
-    ];
-
-    if decision.assumptions.is_empty() {
-        lines.push("- None recorded.".into());
+    let assumptions = if decision.assumptions.is_empty() {
+        "- None recorded.".into()
     } else {
-        lines.extend(decision.assumptions.iter().map(|item| format!("- {item}")));
-    }
+        decision
+            .assumptions
+            .iter()
+            .map(|item| format!("- {item}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    let missing = (!decision.missing.is_empty())
+        .then(|| format!("- Missing: {}", decision.missing.join(", ")))
+        .unwrap_or_default();
+    let notes = decision
+        .notes
+        .iter()
+        .map(|item| format!("- Note: {item}"))
+        .collect::<Vec<_>>()
+        .join("\n");
 
-    lines.extend([
-        String::new(),
-        "### Quality Gate".to_string(),
-        format!("- Decision: {:?}", decision.kind),
-    ]);
-
-    if !decision.missing.is_empty() {
-        lines.push(format!("- Missing: {}", decision.missing.join(", ")));
-    }
-    if !decision.notes.is_empty() {
-        lines.extend(decision.notes.iter().map(|item| format!("- Note: {item}")));
-    }
-
-    lines.extend([
-        String::new(),
-        "### Plan".to_string(),
-        "- [ ] Resolve quality-gate findings before dispatch.".to_string(),
-        String::new(),
-        "### Validation".to_string(),
-        "- [ ] Re-run `shea-symphony forge validate --issue` after issue updates.".to_string(),
-    ]);
-
-    lines.join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::MainQualityGate,
+        &[
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("current_state", issue.state.clone()),
+            ("assumptions", assumptions),
+            ("decision", format!("{:?}", decision.kind)),
+            ("missing", missing),
+            ("notes", notes),
+        ],
+    )
 }
 
 pub(crate) fn gate_target_state(decision: &GateDecision) -> &'static str {

--- a/src/commands/workflow.rs
+++ b/src/commands/workflow.rs
@@ -5,6 +5,7 @@ use shea_symphony::progress::run_with_progress_heartbeat;
 use shea_symphony::prompt_runtime::{PROMPT_RENDERER_MODE, RUNTIME_ENVELOPES};
 use shea_symphony::tracker::adapter_from_config;
 use shea_symphony::workflow::{AgentLane, WorkflowDefinition};
+use shea_symphony::workpad_templates::workpad_template_readback;
 
 use crate::commands::gate::evaluate_issue_for_current_source;
 use crate::commands::project::{filter_issues_by_state, render_state_summary};
@@ -47,6 +48,21 @@ pub(crate) fn validate(workflow_path: PathBuf) -> Result<(), Box<dyn std::error:
         println!(
             "runtime_envelope={} lane={} backend={} path={} purpose={}",
             envelope.id, envelope.lane, envelope.backend, envelope.path, envelope.purpose
+        );
+    }
+    for template in workpad_template_readback(&workflow) {
+        let diagnostic = template
+            .source
+            .diagnostic()
+            .map(|diagnostic| format!(" diagnostic={diagnostic}"))
+            .unwrap_or_default();
+        println!(
+            "workpad_template.{}={} path={} bytes={}{}",
+            template.id.key(),
+            template.source.kind(),
+            template.source.path_display(),
+            template.body.len(),
+            diagnostic
         );
     }
     println!("status=valid");

--- a/src/doctor/report.rs
+++ b/src/doctor/report.rs
@@ -1,6 +1,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::model::TrackerIssue;
+use crate::workpad_templates::{render_workpad_template, WorkpadTemplateId};
 
 use super::{
     claimed_main_agent, issue_refs_match,
@@ -15,61 +16,59 @@ pub fn render_doctor_repair_workpad(
     action: &str,
 ) -> String {
     let related = related_violations(report, &issue.identifier);
-    let mut lines = vec![
-        "## Shea Symphony Doctor Triage".to_string(),
-        String::new(),
-        format!("- Generated at: `{}`", current_gmt_timestamp()),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        "- Lane: `doctor`".to_string(),
-        "- Actor role: `doctor`".to_string(),
-        "- Actor: `shea-symphony doctor`".to_string(),
-        "- Run ID: `doctor-repair`".to_string(),
-        format!("- Input state: `{}`", issue.state),
-        format!(
-            "- Target state after repair: `{}`",
-            doctor_target_state(action)
-        ),
-        format!("- Result: `{}`", doctor_result(action)),
-        format!("- Requested action: `{action}`"),
-    ];
+    let mut extra_lines = Vec::new();
 
     if let Some(main_agent) = claimed_main_agent(issue) {
-        lines.push(format!("- Main Agent: `{main_agent}`"));
+        extra_lines.push(format!("- Main Agent: `{main_agent}`"));
     }
     if let Some(branch) = issue.branch_name.as_deref() {
-        lines.push(format!("- Tracker branch: `{branch}`"));
+        extra_lines.push(format!("- Tracker branch: `{branch}`"));
     }
     if has_pr_url(issue) {
         let targets = reliable_pr_targets(issue).join(", ");
-        lines.push(format!("- PR evidence: `{targets}`"));
+        extra_lines.push(format!("- PR evidence: `{targets}`"));
     } else {
-        lines.push("- PR evidence: `not recorded`".into());
-    }
-    lines.push(format!(
-        "- Evidence summary: {} issue-specific doctor finding(s) captured before repair.",
-        related.len()
-    ));
-
-    lines.extend([String::new(), "### Doctor Findings".to_string()]);
-    if related.is_empty() {
-        lines.push("- No issue-specific doctor violations were found.".to_string());
-    } else {
-        for violation in related {
-            lines.push(format!(
-                "- `{}` ({:?}): {}",
-                violation.code, violation.severity, violation.message
-            ));
-        }
+        extra_lines.push("- PR evidence: `not recorded`".into());
     }
 
-    lines.extend([
-        String::new(),
-        "### State Boundary".to_string(),
-        "- Doctor repair records evidence before any tracker mutation.".to_string(),
-        "- This repair does not delete worktrees, discard local work, or bypass review/merge lane authority.".to_string(),
-    ]);
+    let doctor_findings = if related.is_empty() {
+        "- No issue-specific doctor violations were found.".to_string()
+    } else {
+        related
+            .iter()
+            .map(|violation| {
+                format!(
+                    "- `{}` ({:?}): {}",
+                    violation.code, violation.severity, violation.message
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
 
-    lines.join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::DoctorTriage,
+        &[
+            ("generated_at", current_gmt_timestamp()),
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("run_id", "doctor-repair".into()),
+            ("input_state", issue.state.clone()),
+            ("target_state", doctor_target_state(action).into()),
+            ("result", doctor_result(action).into()),
+            ("action", action.into()),
+            ("extra_lines", extra_lines.join("\n")),
+            (
+                "evidence_summary",
+                format!(
+                    "{} issue-specific doctor finding(s) captured before repair.",
+                    related.len()
+                ),
+            ),
+            ("doctor_findings", doctor_findings),
+        ],
+    )
 }
 
 pub fn render_project_audit_report(report: &ProjectAuditReport) -> String {
@@ -129,30 +128,19 @@ pub fn draft_pr_repair_candidates(report: &ProjectAuditReport) -> Vec<&ProjectAu
 }
 
 pub fn render_human_review_repair_workpad(violation: &ProjectAuditViolation) -> String {
-    [
-        "## Shea Symphony Doctor Triage".to_string(),
-        String::new(),
-        format!("- Generated at: `{}`", current_gmt_timestamp()),
-        format!("- Issue: {} {}", violation.issue_ref, violation.title),
-        "- Lane: `doctor`".into(),
-        "- Actor role: `doctor`".into(),
-        "- Actor: `shea-symphony doctor`".into(),
-        "- Run ID: `doctor-human-review-repair`".into(),
-        format!("- Input state: `{}`", violation.state),
-        "- Target state after repair: `Agent Review`".into(),
-        "- Result: `repair_recorded`".into(),
-        "- PR evidence: `not recorded`".into(),
-        format!("- Violation: `{}`", violation.code),
-        format!("- Previous state: `{}`", violation.state),
-        format!("- Message: {}", violation.message),
-        format!("- Repair: {}", violation.suggestion),
-        "- Evidence summary: invalid Human Review boundary repair evidence recorded before tracker mutation.".to_string(),
-        String::new(),
-        "### State Boundary".to_string(),
-        "- Main implementation agent is moving this issue back to `Agent Review`.".to_string(),
-        "- This repair does not set `Human Review`; that state requires independent Review Agent pass evidence.".to_string(),
-    ]
-    .join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::HumanReviewRepair,
+        &[
+            ("generated_at", current_gmt_timestamp()),
+            ("issue_ref", violation.issue_ref.clone()),
+            ("issue_title", violation.title.clone()),
+            ("input_state", violation.state.clone()),
+            ("violation_code", violation.code.clone()),
+            ("message", violation.message.clone()),
+            ("repair", violation.suggestion.clone()),
+        ],
+    )
 }
 
 pub fn render_project_audit_report_json(

--- a/src/lanes/main_loop/handoff.rs
+++ b/src/lanes/main_loop/handoff.rs
@@ -18,6 +18,7 @@ use shea_symphony::ownership::{render_runtime_ownership_marker, RuntimeOwnership
 use shea_symphony::profiles::selected_execution_profile;
 use shea_symphony::runtime_state::RuntimeState;
 use shea_symphony::tracker::TrackerAdapter;
+use shea_symphony::workpad_templates::{render_workpad_template, WorkpadTemplateId};
 use shea_symphony::workspace::run_workspace_command;
 
 use super::IssueExecutionResult;
@@ -530,20 +531,21 @@ pub(crate) fn run_loop_ownership_workpad(
     event: &str,
     claim: &LaneClaim,
 ) -> String {
-    [
-        "## Shea Symphony Workpad".to_string(),
-        String::new(),
-        "### Runtime Ownership".to_string(),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        format!("- Event: `{event}`"),
-        format!("- Run: `{}`", claim.run),
-        format!("- Claim: `{}`", claim.render()),
-        "- This marker is advisory tracker-visible ownership for active `In Progress` work.".into(),
-        "- Another main loop profile should not resume this issue when the marker differs.".into(),
-        String::new(),
-        render_runtime_ownership_marker(ownership),
-    ]
-    .join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::MainRuntimeOwnership,
+        &[
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("event", event.into()),
+            ("run", claim.run.clone()),
+            ("claim", claim.render()),
+            (
+                "runtime_ownership_marker",
+                render_runtime_ownership_marker(ownership),
+            ),
+        ],
+    )
 }
 
 pub(crate) fn run_loop_live_handoff_enabled(config: &RuntimeConfig) -> bool {
@@ -609,33 +611,7 @@ pub(crate) fn run_loop_handoff_workpad(
     handoff: &IssueHandoffPlan,
     ownership: Option<&RuntimeOwnershipMarker>,
 ) -> String {
-    let mut lines = vec![
-        "## Shea Symphony Workpad".to_string(),
-        String::new(),
-        "### Context".to_string(),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        "- Source: `shea-symphony main loop`".to_string(),
-        String::new(),
-        "### Plan".to_string(),
-        "- [x] Read the issue contract, Project state, Main Workpad, and timeline evidence."
-            .to_string(),
-        "- [x] Prepare or resume the isolated issue workspace and branch.".to_string(),
-        "- [x] Run the configured Main Agent backend for the implementation slice.".to_string(),
-        "- [x] Verify handoff evidence and prepare the PR for Agent Review.".to_string(),
-        String::new(),
-        "### Work Log".to_string(),
-        format!(
-            "- Run `{}` executed with backend `{}`.",
-            result.run_id.as_deref().unwrap_or("n/a"),
-            result.backend
-        ),
-        format!(
-            "- Workspace `{}` was used for implementation evidence.",
-            result.workspace_path.display()
-        ),
-        format!("- Backend message: {}", result.message),
-        String::new(),
-        "### Run Evidence".to_string(),
+    let run_evidence = [
         format!("- Run: `{}`", result.run_id.as_deref().unwrap_or("n/a")),
         format!("- Workspace: `{}`", result.workspace_path.display()),
         format!("- Backend: `{}`", result.backend),
@@ -680,8 +656,9 @@ pub(crate) fn run_loop_handoff_workpad(
                 .unwrap_or_else(|| "n/a".into())
         ),
         format!("- Message: {}", result.message),
-        String::new(),
-        "### Planned Handoff".to_string(),
+    ]
+    .join("\n");
+    let planned_handoff = [
         format!("- Workspace key: `{}`", handoff.workspace_key),
         format!("- Workspace path: `{}`", handoff.workspace_path.display()),
         format!("- Branch: `{}`", handoff.branch_name),
@@ -692,18 +669,32 @@ pub(crate) fn run_loop_handoff_workpad(
         rework_continuation_workpad_line(handoff),
         handoff_verification_workpad_line(result),
         live_handoff_workpad_line(result),
-        String::new(),
-        "### Main-Agent Boundary".to_string(),
-        "- Locally complete main-agent work stops at `Agent Review`.".to_string(),
-        "- `Human Review` is reserved for independent Review Agent pass evidence.".to_string(),
-    ];
+    ]
+    .join("\n");
 
-    if let Some(ownership) = ownership {
-        lines.push(String::new());
-        lines.push(render_runtime_ownership_marker(ownership));
-    }
-
-    lines.join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::MainHandoff,
+        &[
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("run_id", result.run_id.as_deref().unwrap_or("n/a").into()),
+            ("backend", result.backend.clone()),
+            (
+                "workspace_path",
+                result.workspace_path.display().to_string(),
+            ),
+            ("message", result.message.clone()),
+            ("run_evidence", run_evidence),
+            ("planned_handoff", planned_handoff),
+            (
+                "runtime_ownership_marker",
+                ownership
+                    .map(render_runtime_ownership_marker)
+                    .unwrap_or_default(),
+            ),
+        ],
+    )
 }
 
 fn branch_target_workpad_line(handoff: &IssueHandoffPlan) -> String {
@@ -955,37 +946,28 @@ pub(crate) fn run_loop_handoff_failure_workpad(
     issue: &TrackerIssue,
     error: &HandoffError,
 ) -> String {
-    [
-        "## Shea Symphony Workpad".to_string(),
-        String::new(),
-        "### Context".to_string(),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        "- Source: `shea-symphony main loop`".to_string(),
-        String::new(),
-        "### Handoff Planning Blocker".to_string(),
-        format!("- Error: `{error}`"),
-        "- Backend execution was skipped before claim/run to avoid mixing issue scope.".to_string(),
-        String::new(),
-        "### Required Human Decision".to_string(),
-        "- Confirm the correct branch/workspace ownership before retrying.".to_string(),
-    ]
-    .join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::MainHandoffFailure,
+        &[
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("error", error.to_string()),
+        ],
+    )
 }
 
 pub(crate) fn run_loop_assignee_ownership_workpad(issue: &TrackerIssue, reason: &str) -> String {
-    [
-        "## Shea Symphony Workpad".to_string(),
-        String::new(),
-        "### Assignee Ownership Blocker".to_string(),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        format!("- Reason: {reason}"),
-        format!("- Issue assignees: `{}`", issue.assignees.join(", ")),
-        String::new(),
-        "### Boundary".to_string(),
-        "- Shea Symphony did not claim this issue or move it to `In Progress`.".to_string(),
-        "- Assign the issue to the active GitHub identity or selected execution profile before retrying.".to_string(),
-    ]
-    .join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::MainAssigneeOwnership,
+        &[
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("reason", reason.into()),
+            ("assignees", issue.assignees.join(", ")),
+        ],
+    )
 }
 
 pub(crate) fn run_loop_usage_limit_pause_workpad(
@@ -994,22 +976,16 @@ pub(crate) fn run_loop_usage_limit_pause_workpad(
     pause: &UsageLimitPause,
     retry_delay_ms: u64,
 ) -> String {
-    [
-        "## Shea Symphony Workpad".to_string(),
-        String::new(),
-        "### Usage-Limit Pause".to_string(),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        "- Source: `shea-symphony main loop`".to_string(),
-        format!("- Backend: `{}`", result.backend),
-        format!("- Classifier: `{}`", pause.classifier),
-        format!("- Evidence: {}", pause.evidence),
-        format!("- Retry backoff: `{retry_delay_ms}ms`"),
-        String::new(),
-        "### State Safety".to_string(),
-        "- Tracker state was not advanced to `Agent Review`.".to_string(),
-        "- Runtime state keeps the active issue and next retry time.".to_string(),
-        "- The main loop will skip this issue until retry backoff expires or an operator intervenes."
-            .to_string(),
-    ]
-    .join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::MainUsageLimitPause,
+        &[
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("backend", result.backend.clone()),
+            ("classifier", pause.classifier.clone()),
+            ("evidence", pause.evidence.clone()),
+            ("retry_delay_ms", retry_delay_ms.to_string()),
+        ],
+    )
 }

--- a/src/lanes/main_loop/write_candidate.rs
+++ b/src/lanes/main_loop/write_candidate.rs
@@ -10,6 +10,7 @@ use shea_symphony::runtime_state::{
 };
 use shea_symphony::tracker::TrackerAdapter;
 use shea_symphony::workflow::WorkflowDefinition;
+use shea_symphony::workpad_templates::{render_workpad_template, WorkpadTemplateId};
 
 use super::dispatch::RunLoopWorkerOutcome;
 mod live_handoff;
@@ -729,22 +730,19 @@ fn run_loop_parent_topology_workpad(
         .parent_final_base_branch
         .as_deref()
         .unwrap_or("n/a");
-    [
-        "## Shea Symphony Workpad".to_string(),
-        String::new(),
-        "### Parent Topology".to_string(),
-        format!(
-            "- Parent issue: {} {}",
-            parent_issue.identifier, parent_issue.title
-        ),
-        format!(
-            "- First observed subissue: {} {}",
-            issue.identifier, issue.title
-        ),
-        format!("- Parent integration branch: `{parent_integration_branch}`"),
-        format!("- Parent final base branch: `{parent_final_base_branch}`"),
-        "- Source: `shea-symphony main loop parent topology ensure`".to_string(),
-        "- Purpose: durable branch evidence before native subissue PR handoff.".to_string(),
-    ]
-    .join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::ParentTopology,
+        &[
+            ("parent_issue_ref", parent_issue.identifier.clone()),
+            ("parent_issue_title", parent_issue.title.clone()),
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            (
+                "parent_integration_branch",
+                parent_integration_branch.into(),
+            ),
+            ("parent_final_base_branch", parent_final_base_branch.into()),
+        ],
+    )
 }

--- a/src/lanes/review/automatic.rs
+++ b/src/lanes/review/automatic.rs
@@ -14,12 +14,12 @@ use shea_symphony::prompt::render_prompt;
 use shea_symphony::prompt_runtime::AUTOMATIC_HEADLESS_REVIEW_BOUNDARY;
 use shea_symphony::review::{
     gemini_cli_headless_args, gemini_prelaunch_health_diagnostic, gemini_review_health_diagnostic,
-    poll_review_job_until_terminal, render_repeated_review_failure_workpad, render_review_workpad,
-    review_failure_signature, review_gate_decision_for_issue, review_run_eligibility,
-    review_worker_key, transition_allowed_for_review_agent, write_review_job_ledger_record,
-    FakeReviewBackend, FakeReviewOutcome, GeminiCliReviewBackend, GeminiReviewRecoveryPolicy,
-    ReviewBackend, ReviewGateDecision, ReviewJob, ReviewJobState, ReviewOutcome,
-    ReviewRepeatedFailureEvidence, ReviewRequest, ReviewRunEligibility,
+    poll_review_job_until_terminal, render_repeated_review_failure_workpad,
+    render_review_workpad_with_workflow, review_failure_signature, review_gate_decision_for_issue,
+    review_run_eligibility, review_worker_key, transition_allowed_for_review_agent,
+    write_review_job_ledger_record, FakeReviewBackend, FakeReviewOutcome, GeminiCliReviewBackend,
+    GeminiReviewRecoveryPolicy, ReviewBackend, ReviewGateDecision, ReviewJob, ReviewJobState,
+    ReviewOutcome, ReviewRepeatedFailureEvidence, ReviewRequest, ReviewRunEligibility,
 };
 use shea_symphony::rework::rework_transition_expected;
 #[cfg(test)]
@@ -67,6 +67,7 @@ pub(crate) fn review_fake(
     let backend = FakeReviewBackend::new(outcome);
     let job = backend.poll(backend.start(request)?)?;
     apply_review_result(
+        Some(&workflow),
         &config,
         adapter.as_ref(),
         &issue_ref,
@@ -136,6 +137,7 @@ pub(crate) fn review_once(
         }
     };
     apply_review_result(
+        Some(&workflow),
         &config,
         adapter.as_ref(),
         &issue_ref,
@@ -535,6 +537,7 @@ pub(crate) fn review_loop(options: ReviewLoopOptions) -> Result<(), Box<dyn std:
             let repeat_evidence =
                 review_loop_repeated_failure_evidence(&mut failure_memory, &latest, &job);
             apply_review_result(
+                Some(&workflow),
                 &config,
                 adapter.as_ref(),
                 &latest.identifier,
@@ -898,6 +901,7 @@ impl ReviewLoopOptions {
 }
 
 pub(crate) fn apply_review_result(
+    workflow: Option<&WorkflowDefinition>,
     config: &RuntimeConfig,
     adapter: &dyn TrackerAdapter,
     issue_ref: &str,
@@ -930,14 +934,14 @@ pub(crate) fn apply_review_result(
             return Err("review agent transition is not allowed for this review decision".into());
         }
         if rework_transition_expected(&decision) {
-            transition_review_issue_to_rework_with_workpad(config, adapter, issue, job)?;
+            transition_review_issue_to_rework_with_workpad(workflow, config, adapter, issue, job)?;
             return Ok(());
         }
     }
 
     let workpad = repeat_evidence
         .map(|evidence| render_repeated_review_failure_workpad(issue, job, evidence))
-        .unwrap_or_else(|| render_review_workpad(issue, job));
+        .unwrap_or_else(|| render_review_workpad_with_workflow(workflow, issue, job));
     let evidence_key = recovery_key(
         "review-result",
         issue_ref,
@@ -1177,12 +1181,13 @@ pub(crate) fn transition_issue_to_rework_with_diagnostic(
 }
 
 fn transition_review_issue_to_rework_with_workpad(
+    workflow: Option<&WorkflowDefinition>,
     config: &RuntimeConfig,
     adapter: &dyn TrackerAdapter,
     issue: &TrackerIssue,
     job: &ReviewJob,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let workpad = render_review_workpad(issue, job);
+    let workpad = render_review_workpad_with_workflow(workflow, issue, job);
     let evidence_key = recovery_key(
         "review-rework",
         &issue.identifier,

--- a/src/lanes/review/manual.rs
+++ b/src/lanes/review/manual.rs
@@ -8,6 +8,7 @@ use shea_symphony::model::{normalize_state, TrackerIssue};
 use shea_symphony::progress::run_with_progress_heartbeat;
 use shea_symphony::review::review_pass_target_state;
 use shea_symphony::tracker::{adapter_from_config, ProjectFieldAssignment, TrackerAdapter};
+use shea_symphony::workpad_templates::{render_workpad_template, WorkpadTemplateId};
 
 use crate::commands::session::{
     record_manual_lane_claim_evidence, timeline_claim_actor, timeline_claim_run,
@@ -400,52 +401,41 @@ pub(crate) fn render_manual_review_workpad(
     current_claim_value: &str,
     terminal_claim_value: &str,
 ) -> String {
-    let mut lines = vec![
-        "## Shea Symphony Agent Review Run".to_string(),
-        String::new(),
-        format!("- Generated at: `{}`", current_gmt_timestamp()),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        "- Lane: `review`".into(),
-        "- Actor role: `review_agent`".into(),
-        format!(
-            "- Actor: `{}`",
-            timeline_claim_actor(current_claim_value).unwrap_or("manual-operator".into())
-        ),
-        format!(
-            "- Run ID: `{}`",
-            timeline_claim_run(current_claim_value).unwrap_or("not recorded".into())
-        ),
-        "- Input state: `Agent Review`".into(),
-        "- Reviewer backend: manual-operator".into(),
-        format!("- Decision: Manual independent review {decision}."),
-        format!("- Target state after review routing: `{target_state}`"),
-        format!("- Result: `{}`", if pass { "passed" } else { "rework" }),
-        format!("- PR: `{}`", timeline_pr_summary(issue)),
-        format!("- Review Agent claim: `{current_claim_value}`"),
-        format!("- Terminal Review Agent claim: `{terminal_claim_value}`"),
-        "- Evidence summary: manual review evidence captured below.".into(),
-        String::new(),
-        "### Manual Review Evidence".into(),
-        "````md".into(),
-    ];
-    lines.extend(evidence.trim().lines().map(str::to_string));
-    lines.push("````".into());
-    if pass {
-        lines.push(String::new());
-        lines.push("- Review pass evidence: `recorded`".into());
+    let result_note = if pass {
         if normalize_state(target_state) == "merging" {
-            lines.push("Evidence recorded. Independent Review Agent may move this native subissue directly to Merging; final Human Review and UAT remain owned by the parent issue.".into());
+            "- Review pass evidence: `recorded`\nEvidence recorded. Independent Review Agent may move this native subissue directly to Merging; final Human Review and UAT remain owned by the parent issue.".into()
         } else {
-            lines.push("Evidence recorded. Independent Review Agent may move this issue to Human Review; the main implementation agent must not.".into());
+            "- Review pass evidence: `recorded`\nEvidence recorded. Independent Review Agent may move this issue to Human Review; the main implementation agent must not.".into()
         }
     } else {
-        lines.push(String::new());
-        lines.push(
-            "- Review did not pass; unavailable or inconclusive review must not move to Human Review."
-                .into(),
-        );
-    }
-    lines.join("\n")
+        "- Review did not pass; unavailable or inconclusive review must not move to Human Review."
+            .into()
+    };
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::ManualReview,
+        &[
+            ("generated_at", current_gmt_timestamp()),
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            (
+                "actor",
+                timeline_claim_actor(current_claim_value).unwrap_or("manual-operator".into()),
+            ),
+            (
+                "run_id",
+                timeline_claim_run(current_claim_value).unwrap_or("not recorded".into()),
+            ),
+            ("decision", decision.into()),
+            ("target_state", target_state.into()),
+            ("result", if pass { "passed" } else { "rework" }.into()),
+            ("pr", timeline_pr_summary(issue)),
+            ("current_claim", current_claim_value.into()),
+            ("terminal_claim", terminal_claim_value.into()),
+            ("evidence", evidence.trim().into()),
+            ("result_note", result_note),
+        ],
+    )
 }
 
 pub(crate) fn validate_manual_review_pass_claim(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod skill_status;
 pub mod status_surface;
 pub mod tracker;
 pub mod workflow;
+pub mod workpad_templates;
 pub mod workspace;
 
 pub use config::RuntimeConfig;

--- a/src/main/tests/review.rs
+++ b/src/main/tests/review.rs
@@ -434,7 +434,7 @@ fn review_pass_updates_issue_body_checkboxes_before_human_review_transition() {
         error: None,
     };
 
-    apply_review_result(&config, &adapter, "#67", &issue, &job, None, None).unwrap();
+    apply_review_result(None, &config, &adapter, "#67", &issue, &job, None, None).unwrap();
 
     let updated = adapter
         .issues

--- a/src/merge_lane.rs
+++ b/src/merge_lane.rs
@@ -9,6 +9,7 @@ use crate::git_handoff::{CommandOutput, GitHandoffError, HandoffCommandRunner};
 use crate::handoff::branch_target_evidence;
 use crate::lane_claim::LaneClaim;
 use crate::model::{normalize_state, LinkedPullRequest, TrackerIssue};
+use crate::workpad_templates::{render_workpad_template, WorkpadTemplateId};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PullRequestMergeStatus {
@@ -695,64 +696,34 @@ pub fn merge_lane_workpad_with_repair_evidence(
     merge_output: Option<&CommandOutput>,
     repair_evidence: Option<&MergeRepairEvidence>,
 ) -> String {
-    let mut lines = vec![
-        "## Shea Symphony Merge Run".to_string(),
-        String::new(),
-        format!("- Generated at: `{}`", current_gmt_timestamp()),
-        format!("- Issue: {} {}", issue.identifier, issue.title),
-        "- Lane: `merge`".to_string(),
-        "- Actor role: `merge_agent`".to_string(),
+    let branch_target = branch_target_evidence(issue, expected_merge_base_branch_for_workpad());
+    let mut preflight = vec![
+        "- This lane only consumes issues already in `Merging`.".to_string(),
+        "- It must not move work into `Human Review`.".to_string(),
+        "- It records diagnostics before any tracker state transition.".to_string(),
         format!("- Actor: `{}`", merge_actor(issue)),
         format!("- Run ID: `{}`", merge_run_id(issue)),
         "- Source: `shea-symphony merge once`".to_string(),
         "- Input state: `Merging`".to_string(),
-        format!("- Decision: `{:?}`", decision.kind),
-        format!("- Result: `{}`", merge_result(decision)),
         format!("- Reason: {}", decision.reason),
+        "### Branch Target Evidence".to_string(),
+        format!("- Role: `{:?}`", branch_target.role),
         format!(
-            "- Pull request: `{}`",
-            decision.pr_url.as_deref().unwrap_or("missing")
+            "- Expected PR base branch: `{}`",
+            branch_target.pull_request_base_branch
         ),
-        format!(
-            "- Target state after merge routing: `{}`",
-            decision.target_state.unwrap_or("none")
-        ),
-        format!(
-            "- Evidence summary: merge decision `{}`; command evidence `{}`.",
-            merge_result(decision),
-            if merge_output.is_some() {
-                "recorded"
-            } else {
-                "not recorded"
-            }
-        ),
-        String::new(),
-        "### Authority Boundary".to_string(),
-        "- This lane only consumes issues already in `Merging`.".to_string(),
-        "- It must not move work into `Human Review`.".to_string(),
-        "- It records diagnostics before any tracker state transition.".to_string(),
     ];
-    let branch_target = branch_target_evidence(issue, expected_merge_base_branch_for_workpad());
-    lines.push(String::new());
-    lines.push("### Branch Target Evidence".to_string());
-    lines.push(format!("- Role: `{:?}`", branch_target.role));
-    lines.push(format!(
-        "- Expected PR base branch: `{}`",
-        branch_target.pull_request_base_branch
-    ));
     if let Some(parent_issue) = branch_target.parent_issue {
-        lines.push(format!("- Native parent issue: `{parent_issue}`"));
+        preflight.push(format!("- Native parent issue: `{parent_issue}`"));
     }
     if let Some(parent_integration_branch) = branch_target.parent_integration_branch {
-        lines.push(format!(
+        preflight.push(format!(
             "- Parent integration branch: `{parent_integration_branch}`"
         ));
     }
 
-    if let Some(output) = merge_output {
-        lines.extend([
-            String::new(),
-            "### Merge Command Evidence".to_string(),
+    let merge_action = if let Some(output) = merge_output {
+        [
             format!("- Exit status: `{}`", output.status),
             format!(
                 "- Stdout: `{}`",
@@ -762,13 +733,14 @@ pub fn merge_lane_workpad_with_repair_evidence(
                 "- Stderr: `{}`",
                 compact_merge_workpad_field(&output.stderr)
             ),
-        ]);
-    }
+        ]
+        .join("\n")
+    } else {
+        "- Merge command evidence: `not recorded`".into()
+    };
 
-    if let Some(evidence) = repair_evidence {
-        lines.extend([
-            String::new(),
-            "### Merge Repair Evidence".to_string(),
+    let merge_repair_evidence = if let Some(evidence) = repair_evidence {
+        [
             format!(
                 "- Method: `{}`",
                 compact_merge_workpad_field(&evidence.method)
@@ -797,14 +769,52 @@ pub fn merge_lane_workpad_with_repair_evidence(
                 "- Next-state rationale: {}",
                 compact_merge_workpad_field(&evidence.next_state_rationale)
             ),
-        ]);
-    }
+        ]
+        .join("\n")
+    } else {
+        "- Merge repair evidence: `not recorded`".into()
+    };
+    let post_merge_readback = "- Post-merge readback is recorded by the surrounding merge lane transition and tracker readback paths.".to_string();
 
-    if decision.target_state == Some("need_human_input") {
-        lines.extend(required_human_input_section(decision));
-    }
+    let required_human_input = if decision.target_state == Some("need_human_input") {
+        required_human_input_section(decision).join("\n")
+    } else {
+        String::new()
+    };
 
-    lines.join("\n")
+    render_workpad_template(
+        None,
+        WorkpadTemplateId::MergeRun,
+        &[
+            ("generated_at", current_gmt_timestamp()),
+            ("issue_ref", issue.identifier.clone()),
+            ("issue_title", issue.title.clone()),
+            ("result", merge_result(decision).into()),
+            (
+                "target_state",
+                decision.target_state.unwrap_or("none").into(),
+            ),
+            ("pr", decision.pr_url.as_deref().unwrap_or("missing").into()),
+            ("decision", format!("{:?}", decision.kind)),
+            (
+                "evidence_summary",
+                format!(
+                    "merge decision `{}`; command evidence `{}`.",
+                    merge_result(decision),
+                    if merge_output.is_some() {
+                        "recorded"
+                    } else {
+                        "not recorded"
+                    }
+                ),
+            ),
+            ("preflight", preflight.join("\n")),
+            ("merge_action", merge_action),
+            ("post_merge_readback", post_merge_readback),
+            ("merge_repair_evidence", merge_repair_evidence),
+            ("required_human_input", required_human_input),
+        ],
+    )
 }
 
 fn merge_actor(issue: &TrackerIssue) -> String {

--- a/src/review.rs
+++ b/src/review.rs
@@ -10,6 +10,8 @@ use serde::Deserialize;
 
 use crate::lane_claim::{LaneClaim, LaneClaimState};
 use crate::model::{normalize_state, TrackerIssue};
+use crate::workflow::WorkflowDefinition;
+use crate::workpad_templates::{render_workpad_template, WorkpadTemplateId};
 
 mod decision;
 mod freshness;
@@ -41,8 +43,6 @@ pub use report::{classify_findings, AgentReviewReport, ReviewFinding, ReviewFind
 use gemini_health::diagnose_gemini_spawn_failure;
 use job::review_job_id;
 
-const AGENT_REVIEW_WORKPAD_TEMPLATE: &str =
-    include_str!("../workflows/template/workpad/agent-review.md");
 const LOG_BLOCK_LIMIT: usize = 2_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -623,6 +623,14 @@ fn terminal_review_failure_marker_matches(value: &str, worker_key: &str) -> bool
 }
 
 pub fn render_review_workpad(issue: &TrackerIssue, job: &ReviewJob) -> String {
+    render_review_workpad_with_workflow(None, issue, job)
+}
+
+pub fn render_review_workpad_with_workflow(
+    workflow: Option<&WorkflowDefinition>,
+    issue: &TrackerIssue,
+    job: &ReviewJob,
+) -> String {
     let decision = review_gate_decision_for_issue(job, issue);
     let mut attempt_details = Vec::new();
     if let Some(error) = &job.error {
@@ -710,8 +718,9 @@ pub fn render_review_workpad(issue: &TrackerIssue, job: &ReviewJob) -> String {
         String::new()
     };
 
-    render_template(
-        AGENT_REVIEW_WORKPAD_TEMPLATE,
+    render_workpad_template(
+        workflow,
+        WorkpadTemplateId::AgentReviewRun,
         &[
             ("generated_at", current_gmt_timestamp()),
             ("issue_ref", issue.identifier.clone()),
@@ -827,14 +836,6 @@ fn render_parsed_findings_section(
     };
 
     render_section("Findings", &findings)
-}
-
-fn render_template(template: &str, replacements: &[(&str, String)]) -> String {
-    let mut rendered = template.to_string();
-    for (key, value) in replacements {
-        rendered = rendered.replace(&format!("{{{{{key}}}}}"), value);
-    }
-    rendered.trim_end().to_string()
 }
 
 fn render_section(title: &str, body: &str) -> String {

--- a/src/workpad_templates.rs
+++ b/src/workpad_templates.rs
@@ -1,0 +1,687 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::workflow::WorkflowDefinition;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WorkpadTemplateId {
+    MainHandoff,
+    MainHandoffFailure,
+    MainAssigneeOwnership,
+    MainQualityGate,
+    MainRuntimeOwnership,
+    MainUsageLimitPause,
+    ParentTopology,
+    WorkspaceAdoption,
+    WorkspaceEnsure,
+    AgentReviewRun,
+    AgentReviewHandoff,
+    RepeatedReviewFailure,
+    ManualReview,
+    MergeRun,
+    MergeRepair,
+    DoctorTriage,
+    HumanReviewRepair,
+    ForgeReworkRun,
+    ForgeReworkBlocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkpadTemplate {
+    pub id: WorkpadTemplateId,
+    pub body: String,
+    pub source: WorkpadTemplateSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkpadTemplateSource {
+    WorkflowFile(PathBuf),
+    CentralizedFallback,
+    MissingOrInvalid { path: PathBuf, error: String },
+}
+
+impl WorkpadTemplateId {
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::MainHandoff => "main_handoff",
+            Self::MainHandoffFailure => "main_handoff_failure",
+            Self::MainAssigneeOwnership => "main_assignee_ownership",
+            Self::MainQualityGate => "main_quality_gate",
+            Self::MainRuntimeOwnership => "main_runtime_ownership",
+            Self::MainUsageLimitPause => "main_usage_limit_pause",
+            Self::ParentTopology => "parent_topology",
+            Self::WorkspaceAdoption => "workspace_adoption",
+            Self::WorkspaceEnsure => "workspace_ensure",
+            Self::AgentReviewRun => "agent_review_run",
+            Self::AgentReviewHandoff => "agent_review_handoff",
+            Self::RepeatedReviewFailure => "repeated_review_failure",
+            Self::ManualReview => "manual_review",
+            Self::MergeRun => "merge_run",
+            Self::MergeRepair => "merge_repair",
+            Self::DoctorTriage => "doctor_triage",
+            Self::HumanReviewRepair => "human_review_repair",
+            Self::ForgeReworkRun => "forge_rework_run",
+            Self::ForgeReworkBlocked => "forge_rework_blocked",
+        }
+    }
+
+    pub fn all() -> &'static [Self] {
+        &[
+            Self::MainHandoff,
+            Self::MainHandoffFailure,
+            Self::MainAssigneeOwnership,
+            Self::MainQualityGate,
+            Self::MainRuntimeOwnership,
+            Self::MainUsageLimitPause,
+            Self::ParentTopology,
+            Self::WorkspaceAdoption,
+            Self::WorkspaceEnsure,
+            Self::AgentReviewRun,
+            Self::AgentReviewHandoff,
+            Self::RepeatedReviewFailure,
+            Self::ManualReview,
+            Self::MergeRun,
+            Self::MergeRepair,
+            Self::DoctorTriage,
+            Self::HumanReviewRepair,
+            Self::ForgeReworkRun,
+            Self::ForgeReworkBlocked,
+        ]
+    }
+}
+
+impl WorkpadTemplateSource {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::WorkflowFile(_) => "workflow_template_file",
+            Self::CentralizedFallback => "centralized_fallback_template",
+            Self::MissingOrInvalid { .. } => "missing_or_invalid_template",
+        }
+    }
+
+    pub fn path_display(&self) -> String {
+        match self {
+            Self::WorkflowFile(path) | Self::MissingOrInvalid { path, .. } => {
+                path.display().to_string()
+            }
+            Self::CentralizedFallback => "<centralized fallback>".into(),
+        }
+    }
+
+    pub fn diagnostic(&self) -> Option<&str> {
+        match self {
+            Self::MissingOrInvalid { error, .. } => Some(error),
+            _ => None,
+        }
+    }
+}
+
+pub fn workpad_template_for(
+    workflow: Option<&WorkflowDefinition>,
+    id: WorkpadTemplateId,
+) -> WorkpadTemplate {
+    if let Some(workflow) = workflow {
+        if let Some(path) = configured_template_path(workflow, id) {
+            return match fs::read_to_string(&path) {
+                Ok(body) if !body.trim().is_empty() => WorkpadTemplate {
+                    id,
+                    body: body.trim().to_string(),
+                    source: WorkpadTemplateSource::WorkflowFile(path),
+                },
+                Ok(_) => WorkpadTemplate {
+                    id,
+                    body: fallback_template(id).to_string(),
+                    source: WorkpadTemplateSource::MissingOrInvalid {
+                        path,
+                        error: "template file is empty; fallback will be used".into(),
+                    },
+                },
+                Err(error) => WorkpadTemplate {
+                    id,
+                    body: fallback_template(id).to_string(),
+                    source: WorkpadTemplateSource::MissingOrInvalid {
+                        path,
+                        error: error.to_string(),
+                    },
+                },
+            };
+        }
+    }
+
+    WorkpadTemplate {
+        id,
+        body: fallback_template(id).to_string(),
+        source: WorkpadTemplateSource::CentralizedFallback,
+    }
+}
+
+pub fn workpad_template_readback(workflow: &WorkflowDefinition) -> Vec<WorkpadTemplate> {
+    WorkpadTemplateId::all()
+        .iter()
+        .map(|id| workpad_template_for(Some(workflow), *id))
+        .collect()
+}
+
+pub fn render_workpad_template(
+    workflow: Option<&WorkflowDefinition>,
+    id: WorkpadTemplateId,
+    values: &[(&str, String)],
+) -> String {
+    render_template(&workpad_template_for(workflow, id).body, values)
+}
+
+pub fn render_template(template: &str, values: &[(&str, String)]) -> String {
+    let mut rendered = template.to_string();
+    for (key, value) in values {
+        rendered = rendered.replace(&format!("{{{{{key}}}}}"), value);
+    }
+    rendered.trim_end().to_string()
+}
+
+fn configured_template_path(
+    workflow: &WorkflowDefinition,
+    id: WorkpadTemplateId,
+) -> Option<PathBuf> {
+    let config = workflow.config.get("workpad_templates")?;
+    let map = config.as_object()?;
+    let relative = map.get(id.key())?.as_str()?.trim();
+    (!relative.is_empty()).then(|| resolve_workflow_relative_path(&workflow.path, relative))
+}
+
+fn resolve_workflow_relative_path(workflow_path: &Path, value: &str) -> PathBuf {
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        path
+    } else {
+        workflow_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(path)
+    }
+}
+
+fn fallback_template(id: WorkpadTemplateId) -> &'static str {
+    match id {
+        WorkpadTemplateId::MainHandoff => MAIN_HANDOFF,
+        WorkpadTemplateId::MainHandoffFailure => MAIN_HANDOFF_FAILURE,
+        WorkpadTemplateId::MainAssigneeOwnership => MAIN_ASSIGNEE_OWNERSHIP,
+        WorkpadTemplateId::MainQualityGate => MAIN_QUALITY_GATE,
+        WorkpadTemplateId::MainRuntimeOwnership => MAIN_RUNTIME_OWNERSHIP,
+        WorkpadTemplateId::MainUsageLimitPause => MAIN_USAGE_LIMIT_PAUSE,
+        WorkpadTemplateId::ParentTopology => PARENT_TOPOLOGY,
+        WorkpadTemplateId::WorkspaceAdoption => WORKSPACE_ADOPTION,
+        WorkpadTemplateId::WorkspaceEnsure => WORKSPACE_ENSURE,
+        WorkpadTemplateId::AgentReviewRun => AGENT_REVIEW_RUN,
+        WorkpadTemplateId::AgentReviewHandoff => AGENT_REVIEW_HANDOFF,
+        WorkpadTemplateId::RepeatedReviewFailure => REPEATED_REVIEW_FAILURE,
+        WorkpadTemplateId::ManualReview => MANUAL_REVIEW,
+        WorkpadTemplateId::MergeRun => MERGE_RUN,
+        WorkpadTemplateId::MergeRepair => MERGE_REPAIR,
+        WorkpadTemplateId::DoctorTriage => DOCTOR_TRIAGE,
+        WorkpadTemplateId::HumanReviewRepair => HUMAN_REVIEW_REPAIR,
+        WorkpadTemplateId::ForgeReworkRun => FORGE_REWORK_RUN,
+        WorkpadTemplateId::ForgeReworkBlocked => FORGE_REWORK_BLOCKED,
+    }
+}
+
+pub fn configured_workpad_template_paths(config: &Value) -> BTreeMap<String, String> {
+    config
+        .get("workpad_templates")
+        .and_then(Value::as_object)
+        .map(|map| {
+            map.iter()
+                .filter_map(|(key, value)| value.as_str().map(|path| (key.clone(), path.into())))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+const MAIN_HANDOFF: &str = r#"## Shea Symphony Workpad
+
+### Context
+- Issue: {{issue_ref}} {{issue_title}}
+- Source: `shea-symphony main loop`
+
+### Plan
+- [x] Read the issue contract, Project state, Main Workpad, and timeline evidence.
+- [x] Prepare or resume the isolated issue workspace and branch.
+- [x] Run the configured Main Agent backend for the implementation slice.
+- [x] Verify handoff evidence and prepare the PR for Agent Review.
+
+### Work Log
+- Run `{{run_id}}` executed with backend `{{backend}}`.
+- Workspace `{{workspace_path}}` was used for implementation evidence.
+- Backend message: {{message}}
+
+### Run Evidence
+{{run_evidence}}
+
+### Planned Handoff
+{{planned_handoff}}
+
+### Main-Agent Boundary
+- Locally complete main-agent work stops at `Agent Review`.
+- `Human Review` is reserved for independent Review Agent pass evidence.
+
+{{runtime_ownership_marker}}"#;
+
+const MAIN_RUNTIME_OWNERSHIP: &str = r#"## Shea Symphony Workpad
+
+### Runtime Ownership
+- Issue: {{issue_ref}} {{issue_title}}
+- Event: `{{event}}`
+- Run: `{{run}}`
+- Claim: `{{claim}}`
+- This marker is advisory tracker-visible ownership for active `In Progress` work.
+- Another main loop profile should not resume this issue when the marker differs.
+
+{{runtime_ownership_marker}}"#;
+
+const MAIN_HANDOFF_FAILURE: &str = r#"## Shea Symphony Workpad
+
+### Context
+- Issue: {{issue_ref}} {{issue_title}}
+- Source: `shea-symphony main loop`
+
+### Handoff Planning Blocker
+- Error: `{{error}}`
+- Backend execution was skipped before claim/run to avoid mixing issue scope.
+
+### Required Human Decision
+- Confirm the correct branch/workspace ownership before retrying."#;
+
+const MAIN_ASSIGNEE_OWNERSHIP: &str = r#"## Shea Symphony Workpad
+
+### Assignee Ownership Blocker
+- Issue: {{issue_ref}} {{issue_title}}
+- Reason: {{reason}}
+- Issue assignees: `{{assignees}}`
+
+### Boundary
+- Shea Symphony did not claim this issue or move it to `In Progress`.
+- Assign the issue to the active GitHub identity or selected execution profile before retrying."#;
+
+const MAIN_QUALITY_GATE: &str = r#"## Shea Symphony Workpad
+
+### Context
+- Issue: {{issue_ref}} {{issue_title}}
+- Current state: {{current_state}}
+
+### Decisions / Assumptions
+{{assumptions}}
+
+### Quality Gate
+- Decision: {{decision}}
+{{missing}}
+{{notes}}
+
+### Plan
+- [ ] Resolve quality-gate findings before dispatch.
+
+### Validation
+- [ ] Re-run `shea-symphony forge validate --issue` after issue updates."#;
+
+const MAIN_USAGE_LIMIT_PAUSE: &str = r#"## Shea Symphony Workpad
+
+### Usage-Limit Pause
+- Issue: {{issue_ref}} {{issue_title}}
+- Source: `shea-symphony main loop`
+- Backend: `{{backend}}`
+- Classifier: `{{classifier}}`
+- Evidence: {{evidence}}
+- Retry backoff: `{{retry_delay_ms}}ms`
+
+### State Safety
+- Tracker state was not advanced to `Agent Review`.
+- Runtime state keeps the active issue and next retry time.
+- The main loop will skip this issue until retry backoff expires or an operator intervenes."#;
+
+const PARENT_TOPOLOGY: &str = r#"## Shea Symphony Workpad
+
+### Parent Topology
+- Parent issue: {{parent_issue_ref}} {{parent_issue_title}}
+- First observed subissue: {{issue_ref}} {{issue_title}}
+- Parent integration branch: `{{parent_integration_branch}}`
+- Parent final base branch: `{{parent_final_base_branch}}`
+- Source: `shea-symphony main loop parent topology ensure`
+- Purpose: durable branch evidence before native subissue PR handoff."#;
+
+const WORKSPACE_ADOPTION: &str = r#"## Shea Symphony Workspace Adoption
+
+- Issue: {{issue_ref}} {{issue_title}}
+- Workspace path: `{{workspace_path}}`
+- Branch: `{{branch}}`
+- Head: `{{head}}`
+- Evidence summary: {{evidence_summary}}"#;
+
+const WORKSPACE_ENSURE: &str = r#"## Shea Symphony Workspace Ensure
+
+- Issue: {{issue_ref}} {{issue_title}}
+- Workspace path: `{{workspace_path}}`
+- Branch: `{{branch}}`
+- Source: `workspace ensure`
+- Evidence summary: {{evidence_summary}}"#;
+
+const AGENT_REVIEW_RUN: &str = include_str!("../workflows/template/workpad/agent-review.md");
+
+const AGENT_REVIEW_HANDOFF: &str = r#"## Shea Symphony Agent Review Handoff
+
+- Issue: {{issue_ref}} {{issue_title}}
+- Status: `{{status}}`
+- Target state after handoff: `{{target_state}}`
+- PR: `{{pull_request}}`
+- Project linked PR verified: `{{project_pr_link_verified}}`
+- PR draft: `{{pull_request_is_draft}}`
+- Validation: {{validation_summary}}
+- Last transition: {{last_transition}}
+
+### Missing Handoff Evidence
+{{missing}}
+
+### Boundary
+- Main implementation agent stops at `Agent Review`.
+- Independent Review Agent owns review evidence and any later Human Review routing."#;
+
+const REPEATED_REVIEW_FAILURE: &str = r#"## Shea Symphony Agent Review Run
+
+### Repeated Backend Failure
+- Generated at: `{{generated_at}}`
+- Issue: {{issue_ref}} {{issue_title}}
+- Worker key: `{{worker_key}}`
+- Reviewer backend: `{{reviewer_backend}}`
+- Job state: `{{job_state}}`
+- Current job id: `{{job_id}}`
+- First same-cause job id: `{{first_job_id}}`
+- Previous same-cause job id: `{{previous_job_id}}`
+- Same-cause repeat count: `{{repeat_count}}`
+- Failure signature: `{{signature}}`
+- Decision: {{decision}}
+- Target state after review routing: `{{target_state}}`
+- Evidence policy: compact repeat line only; full diagnostic was already recorded for the first same-cause attempt.
+{{ledger_line}}
+{{gemini_health_lines}}"#;
+
+const MANUAL_REVIEW: &str = r#"## Shea Symphony Agent Review Run
+
+- Generated at: `{{generated_at}}`
+- Issue: {{issue_ref}} {{issue_title}}
+- Lane: `review`
+- Actor role: `review_agent`
+- Actor: `{{actor}}`
+- Run ID: `{{run_id}}`
+- Input state: `Agent Review`
+- Reviewer backend: manual-operator
+- Decision: Manual independent review {{decision}}.
+- Target state after review routing: `{{target_state}}`
+- Result: `{{result}}`
+- PR: `{{pr}}`
+- Review Agent claim: `{{current_claim}}`
+- Terminal Review Agent claim: `{{terminal_claim}}`
+- Evidence summary: manual review evidence captured below.
+
+### Manual Review Evidence
+````md
+{{evidence}}
+````
+{{result_note}}"#;
+
+const MERGE_RUN: &str = r#"## Shea Symphony Merge Run
+
+- Generated at: `{{generated_at}}`
+- Issue: {{issue_ref}} {{issue_title}}
+- Lane: `merge`
+- Actor role: `merge_agent`
+- Result: `{{result}}`
+- Target state after merge routing: `{{target_state}}`
+- PR: `{{pr}}`
+- Decision: `{{decision}}`
+- Evidence summary: {{evidence_summary}}
+
+### Preflight
+{{preflight}}
+
+### Merge Action
+{{merge_action}}
+
+### Post-Merge Readback
+{{post_merge_readback}}
+
+### Merge Repair Evidence
+{{merge_repair_evidence}}
+
+{{required_human_input}}"#;
+
+const MERGE_REPAIR: &str = r#"## Shea Symphony Merge Repair
+
+- Generated at: `{{generated_at}}`
+- Issue: {{issue_ref}} {{issue_title}}
+- PR: `{{pr}}`
+- Result: `{{result}}`
+- Evidence summary: {{evidence_summary}}
+
+### Repair Evidence
+{{repair_evidence}}
+
+### Boundary
+- Merge-lane repair records evidence before tracker routing."#;
+
+const DOCTOR_TRIAGE: &str = r#"## Shea Symphony Doctor Triage
+
+- Generated at: `{{generated_at}}`
+- Issue: {{issue_ref}} {{issue_title}}
+- Lane: `doctor`
+- Actor role: `doctor`
+- Actor: `shea-symphony doctor`
+- Run ID: `{{run_id}}`
+- Input state: `{{input_state}}`
+- Target state after repair: `{{target_state}}`
+- Result: `{{result}}`
+- Requested action: `{{action}}`
+{{extra_lines}}
+- Evidence summary: {{evidence_summary}}
+
+### Doctor Findings
+{{doctor_findings}}
+
+### State Boundary
+- Doctor repair records evidence before any tracker mutation.
+- This repair does not delete worktrees, discard local work, or bypass review/merge lane authority."#;
+
+const HUMAN_REVIEW_REPAIR: &str = r#"## Shea Symphony Doctor Triage
+
+- Generated at: `{{generated_at}}`
+- Issue: {{issue_ref}} {{issue_title}}
+- Lane: `doctor`
+- Actor role: `doctor`
+- Actor: `shea-symphony doctor`
+- Run ID: `doctor-human-review-repair`
+- Input state: `{{input_state}}`
+- Target state after repair: `Agent Review`
+- Result: `repair_recorded`
+- PR evidence: `not recorded`
+- Violation: `{{violation_code}}`
+- Previous state: `{{input_state}}`
+- Message: {{message}}
+- Repair: {{repair}}
+- Evidence summary: invalid Human Review boundary repair evidence recorded before tracker mutation.
+
+### State Boundary
+- Main implementation agent is moving this issue back to `Agent Review`.
+- This repair does not set `Human Review`; that state requires independent Review Agent pass evidence."#;
+
+const FORGE_REWORK_RUN: &str = r#"## Shea Symphony Rework Run
+
+- Generated at: `{{generated_at}}`
+- Issue: {{issue_ref}} {{issue_title}}
+- Lane: `main`
+- Actor role: `human_review_revision`
+- Actor: `operator`
+- Run ID: `forge-rework`
+- Run type: `human_review_rework_revision`
+- Input state: `Human Review`
+- Target state after run: `Rework`
+- Result: `rework_revision_recorded`
+- PR: `{{pr}}`
+- Replacement Rework title/status: `{{rework_title}}` / `Rework`
+- Operator confirmation: {{operator_confirmation}}
+- Evidence summary: operator confirmation, replacement contract, and readback evidence recorded.
+- Source state validated as `Human Review` before mutation.
+- Terminal lane claims, when present, were preserved as audit pointers.
+- Active lane claims in `Human Review` are rejected before content or status writes.
+- Replacement body was written and read back before the final Project status mutation.
+- Final Project status mutation is `Rework`.
+
+### Rework Direction
+
+{{evidence}}
+
+### Verification Readback
+
+{{readbacks}}
+
+### Role Boundary
+
+- Main Agent may claim `Rework`, repair the revised contract, and stop at `Agent Review`.
+- `Human Review` remains reserved for independent Review Agent pass evidence."#;
+
+const FORGE_REWORK_BLOCKED: &str = r#"## Shea Symphony Rework Run
+
+- Generated at: `{{generated_at}}`
+- Issue: {{issue_ref}} {{issue_title}}
+- Lane: `main`
+- Actor role: `human_review_revision`
+- Actor: `operator`
+- Run ID: `forge-rework`
+- Run type: `human_review_rework_revision`
+- Source state: `Human Review`
+- Target state after run: `unchanged`
+- Result: `blocked`
+- PR: `{{pr}}`
+- Blocker: {{reason}}
+- Evidence summary: blocked rework revision recorded before any state mutation.
+- No replacement body was written.
+- Project status was not changed to `Rework`.
+- Resolve or supersede the active lane claim before retrying `forge rework`."#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fallback_registry_covers_every_template_id() {
+        for id in WorkpadTemplateId::all() {
+            let template = workpad_template_for(None, *id);
+            assert!(!template.body.trim().is_empty(), "missing {:?}", id);
+            assert_eq!(template.source, WorkpadTemplateSource::CentralizedFallback);
+        }
+    }
+
+    #[test]
+    fn renders_configured_workflow_template_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let template_path = dir.path().join("main.md");
+        fs::write(&template_path, "Configured {{issue_ref}}").unwrap();
+        let workflow_path = dir.path().join("WORKFLOW.md");
+        let workflow = WorkflowDefinition::parse(
+            &workflow_path,
+            "---\nworkpad_templates:\n  main_handoff: main.md\n---\nPrompt",
+        )
+        .unwrap();
+
+        let rendered = render_workpad_template(
+            Some(&workflow),
+            WorkpadTemplateId::MainHandoff,
+            &[("issue_ref", "#435".into())],
+        );
+
+        assert_eq!(rendered, "Configured #435");
+        assert!(matches!(
+            workpad_template_for(Some(&workflow), WorkpadTemplateId::MainHandoff).source,
+            WorkpadTemplateSource::WorkflowFile(_)
+        ));
+    }
+
+    #[test]
+    fn missing_configured_template_reports_diagnostic_and_uses_fallback() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\nworkpad_templates:\n  main_handoff: missing.md\n---\nPrompt",
+        )
+        .unwrap();
+        let template = workpad_template_for(Some(&workflow), WorkpadTemplateId::MainHandoff);
+
+        assert!(template.body.contains("## Shea Symphony Workpad"));
+        assert!(matches!(
+            template.source,
+            WorkpadTemplateSource::MissingOrInvalid { .. }
+        ));
+    }
+
+    #[test]
+    fn canonical_workflow_readback_lists_every_workpad_surface() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("workflows/shea-symphony.md");
+        let workflow = WorkflowDefinition::load(path).unwrap();
+        let readback = workpad_template_readback(&workflow);
+
+        assert_eq!(readback.len(), WorkpadTemplateId::all().len());
+        for id in WorkpadTemplateId::all() {
+            let template = readback.iter().find(|template| template.id == *id).unwrap();
+            assert!(!template.body.trim().is_empty(), "empty {:?}", id);
+        }
+        assert!(readback
+            .iter()
+            .any(|template| matches!(template.source, WorkpadTemplateSource::WorkflowFile(_))));
+        assert!(readback
+            .iter()
+            .any(|template| matches!(template.source, WorkpadTemplateSource::CentralizedFallback)));
+    }
+
+    #[test]
+    fn migrated_renderers_do_not_reintroduce_scattered_workpad_layout_headings() {
+        let migrated_sources = [
+            (
+                "src/lanes/main_loop/handoff.rs",
+                include_str!("lanes/main_loop/handoff.rs"),
+            ),
+            (
+                "src/lanes/main_loop/write_candidate.rs",
+                include_str!("lanes/main_loop/write_candidate.rs"),
+            ),
+            ("src/doctor/report.rs", include_str!("doctor/report.rs")),
+            ("src/merge_lane.rs", include_str!("merge_lane.rs")),
+            (
+                "src/lanes/review/manual.rs",
+                include_str!("lanes/review/manual.rs"),
+            ),
+            (
+                "src/commands/forge/rework.rs",
+                include_str!("commands/forge/rework.rs"),
+            ),
+            ("src/commands/gate.rs", include_str!("commands/gate.rs")),
+        ];
+        let forbidden = [
+            "\"## Shea Symphony Workpad\"",
+            "\"## Shea Symphony Merge Run\"",
+            "\"## Shea Symphony Doctor Triage\"",
+            "\"## Shea Symphony Rework Run\"",
+            "\"### Runtime Ownership\"",
+            "\"### Parent Topology\"",
+            "\"### Manual Review Evidence\"",
+            "\"### Usage-Limit Pause\"",
+            "\"### Assignee Ownership Blocker\"",
+            "\"### Handoff Planning Blocker\"",
+        ];
+
+        for (path, source) in migrated_sources {
+            for heading in forbidden {
+                assert!(
+                    !source.contains(heading),
+                    "{path} reintroduced scattered workpad layout heading {heading}"
+                );
+            }
+        }
+    }
+}

--- a/workflows/shea-symphony.md
+++ b/workflows/shea-symphony.md
@@ -38,6 +38,14 @@ prompts:
   main_agent: prompts/main-agent.md
   review_agent: prompts/review-agent.md
   merge_agent: prompts/merge-agent.md
+workpad_templates:
+  agent_review_run: template/workpad/agent-review.md
+  doctor_triage: template/workpad/doctor-triage.md
+  human_review_repair: template/workpad/doctor-triage.md
+  merge_run: template/workpad/merge-run.md
+  merge_repair: template/workpad/merge-run.md
+  forge_rework_run: template/workpad/rework-run.md
+  forge_rework_blocked: template/workpad/rework-run.md
 polling:
   interval_ms: 5000
 artifacts:


### PR DESCRIPTION
## Summary
- Implements #435: Make all workpad content workflow-configurable.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #435
