### PR TITLE
#445: Generalize ReviewBackend while preserving Gemini review behavior

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -625,6 +625,13 @@ changes.
 | `session list` | List active Shea Symphony tmux sessions by configured prefix. | Read-only operator summary. |
 | `session attach` | Print or execute the tmux attach command for one session. | Defaults to printing the command; `--exec` enters tmux. |
 
+Review backend implementations own backend-specific command previews, prelaunch
+diagnostics, stdout parsing, and artifact shaping. The current canonical
+workflow still selects `review_lane.backend: gemini-cli`; Gemini-specific
+configuration fields such as `gemini_command`, `gemini_model`, and
+`gemini_allowed_tools` remain the supported configuration surface for that
+backend.
+
 Example:
 
 ```bash

--- a/src/commands/autopilot/looping.rs
+++ b/src/commands/autopilot/looping.rs
@@ -1531,8 +1531,7 @@ fn autopilot_lane_result_from_review_execution(
     }
     if let Some(issue_ref) = recovery_issue_ref.as_deref() {
         evidence.push(format!(
-            "review_recovery=cleared_stale_claim issue={}",
-            issue_ref
+            "review_recovery=cleared_stale_claim issue={issue_ref}"
         ));
     }
     let (status, action, completed_work_units): (String, String, usize) = match result {
@@ -1832,8 +1831,8 @@ pub(crate) fn autopilot_loop_status_from_plan_with_work_units(
                 .iter()
                 .filter(|blocker| {
                     !(main_recovery_can_tick
-                        && autopilot_readiness_blocker_is_main_recoverable(plan, blocker))
-                        && !(merge_recovery_can_tick
+                        && autopilot_readiness_blocker_is_main_recoverable(plan, blocker)
+                        || merge_recovery_can_tick
                             && autopilot_readiness_blocker_is_merge_recoverable(plan, blocker))
                 })
                 .cloned()

--- a/src/commands/gate.rs
+++ b/src/commands/gate.rs
@@ -152,9 +152,11 @@ pub(crate) fn gate_workpad(issue: &TrackerIssue, decision: &GateDecision) -> Str
             .collect::<Vec<_>>()
             .join("\n")
     };
-    let missing = (!decision.missing.is_empty())
-        .then(|| format!("- Missing: {}", decision.missing.join(", ")))
-        .unwrap_or_default();
+    let missing = if decision.missing.is_empty() {
+        String::new()
+    } else {
+        format!("- Missing: {}", decision.missing.join(", "))
+    };
     let notes = decision
         .notes
         .iter()

--- a/src/lanes/main_loop/dispatch.rs
+++ b/src/lanes/main_loop/dispatch.rs
@@ -106,18 +106,16 @@ fn print_run_loop_write_selection(
                 iterations, issue.identifier, issue.title, max_concurrent, selected_count
             );
         }
-    } else {
-        if !options.quiet_idle {
-            println!(
-                "run_loop_iteration={} issue={} title={:?} mode=write max_concurrent={} selected_count={} slot={}",
-                iterations,
-                issue.identifier,
-                issue.title,
-                max_concurrent,
-                selected_count,
-                slot_index + 1
-            );
-        }
+    } else if !options.quiet_idle {
+        println!(
+            "run_loop_iteration={} issue={} title={:?} mode=write max_concurrent={} selected_count={} slot={}",
+            iterations,
+            issue.identifier,
+            issue.title,
+            max_concurrent,
+            selected_count,
+            slot_index + 1
+        );
     }
     let smoke_gate = main_app_server_smoke_gate(config);
     println!(

--- a/src/lanes/main_loop/session.rs
+++ b/src/lanes/main_loop/session.rs
@@ -373,7 +373,7 @@ fn git_output(workspace: Option<&Path>, args: &[&str]) -> String {
             args,
             compact_evidence(&String::from_utf8_lossy(&output.stderr))
         ),
-        Err(error) => format!("git {:?} failed: {error}", args),
+        Err(error) => format!("git {args:?} failed: {error}"),
     }
 }
 

--- a/src/lanes/review/automatic.rs
+++ b/src/lanes/review/automatic.rs
@@ -13,13 +13,14 @@ use shea_symphony::progress::{run_with_progress_heartbeat, ProgressHeartbeatSpec
 use shea_symphony::prompt::render_prompt;
 use shea_symphony::prompt_runtime::AUTOMATIC_HEADLESS_REVIEW_BOUNDARY;
 use shea_symphony::review::{
-    gemini_cli_headless_args, gemini_prelaunch_health_diagnostic, gemini_review_health_diagnostic,
-    poll_review_job_until_terminal, render_repeated_review_failure_workpad,
-    render_review_workpad_with_workflow, review_failure_signature, review_gate_decision_for_issue,
-    review_run_eligibility, review_worker_key, transition_allowed_for_review_agent,
-    write_review_job_ledger_record, FakeReviewBackend, FakeReviewOutcome, GeminiCliReviewBackend,
-    GeminiReviewRecoveryPolicy, ReviewBackend, ReviewGateDecision, ReviewJob, ReviewJobState,
-    ReviewOutcome, ReviewRepeatedFailureEvidence, ReviewRequest, ReviewRunEligibility,
+    gemini_review_health_diagnostic, poll_review_job_until_terminal,
+    render_repeated_review_failure_workpad, render_review_workpad_with_workflow,
+    review_backend_from_config, review_backend_kind_from_config, review_failure_signature,
+    review_gate_decision_for_issue, review_run_eligibility, review_worker_key,
+    transition_allowed_for_review_agent, write_review_job_ledger_record, FakeReviewBackend,
+    FakeReviewOutcome, GeminiReviewRecoveryPolicy, ReviewBackend, ReviewGateDecision, ReviewJob,
+    ReviewJobState, ReviewOutcome, ReviewRepeatedFailureEvidence, ReviewRequest,
+    ReviewRunEligibility,
 };
 use shea_symphony::rework::rework_transition_expected;
 #[cfg(test)]
@@ -105,37 +106,8 @@ pub(crate) fn review_once(
         workspace: config.workspace.root.clone(),
         artifact_root: config.observability.logs_root.join("reviews"),
     };
-    let job = match config.review.backend.as_str() {
-        "gemini-cli" => {
-            let backend = GeminiCliReviewBackend::with_headless_options(
-                config.review.gemini_command.clone(),
-                config.review.gemini_model.clone(),
-                config.review.gemini_allowed_tools.clone(),
-            );
-            match backend.start(request) {
-                Ok(job) => {
-                    let spec = review_backend_progress_spec(&config, &issue, backend.kind(), &job);
-                    run_with_progress_heartbeat(spec, || {
-                        poll_review_job_until_terminal(
-                            &backend,
-                            job,
-                            Duration::from_millis(config.review.timeout_ms),
-                            Duration::from_millis(500),
-                        )
-                    })?
-                }
-                Err(error) => ReviewJob::failed_unavailable(
-                    issue.identifier.clone(),
-                    "gemini-cli",
-                    error.to_string(),
-                ),
-            }
-        }
-        _ => {
-            let backend = FakeReviewBackend::new(FakeReviewOutcome::Pass);
-            backend.poll(backend.start(request)?)?
-        }
-    };
+    let backend = review_backend_from_config(&config.review);
+    let job = run_configured_review_backend(&config, &issue, backend.as_ref(), request)?;
     apply_review_result(
         Some(&workflow),
         &config,
@@ -393,6 +365,8 @@ pub(crate) fn review_loop_with_summary(
                     );
                     }
                     if !options.write {
+                        let backend = review_backend_from_config(&config.review);
+                        let command_preview = backend.command_preview();
                         print_latest_status(&latest_status_for_issue(
                             &config,
                             &selected_issue,
@@ -404,22 +378,17 @@ pub(crate) fn review_loop_with_summary(
                         println!(
                             "review_loop_dry_run action=start issue={} backend={backend_kind} mode={}",
                             selected_issue.identifier,
-                            if backend_kind == "gemini-cli" {
-                                "headless"
-                            } else {
-                                "job"
-                            }
+                            command_preview
+                                .as_ref()
+                                .map(|command| command.mode)
+                                .unwrap_or("job")
                         );
-                        if backend_kind == "gemini-cli" {
+                        if let Some(command_preview) = command_preview {
                             println!(
                                 "review_loop_dry_run action=command issue={} command={} args={}",
                                 selected_issue.identifier,
-                                shell_quote_display(&config.review.gemini_command),
-                                gemini_cli_headless_args(
-                                    config.review.gemini_model.as_deref(),
-                                    &config.review.gemini_allowed_tools,
-                                )
-                                .join(" ")
+                                shell_quote_display(&command_preview.command),
+                                command_preview.args.join(" ")
                             );
                         }
                         print_review_claim_field_dry_run(&selected_issue, &worker_key);
@@ -478,7 +447,10 @@ pub(crate) fn review_loop_with_summary(
                                 latest.identifier,
                                 worker_slot,
                                 backend_kind,
-                                if backend_kind == "gemini-cli" { "headless" } else { "job" }
+                                review_backend_from_config(&config.review)
+                                    .command_preview()
+                                    .map(|command| command.mode)
+                                    .unwrap_or("job")
                             );
                             let handle = thread::spawn(move || {
                                 run_review_job(
@@ -660,10 +632,8 @@ pub(crate) fn review_backend_kind(
 ) -> String {
     if fake_outcome.is_some() {
         "fake-reviewer".into()
-    } else if config.review.backend == "gemini-cli" {
-        "gemini-cli".into()
     } else {
-        "fake-reviewer".into()
+        review_backend_kind_from_config(&config.review).into()
     }
 }
 
@@ -825,47 +795,41 @@ fn run_review_job(
         })?);
     }
 
-    match config.review.backend.as_str() {
-        "gemini-cli" => {
-            if let Some(diagnostic) = gemini_prelaunch_health_diagnostic(
-                &config.review.gemini_command,
-                config.review.gemini_model.as_deref(),
-                &config.review.gemini_allowed_tools,
-            ) {
-                return Ok(ReviewJob::failed_unavailable(
-                    issue.identifier.clone(),
-                    "gemini-cli",
-                    diagnostic.to_error_message(),
-                ));
-            }
-            let backend = GeminiCliReviewBackend::with_headless_options(
-                config.review.gemini_command.clone(),
-                config.review.gemini_model.clone(),
-                config.review.gemini_allowed_tools.clone(),
-            );
-            match backend.start(request) {
-                Ok(job) => {
-                    let spec = review_backend_progress_spec(config, issue, backend.kind(), &job);
-                    Ok(run_with_progress_heartbeat(spec, || {
-                        poll_review_job_until_terminal(
-                            &backend,
-                            job,
-                            Duration::from_millis(config.review.timeout_ms),
-                            Duration::from_millis(500),
-                        )
-                    })?)
-                }
-                Err(error) => Ok(ReviewJob::failed_unavailable(
-                    issue.identifier.clone(),
-                    "gemini-cli",
-                    error.to_string(),
-                )),
-            }
+    let backend = review_backend_from_config(&config.review);
+    run_configured_review_backend(config, issue, backend.as_ref(), request)
+}
+
+fn run_configured_review_backend(
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+    backend: &dyn ReviewBackend,
+    request: ReviewRequest,
+) -> Result<ReviewJob, Box<dyn std::error::Error>> {
+    if let Some(error) = backend.prelaunch_error() {
+        return Ok(ReviewJob::failed_unavailable(
+            issue.identifier.clone(),
+            backend.kind(),
+            error,
+        ));
+    }
+
+    match backend.start(request) {
+        Ok(job) => {
+            let spec = review_backend_progress_spec(config, issue, backend.kind(), &job);
+            Ok(run_with_progress_heartbeat(spec, || {
+                poll_review_job_until_terminal(
+                    backend,
+                    job,
+                    Duration::from_millis(config.review.timeout_ms),
+                    Duration::from_millis(500),
+                )
+            })?)
         }
-        _ => {
-            let backend = FakeReviewBackend::new(FakeReviewOutcome::Pass);
-            Ok(backend.poll(backend.start(request)?)?)
-        }
+        Err(error) => Ok(ReviewJob::failed_unavailable(
+            issue.identifier.clone(),
+            backend.kind(),
+            error.to_string(),
+        )),
     }
 }
 
@@ -945,6 +909,7 @@ impl ReviewLoopOptions {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn apply_review_result(
     workflow: Option<&WorkflowDefinition>,
     config: &RuntimeConfig,

--- a/src/main/tests/autopilot.rs
+++ b/src/main/tests/autopilot.rs
@@ -77,7 +77,7 @@ fn review_worker_exists_lane_plan(identifier: &str) -> AutopilotLanePlan {
         selected_issue: None,
         proposed_action: "skip".into(),
         target_state: None,
-        reason: format!("review_worker_exists:review:{}:gemini-cli", identifier),
+        reason: format!("review_worker_exists:review:{identifier}:gemini-cli"),
         evidence: vec!["source=review_lane_decision".into()],
     }
 }

--- a/src/review.rs
+++ b/src/review.rs
@@ -8,6 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::Deserialize;
 
+use crate::config::ReviewConfig;
 use crate::lane_claim::{LaneClaim, LaneClaimState};
 use crate::model::{normalize_state, TrackerIssue};
 use crate::workflow::WorkflowDefinition;
@@ -35,8 +36,8 @@ pub use gemini_health::{
 };
 pub use job::{
     poll_review_job_until_terminal, review_job_is_terminal, review_job_ledger_record,
-    review_usage_limit_pause, write_review_job_ledger_record, ReviewBackend, ReviewError,
-    ReviewJob, ReviewJobLedgerRecord, ReviewJobState, ReviewRequest,
+    review_usage_limit_pause, write_review_job_ledger_record, ReviewBackend, ReviewBackendCommand,
+    ReviewError, ReviewJob, ReviewJobLedgerRecord, ReviewJobState, ReviewRequest,
 };
 pub use report::{classify_findings, AgentReviewReport, ReviewFinding, ReviewFindingClass};
 
@@ -136,6 +137,20 @@ impl ReviewBackend for FakeReviewBackend {
     }
 }
 
+pub fn review_backend_from_config(config: &ReviewConfig) -> Box<dyn ReviewBackend> {
+    match config.backend.as_str() {
+        "gemini-cli" => Box::new(GeminiCliReviewBackend::from_config(config)),
+        _ => Box::new(FakeReviewBackend::new(FakeReviewOutcome::Pass)),
+    }
+}
+
+pub fn review_backend_kind_from_config(config: &ReviewConfig) -> &'static str {
+    match config.backend.as_str() {
+        "gemini-cli" => "gemini-cli",
+        _ => "fake-reviewer",
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct GeminiCliReviewBackend {
     command: String,
@@ -164,6 +179,21 @@ impl GeminiCliReviewBackend {
             model,
             allowed_tools,
             children: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    pub fn from_config(config: &ReviewConfig) -> Self {
+        Self::with_headless_options(
+            config.gemini_command.clone(),
+            config.gemini_model.clone(),
+            config.gemini_allowed_tools.clone(),
+        )
+    }
+
+    fn headless_config(&self) -> GeminiCliHeadlessConfig<'_> {
+        GeminiCliHeadlessConfig {
+            model: self.model.as_deref(),
+            allowed_tools: &self.allowed_tools,
         }
     }
 }
@@ -304,6 +334,20 @@ impl ReviewBackend for GeminiCliReviewBackend {
         Ok(job)
     }
 
+    fn command_preview(&self) -> Option<ReviewBackendCommand> {
+        Some(ReviewBackendCommand {
+            mode: "headless",
+            command: self.command.clone(),
+            args: self.headless_config().args(),
+        })
+    }
+
+    fn prelaunch_error(&self) -> Option<String> {
+        self.headless_config()
+            .prelaunch_health_diagnostic(&self.command)
+            .map(|diagnostic| diagnostic.to_error_message())
+    }
+
     fn cancel(&self, job: &ReviewJob) -> Result<(), ReviewError> {
         let mut children = self
             .children
@@ -314,6 +358,22 @@ impl ReviewBackend for GeminiCliReviewBackend {
             let _ = child.wait();
         }
         Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GeminiCliHeadlessConfig<'a> {
+    model: Option<&'a str>,
+    allowed_tools: &'a [String],
+}
+
+impl GeminiCliHeadlessConfig<'_> {
+    fn args(&self) -> Vec<String> {
+        gemini_cli_headless_args(self.model, self.allowed_tools)
+    }
+
+    fn prelaunch_health_diagnostic(&self, command: &str) -> Option<GeminiReviewHealthDiagnostic> {
+        gemini_prelaunch_health_diagnostic(command, self.model, self.allowed_tools)
     }
 }
 
@@ -1275,6 +1335,55 @@ mod tests {
             job.error.as_deref(),
             Some("Review backend timed out after 0ms.")
         );
+    }
+
+    fn gemini_review_config() -> ReviewConfig {
+        ReviewConfig {
+            backend: "gemini-cli".into(),
+            gemini_command: "/opt/homebrew/bin/gemini".into(),
+            gemini_model: Some("gemini-3.1-pro-preview".into()),
+            gemini_allowed_tools: vec!["run_shell_command".into()],
+            timeout_ms: 600_000,
+            max_concurrent_workers: 1,
+        }
+    }
+
+    #[test]
+    fn configured_review_backend_preserves_gemini_identity_and_command_preview() {
+        let config = gemini_review_config();
+        let backend = review_backend_from_config(&config);
+        let preview = backend.command_preview().unwrap();
+
+        assert_eq!(review_backend_kind_from_config(&config), "gemini-cli");
+        assert_eq!(backend.kind(), "gemini-cli");
+        assert_eq!(preview.mode, "headless");
+        assert_eq!(preview.command, "/opt/homebrew/bin/gemini");
+        assert_eq!(
+            preview.args,
+            vec![
+                "--skip-trust",
+                "--prompt",
+                "",
+                "--output-format",
+                "json",
+                "--model",
+                "gemini-3.1-pro-preview",
+                "--allowed-tools",
+                "run_shell_command,read_file,grep_search,list_directory",
+            ]
+        );
+    }
+
+    #[test]
+    fn configured_review_backend_routes_gemini_prelaunch_diagnostics_through_backend_boundary() {
+        let mut config = gemini_review_config();
+        config.gemini_command = "shea-missing-gemini-command".into();
+        let backend = review_backend_from_config(&config);
+        let error = backend.prelaunch_error().unwrap();
+
+        assert_eq!(backend.kind(), "gemini-cli");
+        assert!(error.contains("Gemini review backend health check classified"));
+        assert!(error.contains("reason=command_not_found"));
     }
 
     #[test]

--- a/src/review/job.rs
+++ b/src/review/job.rs
@@ -102,9 +102,22 @@ pub trait ReviewBackend {
     fn kind(&self) -> &'static str;
     fn start(&self, request: ReviewRequest) -> Result<ReviewJob, ReviewError>;
     fn poll(&self, job: ReviewJob) -> Result<ReviewJob, ReviewError>;
+    fn command_preview(&self) -> Option<ReviewBackendCommand> {
+        None
+    }
+    fn prelaunch_error(&self) -> Option<String> {
+        None
+    }
     fn cancel(&self, _job: &ReviewJob) -> Result<(), ReviewError> {
         Ok(())
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReviewBackendCommand {
+    pub mode: &'static str,
+    pub command: String,
+    pub args: Vec<String>,
 }
 
 pub fn review_job_is_terminal(job: &ReviewJob) -> bool {

--- a/src/workpad_templates.rs
+++ b/src/workpad_templates.rs
@@ -574,7 +574,7 @@ mod tests {
     fn fallback_registry_covers_every_template_id() {
         for id in WorkpadTemplateId::all() {
             let template = workpad_template_for(None, *id);
-            assert!(!template.body.trim().is_empty(), "missing {:?}", id);
+            assert!(!template.body.trim().is_empty(), "missing {id:?}");
             assert_eq!(template.source, WorkpadTemplateSource::CentralizedFallback);
         }
     }
@@ -686,7 +686,7 @@ mod tests {
         assert_eq!(readback.len(), WorkpadTemplateId::all().len());
         for id in WorkpadTemplateId::all() {
             let template = readback.iter().find(|template| template.id == *id).unwrap();
-            assert!(!template.body.trim().is_empty(), "empty {:?}", id);
+            assert!(!template.body.trim().is_empty(), "empty {id:?}");
         }
         assert!(readback
             .iter()


### PR DESCRIPTION
## Summary
- Implements #445: Generalize ReviewBackend while preserving Gemini review behavior.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #445
