### PR TITLE
#438: Show blocked Todo dependencies outside Main lane queue

### DIFF
--- a/app/src/lib/viewModel/queueIssues.ts
+++ b/app/src/lib/viewModel/queueIssues.ts
@@ -12,18 +12,29 @@ export function buildQueueIssues(githubQueue: any, attentionTasks: any[] = []) {
   const fromGithub = (githubQueue?.issues ?? [])
     .map((issue) => {
       const state = normalizeStateName(issue.state);
+      const blockedBy = normalizedBlockers(issue.blockedBy ?? issue.blocked_by);
+      const unresolvedBlocked = isBlockedMainQueueState(state) && hasUnresolvedBlockers(blockedBy);
+      const blockedReason = textFromValue(issue.blockedReason ?? issue.blocked_reason, 'issue has unresolved tracker dependencies');
       return {
         id: issue.identifier,
         title: issue.title,
         state,
-        lane: stateToLane(state),
+        lane: unresolvedBlocked ? 'Blocked' : stateToLane(state),
         url: issue.url,
         updatedAt: issue.updatedAt,
         assignees: issue.assignees ?? [],
         labels: issue.labels ?? [],
-        evidence: `${githubQueue.source ?? 'GitHub queue'} · ${issue.state}`,
-        recommended: recommendationForQueueState(state),
-        tone: toneForState(state),
+        blockedBy,
+        blockedReason: blockedBy.length ? blockedReason : null,
+        evidence: [
+          githubQueue.source ?? 'GitHub queue',
+          issue.state,
+          unresolvedBlocked ? blockerSummary(blockedBy) : null
+        ].filter(Boolean).join(' · '),
+        recommended: unresolvedBlocked
+          ? 'Blocked by unresolved tracker dependencies; keep out of Main lane selection.'
+          : recommendationForQueueState(state),
+        tone: unresolvedBlocked ? 'danger' : toneForState(state),
         source: 'githubQueue'
       };
     })
@@ -142,12 +153,52 @@ function recommendationForQueueState(state: any) {
   return 'Observe this issue in the Project queue.';
 }
 
+function isBlockedMainQueueState(state: any) {
+  return ['Todo', 'Rework'].includes(normalizeStateName(state));
+}
+
+function normalizedBlockers(blockedBy: any) {
+  return (Array.isArray(blockedBy) ? blockedBy : [])
+    .map((blocker) => {
+      if (typeof blocker === 'string' || typeof blocker === 'number') {
+        return { id: null, identifier: issueRefFromValue(blocker), state: null };
+      }
+      if (!blocker || typeof blocker !== 'object') return null;
+      return {
+        id: blocker.id ?? null,
+        identifier: issueRefFromValue(blocker.identifier ?? blocker.issue ?? blocker.number ?? blocker.url ?? blocker.id),
+        state: blocker.state ? normalizeStateName(blocker.state) : null
+      };
+    })
+    .filter(Boolean);
+}
+
+function hasUnresolvedBlockers(blockedBy: any[] = []) {
+  return blockedBy.some((blocker) => !isTerminalBlockerState(blocker?.state));
+}
+
+function isTerminalBlockerState(state: any) {
+  const normalized = normalizeStateName(state);
+  return ['Done', 'Closed', 'Merged'].includes(normalized);
+}
+
+function blockerSummary(blockedBy: any[] = []) {
+  const blockers = blockedBy
+    .map((blocker) => {
+      const ref = blocker.identifier ?? blocker.id ?? 'unknown blocker';
+      return blocker.state ? `${ref} ${blocker.state}` : ref;
+    })
+    .join(', ');
+  return blockers ? `blocked by ${blockers}` : null;
+}
+
 function queueIssueSort(left: any, right: any) {
   const order: Record<string, number> = {
     'Need Human Input': 0,
     'Human Review': 1,
     Rework: 2,
     Todo: 3,
+    Blocked: 3,
     'Agent Review': 4,
     Merging: 5
   };

--- a/app/test/operator-view.test.mjs
+++ b/app/test/operator-view.test.mjs
@@ -1555,6 +1555,65 @@ test('view model keeps lane queue rows observational without next skill metadata
   assert.ok(view.laneProjectIssues.merge.every((issue) => !Object.hasOwn(issue, 'nextSkill')));
 });
 
+test('blocked Todo project rows keep dependency readback but stay out of Main lane queue', () => {
+  const view = buildViewModel({
+    generatedAt: new Date().toISOString(),
+    workflowPath: 'workflows/shea-symphony.md',
+    commands: {
+      githubQueue: {
+        ok: true,
+        args: ['project', 'state', 'workflows/shea-symphony.md', '--json'],
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        durationMs: 12,
+        stderr: '',
+        stdoutPreview: '{}'
+      }
+    },
+    githubQueue: {
+      source: 'GitHub Project',
+      issues: [
+        { identifier: '#438', title: 'Ready Todo', state: 'Todo', blockedBy: [] },
+        {
+          identifier: '#439',
+          title: 'Blocked Todo',
+          state: 'Todo',
+          blockedBy: [{ identifier: '#401', state: 'Todo' }],
+          blockedReason: 'issue has unresolved tracker dependencies'
+        },
+        {
+          identifier: '#440',
+          title: 'Blocked Rework',
+          state: 'Rework',
+          blockedBy: [{ identifier: '#402', state: 'Agent Review' }]
+        },
+        {
+          identifier: '#441',
+          title: 'Resolved Rework',
+          state: 'Rework',
+          blockedBy: [{ identifier: '#403', state: 'Done' }]
+        }
+      ]
+    },
+    healthy: true
+  });
+
+  const ready = view.queueIssues.find((issue) => issue.id === '#438');
+  const blocked = view.queueIssues.find((issue) => issue.id === '#439');
+  const blockedRework = view.queueIssues.find((issue) => issue.id === '#440');
+  const board = buildLaneThroughputBoard({ queueIssues: view.queueIssues });
+  const main = board.find((lane) => lane.laneKey === 'main');
+
+  assert.equal(ready.lane, 'Main');
+  assert.equal(blocked.lane, 'Blocked');
+  assert.equal(blockedRework.lane, 'Blocked');
+  assert.deepEqual(blocked.blockedBy, [{ id: null, identifier: '#401', state: 'Todo' }]);
+  assert.match(blocked.evidence, /blocked by #401 Todo/);
+  assert.deepEqual(view.laneProjectIssues.main.map((issue) => issue.id), ['#441', '#438']);
+  assert.deepEqual(main.issues.map((issue) => issue.id), ['#441', '#438']);
+});
+
 test('fixture overview feeds first-screen human todo and lane board data', () => {
   const overview = buildFixtureOverview(true);
   const view = buildViewModel(overview);

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use serde_json::{json, Value};
@@ -67,7 +67,8 @@ pub(crate) fn project_state(
                     render_project_state_json(
                         &issues,
                         &integration_gaps,
-                        project_state_scope(options.include_terminal)
+                        project_state_scope(options.include_terminal),
+                        &config.terminal_state_set().into_iter().collect()
                     )?
                 );
                 return Ok(());
@@ -569,6 +570,7 @@ pub(crate) fn render_project_state_json(
     issues: &[TrackerIssue],
     integration_gaps: &[String],
     scope: &str,
+    terminal_states: &BTreeSet<String>,
 ) -> Result<String, serde_json::Error> {
     let mut state_counts = BTreeMap::new();
     let mut lane_counts = BTreeMap::from([
@@ -583,7 +585,7 @@ pub(crate) fn render_project_state_json(
         let state = issue.state.trim();
         let state = if state.is_empty() { "(unknown)" } else { state };
         *state_counts.entry(state.to_string()).or_insert(0usize) += 1;
-        if let Some(lane) = lane_for_state(state) {
+        if let Some(lane) = lane_for_issue(issue, terminal_states) {
             *lane_counts.entry(lane.to_string()).or_insert(0usize) += 1;
         }
 
@@ -610,6 +612,23 @@ pub(crate) fn render_project_state_json(
 }
 
 fn render_queue_issue(issue: &TrackerIssue) -> Value {
+    let blocked_by = issue
+        .blocked_by
+        .iter()
+        .map(|blocker| {
+            json!({
+                "id": blocker.id,
+                "identifier": blocker.identifier,
+                "state": blocker.state,
+            })
+        })
+        .collect::<Vec<_>>();
+    let blocked_reason = if blocked_by.is_empty() {
+        None
+    } else {
+        Some("issue has tracker dependencies")
+    };
+
     json!({
         "identifier": issue.identifier,
         "title": issue.title,
@@ -621,16 +640,39 @@ fn render_queue_issue(issue: &TrackerIssue) -> Value {
         "labels": issue.labels,
         "priority": issue.priority,
         "branchName": issue.branch_name,
+        "blockedBy": blocked_by,
+        "blockedReason": blocked_reason,
     })
 }
 
-fn lane_for_state(state: &str) -> Option<&'static str> {
-    match normalize_state(state).as_str() {
+fn lane_for_issue(
+    issue: &TrackerIssue,
+    terminal_states: &BTreeSet<String>,
+) -> Option<&'static str> {
+    let normalized_state = issue.normalized_state();
+    if matches!(normalized_state.as_str(), "todo" | "rework")
+        && issue_has_unresolved_blockers(issue, terminal_states)
+    {
+        return None;
+    }
+
+    match normalized_state.as_str() {
         "todo" | "rework" | "in progress" => Some("main"),
         "agent review" => Some("review"),
         "merging" => Some("merge"),
         _ => None,
     }
+}
+
+fn issue_has_unresolved_blockers(issue: &TrackerIssue, terminal_states: &BTreeSet<String>) -> bool {
+    issue.blocked_by.iter().any(|blocker| {
+        blocker
+            .state
+            .as_deref()
+            .map(normalize_state)
+            .map(|state| !terminal_states.contains(&state))
+            .unwrap_or(true)
+    })
 }
 
 fn is_operator_state(state: &str) -> bool {

--- a/src/main/tests.rs
+++ b/src/main/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use shea_symphony::tracker::MemoryTracker;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
@@ -103,9 +103,8 @@ use shea_symphony::lane_claim::{
     LaneClaim, LaneClaimActor, LaneClaimLane, LaneClaimSource, LaneClaimState,
 };
 use shea_symphony::merge_lane::repair_dirty_pull_request;
-use shea_symphony::model::SessionStatusSnapshot;
-use shea_symphony::model::TrackerIssue;
 use shea_symphony::model::{normalize_state, LinkedPullRequest};
+use shea_symphony::model::{BlockerRef, SessionStatusSnapshot, TrackerIssue};
 use shea_symphony::orchestrator::Orchestrator;
 use shea_symphony::ownership::render_runtime_ownership_marker;
 use shea_symphony::ownership::{runtime_ownership_decision, RuntimeOwnershipDecision};
@@ -697,7 +696,13 @@ fn renders_project_state_json_queue_projection() {
         tracker_issue_with_ref("#3", "Approval", "Human Review"),
     ];
 
-    let rendered = render_project_state_json(&issues, &["gap".into()], "queue").unwrap();
+    let rendered = render_project_state_json(
+        &issues,
+        &["gap".into()],
+        "queue",
+        &BTreeSet::from(["done".into()]),
+    )
+    .unwrap();
     let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
 
     assert_eq!(value["trusted"], true);
@@ -707,6 +712,39 @@ fn renders_project_state_json_queue_projection() {
     assert_eq!(value["laneCounts"]["review"], 1);
     assert_eq!(value["operatorIssues"][0]["identifier"], "#3");
     assert_eq!(value["integrationGaps"][0], "gap");
+}
+
+#[test]
+fn renders_project_state_json_dependency_readback_without_main_lane_projection() {
+    let ready = tracker_issue_with_ref("#1", "Ready", "Todo");
+    let mut blocked = tracker_issue_with_ref("#2", "Blocked", "Todo");
+    blocked.blocked_by = vec![BlockerRef {
+        id: Some("I_kwBLOCKER".into()),
+        identifier: Some("#9".into()),
+        state: Some("Todo".into()),
+    }];
+    let mut resolved = tracker_issue_with_ref("#3", "Resolved dependency", "Rework");
+    resolved.blocked_by = vec![BlockerRef {
+        id: None,
+        identifier: Some("#8".into()),
+        state: Some("Done".into()),
+    }];
+    let terminal_states = BTreeSet::from(["done".into()]);
+
+    let rendered =
+        render_project_state_json(&[ready, blocked, resolved], &[], "queue", &terminal_states)
+            .unwrap();
+    let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+    assert_eq!(value["laneCounts"]["main"], 2);
+    assert_eq!(value["issues"][1]["identifier"], "#2");
+    assert_eq!(value["issues"][1]["blockedBy"][0]["identifier"], "#9");
+    assert_eq!(value["issues"][1]["blockedBy"][0]["state"], "Todo");
+    assert_eq!(
+        value["issues"][1]["blockedReason"],
+        "issue has tracker dependencies"
+    );
+    assert_eq!(value["issues"][2]["blockedBy"][0]["state"], "Done");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Implements #438: Show blocked Todo dependencies outside Main lane queue.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #438
