### PR TITLE
#448: Add workflow-configurable git base branch

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -277,12 +277,13 @@ loop`, and `merge once` print compact issue-scoped `Latest:` status bars for
 real lane work; no-issue idle status and runtime telemetry stay in debug/JSON
 surfaces instead of the default operator log stream.
 Write-mode lane/control commands first run a guarded canonical checkout refresh
-before the first tracker mutation. From a clean attached `main` checkout, the
-CLI fetches the upstream branch and fast-forwards with `git merge --ff-only`
-when local `main` is only behind. Output includes
+before the first tracker mutation. From a clean attached workflow git base
+branch checkout (`git.base_branch`, default `main`), the CLI fetches the
+upstream branch and fast-forwards with `git merge --ff-only` when that local
+base branch is only behind. Output includes
 `canonical_checkout_refresh=already_current`, `ff_only`, `would_ff_only`, or
 `blocked`, followed by the normal `canonical_checkout ...` safety line.
-Tracked dirty files, detached HEAD, non-`main` branches, missing upstreams,
+Tracked dirty files, detached HEAD, non-base branches, missing upstreams,
 unclassified untracked files, and non-fast-forward updates block the lane.
 Recognized untracked runtime/log/prompt/evidence/draft artifacts are moved to
 artifact quarantine with a warning before write-mode git or tracker mutation.
@@ -319,10 +320,10 @@ subissue changes cannot silently bypass parent dispatch safety.
 
 Live write-mode claim, session, lane loop, review pass/reject, forge rework, and
 workspace ensure commands refuse to run unless the canonical checkout is a clean
-attached `main` checkout with a configured upstream. If local `main` is behind
-and can fast-forward, the CLI performs that canonical-only `ff-only` refresh
-before continuing. It never refreshes issue worktrees or PR branches in this
-path.
+attached workflow git base branch checkout with a configured upstream. If that
+local base branch is behind and can fast-forward, the CLI performs that
+canonical-only `ff-only` refresh before continuing. It never refreshes issue
+worktrees or PR branches in this path.
 
 PR relationship verification is a lane invariant, not just evidence text. A PR
 URL found in a workpad, issue comment, or local branch can help operators
@@ -722,7 +723,7 @@ Doctor lanes.
 
 | Command | Purpose | Boundary |
 | --- | --- | --- |
-| `merge once` | Inspect one `Merging` issue, verify a single linked PR, and either merge, safely refresh a stale branch, attempt safe conflict repair, or route blockers. | Live merge requires explicit `--write`; fixture workflows synthesize merge or conflict-repair command evidence without touching GitHub. Native subissues expect the parent integration branch as the PR base; parent final PRs expect `main`. `BEHIND` PRs are updated with `gh pr update-branch` and left in `Merging` for retry, transient `UNKNOWN` mergeability stays in `Merging`, `DIRTY` PRs first try direct clean local PR-worktree repair, then use the configured merge-agent backend for content conflicts in a trusted clean PR worktree. Interrupted conflict-repair merge states are aborted before retry. Successful repair and retryable backend or verification failures stay in `Merging`; only semantic uncertainty, unsafe or untrusted preconditions, untracked-file residue, push failures, or failing checks route to `Need Human Input` with a concrete question instead of defaulting to `Rework`. |
+| `merge once` | Inspect one `Merging` issue, verify a single linked PR, and either merge, safely refresh a stale branch, attempt safe conflict repair, or route blockers. | Live merge requires explicit `--write`; fixture workflows synthesize merge or conflict-repair command evidence without touching GitHub. Native subissues expect the parent integration branch as the PR base; parent final PRs expect the configured workflow git base branch (`git.base_branch`, default `main`). `BEHIND` PRs are updated with `gh pr update-branch` and left in `Merging` for retry, transient `UNKNOWN` mergeability stays in `Merging`, `DIRTY` PRs first try direct clean local PR-worktree repair, then use the configured merge-agent backend for content conflicts in a trusted clean PR worktree. Interrupted conflict-repair merge states are aborted before retry. Successful repair and retryable backend or verification failures stay in `Merging`; only semantic uncertainty, unsafe or untrusted preconditions, untracked-file residue, push failures, or failing checks route to `Need Human Input` with a concrete question instead of defaulting to `Rework`. |
 | `merge loop` | Repeat guarded merge ticks for an explicit bounded iteration count. | Requires `--max-iterations` or `--once`; `--max-concurrent N` processes up to `N` merge slots while respecting `Merging Agent` claim fields; recover-first handling is enabled by default in `--write` mode and can be disabled with `--no-recover`. |
 
 Examples:

--- a/docs/parent-subissue-topology.md
+++ b/docs/parent-subissue-topology.md
@@ -184,10 +184,11 @@ PRs, edit native GitHub relationships, move Project statuses, or replace the
 
 Shea Symphony resolves branch targets from GitHub native parent/subissue
 metadata plus durable supplemental evidence. Normal single-issue work still
-targets `main`. A native subissue keeps its per-issue feature branch as the PR
-head and uses the recorded parent integration branch as the PR base. A parent
-issue with native subissues uses the parent integration branch as the parent
-final PR head and `main` as the PR base.
+targets the configured workflow git base branch (`git.base_branch`, default
+`main`). A native subissue keeps its per-issue feature branch as the PR head and
+uses the recorded parent integration branch as the PR base. A parent issue with
+native subissues uses the parent integration branch as the parent final PR head
+and the configured workflow git base branch as the PR base.
 
 Handoff, workpad, PR body, and merge readback surfaces should record:
 

--- a/examples/github-project-workflow.md
+++ b/examples/github-project-workflow.md
@@ -156,8 +156,8 @@ workpad. Record:
 
 ## Git And PR Discipline
 
-- Base the issue branch on the current `origin/main` unless the issue says
-  otherwise.
+- Base the issue branch on the current workflow git base branch
+  (`git.base_branch`, default `main`) unless the issue says otherwise.
 - Use a branch name that includes the issue number.
 - Keep one issue per branch and one branch per PR.
 - Do not rewrite or revert unrelated user changes.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2045,6 +2045,9 @@ mod tests {
     use super::*;
     use crate::config::RuntimeConfig;
     use crate::workflow::WorkflowDefinition;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_ARTIFACT_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     #[test]
     fn dry_run_backend_emits_normalized_events() {
@@ -2737,10 +2740,12 @@ exit 0
     }
 
     fn codex_config(command: &str, timeout_ms: u64) -> RuntimeConfig {
+        let artifact_root = test_artifact_root();
         let workflow = WorkflowDefinition::parse(
             "/tmp/WORKFLOW.md",
             &format!(
-                "---\nagent:\n  backend: codex\ncodex:\n  command: {command:?}\n  turn_timeout_ms: {timeout_ms}\n---\nPrompt"
+                "---\nartifacts:\n  root: {:?}\nagent:\n  backend: codex\ncodex:\n  command: {command:?}\n  turn_timeout_ms: {timeout_ms}\n---\nPrompt",
+                artifact_root.display().to_string()
             ),
         )
         .unwrap();
@@ -2752,14 +2757,24 @@ exit 0
         timeout_ms: u64,
         stall_timeout_ms: u64,
     ) -> RuntimeConfig {
+        let artifact_root = test_artifact_root();
         let workflow = WorkflowDefinition::parse(
             "/tmp/WORKFLOW.md",
             &format!(
-                "---\nagent:\n  backend: codex\ncodex:\n  command: {command:?}\n  turn_timeout_ms: {timeout_ms}\n  stall_timeout_ms: {stall_timeout_ms}\n---\nPrompt"
+                "---\nartifacts:\n  root: {:?}\nagent:\n  backend: codex\ncodex:\n  command: {command:?}\n  turn_timeout_ms: {timeout_ms}\n  stall_timeout_ms: {stall_timeout_ms}\n---\nPrompt",
+                artifact_root.display().to_string()
             ),
         )
         .unwrap();
         RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md")).unwrap()
+    }
+
+    fn test_artifact_root() -> PathBuf {
+        let counter = TEST_ARTIFACT_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "shea-symphony-agent-test-{}-{counter}",
+            std::process::id()
+        ))
     }
 
     fn claude_config(command: &str, timeout_ms: u64) -> RuntimeConfig {

--- a/src/artifacts.rs
+++ b/src/artifacts.rs
@@ -136,7 +136,7 @@ pub fn cleanup_plan(config: &RuntimeConfig, issues: &[TrackerIssue]) -> CleanupP
         .iter()
         .map(|issue| {
             cleanup_candidate(
-                &config.workspace.root,
+                config,
                 issue,
                 &terminal_states,
                 profile_namespace.as_deref(),
@@ -151,12 +151,18 @@ pub fn cleanup_plan(config: &RuntimeConfig, issues: &[TrackerIssue]) -> CleanupP
 }
 
 fn cleanup_candidate(
-    workspace_root: &Path,
+    config: &RuntimeConfig,
     issue: &TrackerIssue,
     terminal_states: &BTreeSet<String>,
     profile_namespace: Option<&str>,
 ) -> CleanupCandidate {
-    let handoff = plan_issue_handoff_for_profile(workspace_root, issue, "main", profile_namespace);
+    let workspace_root = &config.workspace.root;
+    let handoff = plan_issue_handoff_for_profile(
+        workspace_root,
+        issue,
+        config.git_base_branch(),
+        profile_namespace,
+    );
     let path = handoff
         .as_ref()
         .map(|handoff| handoff.workspace_path.clone())

--- a/src/canonical_checkout.rs
+++ b/src/canonical_checkout.rs
@@ -119,19 +119,28 @@ pub enum CanonicalCheckoutError {
     TrackedDirty { root: PathBuf, paths: String },
     #[error("canonical checkout is blocked: unclassified untracked files in {root}: {paths}. Move them to an issue worktree or artifact location, or add legitimate ignored files to .gitignore before running a live write lane.")]
     UnclassifiedUntracked { root: PathBuf, paths: String },
-    #[error("canonical checkout is blocked: {root} is detached at {head}. Switch the canonical checkout back to clean latest `main` before running a live write lane.")]
-    Detached { root: PathBuf, head: String },
-    #[error("canonical checkout is blocked: {root} is on branch `{branch}` instead of `main`. Do local inspection in an issue worktree; keep the canonical checkout on clean latest `main`.")]
-    NonMain { root: PathBuf, branch: String },
-    #[error("canonical checkout is blocked: local `main` at {head} does not match upstream `{upstream}` at {upstream_head}. Refresh the canonical checkout to latest `main` before running a live write lane.")]
-    StaleMain {
+    #[error("canonical checkout is blocked: {root} is detached at {head}. Switch the canonical checkout back to clean latest `{expected_branch}` before running a live write lane.")]
+    Detached {
         root: PathBuf,
+        head: String,
+        expected_branch: String,
+    },
+    #[error("canonical checkout is blocked: {root} is on branch `{branch}` instead of `{expected_branch}`. Do local inspection in an issue worktree; keep the canonical checkout on clean latest `{expected_branch}`.")]
+    NonBaseBranch {
+        root: PathBuf,
+        branch: String,
+        expected_branch: String,
+    },
+    #[error("canonical checkout is blocked: local `{base_branch}` at {head} does not match upstream `{upstream}` at {upstream_head}. Refresh the canonical checkout to latest `{base_branch}` before running a live write lane.")]
+    StaleBaseBranch {
+        root: PathBuf,
+        base_branch: String,
         head: String,
         upstream: String,
         upstream_head: String,
     },
-    #[error("canonical checkout refresh is blocked: local `main` in {root} has no upstream. Configure it to track `origin/main` before running a live write lane.")]
-    MissingUpstream { root: PathBuf },
+    #[error("canonical checkout refresh is blocked: local `{base_branch}` in {root} has no upstream. Configure it to track `origin/{base_branch}` before running a live write lane.")]
+    MissingUpstream { root: PathBuf, base_branch: String },
     #[error("canonical checkout refresh is blocked: {root} is under workflow workspace root {workspace_root}. Run write-mode lane/control commands from the canonical checkout, not an issue worktree.")]
     IssueWorktree {
         root: PathBuf,
@@ -155,9 +164,10 @@ pub enum CanonicalCheckoutError {
         stdout: String,
         stderr: String,
     },
-    #[error("canonical checkout refresh is blocked: local `main` at {head} cannot fast-forward to upstream `{upstream}` at {upstream_head}.")]
+    #[error("canonical checkout refresh is blocked: local `{base_branch}` at {head} cannot fast-forward to upstream `{upstream}` at {upstream_head}.")]
     NonFastForward {
         root: PathBuf,
+        base_branch: String,
         head: String,
         upstream: String,
         upstream_head: String,
@@ -229,14 +239,14 @@ pub fn enforce_clean_canonical_checkout_for_write(
 ) -> Result<CanonicalCheckoutReport, CanonicalCheckoutError> {
     let mut report = inspect_canonical_checkout(root, config)?;
     ensure_not_issue_worktree(&report, config)?;
-    ensure_attached_main(&report)?;
+    ensure_attached_base(&report, config.git_base_branch())?;
     ensure_clean_enough_for_write(&report)?;
     migrate_classified_artifacts(&mut report)?;
     if !report.migrated.is_empty() {
         let migrated = report.migrated.clone();
         report = inspect_canonical_checkout(root, config)?;
         report.migrated = migrated;
-        ensure_attached_main(&report)?;
+        ensure_attached_base(&report, config.git_base_branch())?;
         ensure_clean_enough_for_write(&report)?;
     }
     if let (Some(upstream), Some(upstream_head), Some(head)) = (
@@ -245,8 +255,9 @@ pub fn enforce_clean_canonical_checkout_for_write(
         report.head.as_deref(),
     ) {
         if head != upstream_head {
-            return Err(CanonicalCheckoutError::StaleMain {
+            return Err(CanonicalCheckoutError::StaleBaseBranch {
                 root: report.root.clone(),
+                base_branch: config.git_base_branch().to_string(),
                 head: head.to_string(),
                 upstream: upstream.to_string(),
                 upstream_head: upstream_head.to_string(),
@@ -264,9 +275,9 @@ pub fn refresh_canonical_checkout_before_write(
 ) -> Result<CanonicalCheckoutRefreshReport, CanonicalCheckoutError> {
     let mut report = inspect_canonical_checkout(root, config)?;
     ensure_not_issue_worktree(&report, config)?;
-    ensure_attached_main(&report)?;
+    ensure_attached_base(&report, config.git_base_branch())?;
     ensure_clean_enough_for_write(&report)?;
-    let upstream = require_upstream(&report)?;
+    let upstream = require_upstream(&report, config.git_base_branch())?;
 
     if matches!(mode, CanonicalCheckoutRefreshMode::Apply) {
         migrate_classified_artifacts(&mut report)?;
@@ -274,7 +285,7 @@ pub fn refresh_canonical_checkout_before_write(
         let migrated = report.migrated.clone();
         report = inspect_canonical_checkout(root, config)?;
         report.migrated = migrated;
-        ensure_attached_main(&report)?;
+        ensure_attached_base(&report, config.git_base_branch())?;
         ensure_clean_enough_for_write(&report)?;
     }
 
@@ -284,6 +295,7 @@ pub fn refresh_canonical_checkout_before_write(
         .as_deref()
         .ok_or_else(|| CanonicalCheckoutError::MissingUpstream {
             root: report.root.clone(),
+            base_branch: config.git_base_branch().to_string(),
         })?
         .to_string();
 
@@ -302,6 +314,7 @@ pub fn refresh_canonical_checkout_before_write(
     if !git_can_fast_forward(&report.root, &head_before, &upstream_head)? {
         return Err(CanonicalCheckoutError::NonFastForward {
             root: report.root.clone(),
+            base_branch: config.git_base_branch().to_string(),
             head: head_before,
             upstream,
             upstream_head,
@@ -407,18 +420,23 @@ fn ensure_not_issue_worktree(
     Ok(())
 }
 
-fn ensure_attached_main(report: &CanonicalCheckoutReport) -> Result<(), CanonicalCheckoutError> {
+fn ensure_attached_base(
+    report: &CanonicalCheckoutReport,
+    base_branch: &str,
+) -> Result<(), CanonicalCheckoutError> {
     let head = report.head.as_deref().unwrap_or("unknown").to_string();
     let Some(branch) = report.branch.as_deref() else {
         return Err(CanonicalCheckoutError::Detached {
             root: report.root.clone(),
             head,
+            expected_branch: base_branch.to_string(),
         });
     };
-    if branch != "main" {
-        return Err(CanonicalCheckoutError::NonMain {
+    if branch != base_branch {
+        return Err(CanonicalCheckoutError::NonBaseBranch {
             root: report.root.clone(),
             branch: branch.to_string(),
+            expected_branch: base_branch.to_string(),
         });
     }
     Ok(())
@@ -448,13 +466,17 @@ fn ensure_clean_enough_for_write(
     Ok(())
 }
 
-fn require_upstream(report: &CanonicalCheckoutReport) -> Result<String, CanonicalCheckoutError> {
+fn require_upstream(
+    report: &CanonicalCheckoutReport,
+    base_branch: &str,
+) -> Result<String, CanonicalCheckoutError> {
     report
         .upstream
         .clone()
         .filter(|upstream| !upstream.trim().is_empty())
         .ok_or_else(|| CanonicalCheckoutError::MissingUpstream {
             root: report.root.clone(),
+            base_branch: base_branch.to_string(),
         })
 }
 
@@ -496,6 +518,7 @@ fn fetch_upstream(root: &Path, upstream: &str) -> Result<(), CanonicalCheckoutEr
             .split_once('/')
             .ok_or_else(|| CanonicalCheckoutError::MissingUpstream {
                 root: root.to_path_buf(),
+                base_branch: upstream.to_string(),
             })?;
     let output = Command::new("git")
         .args(["fetch", remote, branch])
@@ -758,8 +781,13 @@ mod tests {
     use std::process::Command;
 
     fn config(root: &Path) -> RuntimeConfig {
+        config_with_base(root, "main")
+    }
+
+    fn config_with_base(root: &Path, base_branch: &str) -> RuntimeConfig {
         let markdown = format!(
-            "---\ntracker:\n  kind: memory\nartifacts:\n  root: {}\nworkspace:\n  root: {}/worktrees\nobservability:\n  logs_root: {}/logs\n---\nPrompt",
+            "---\ntracker:\n  kind: memory\ngit:\n  base_branch: {}\nartifacts:\n  root: {}\nworkspace:\n  root: {}/worktrees\nobservability:\n  logs_root: {}/logs\n---\nPrompt",
+            base_branch,
             root.display(),
             root.display(),
             root.display()
@@ -911,6 +939,30 @@ mod tests {
         assert_eq!(report.action, CanonicalCheckoutRefreshAction::FfOnly);
         assert_eq!(report.head_after, remote_head);
         assert_eq!(git_head(&repo), remote_head);
+    }
+
+    #[test]
+    fn refresh_accepts_configured_base_branch() {
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, _remote) = init_repo_with_origin(temp.path());
+        git_ok(&repo, &["checkout", "-b", "dev-chunteng"]);
+        fs::write(repo.join("tracked.txt"), "dev\n").unwrap();
+        git_ok(&repo, &["add", "tracked.txt"]);
+        git_ok(&repo, &["commit", "-qm", "dev base"]);
+        git_ok(&repo, &["push", "-u", "origin", "dev-chunteng"]);
+
+        let report = refresh_canonical_checkout_before_write(
+            &repo,
+            &config_with_base(temp.path(), "dev-chunteng"),
+            CanonicalCheckoutRefreshMode::Apply,
+        )
+        .unwrap();
+
+        assert_eq!(
+            report.action,
+            CanonicalCheckoutRefreshAction::AlreadyCurrent
+        );
+        assert_eq!(report.checkout.branch.as_deref(), Some("dev-chunteng"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -465,10 +465,7 @@ struct AutopilotPlanArgs {
 struct AutopilotLoopArgs {
     #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
     workflow_path: PathBuf,
-    #[arg(
-        long,
-        help = "Bounded number of foreground Autoloop iterations to run"
-    )]
+    #[arg(long, help = "Bounded number of foreground Autoloop iterations to run")]
     max_iterations: Option<usize>,
     #[arg(
         long,

--- a/src/commands/autopilot/readiness.rs
+++ b/src/commands/autopilot/readiness.rs
@@ -266,7 +266,8 @@ impl AutopilotCanonicalCheckout {
         };
         match inspect_canonical_checkout(&root, config) {
             Ok(report) => {
-                let reason = canonical_checkout_readiness_blocker(&report);
+                let reason =
+                    canonical_checkout_readiness_blocker(&report, config.git_base_branch());
                 Self {
                     safe_for_write: reason.is_none(),
                     root: Some(report.root.display().to_string()),
@@ -294,12 +295,17 @@ impl AutopilotCanonicalCheckout {
     }
 }
 
-fn canonical_checkout_readiness_blocker(report: &CanonicalCheckoutReport) -> Option<String> {
+fn canonical_checkout_readiness_blocker(
+    report: &CanonicalCheckoutReport,
+    base_branch: &str,
+) -> Option<String> {
     let Some(branch) = report.branch.as_deref() else {
         return Some("HEAD is detached".into());
     };
-    if branch != "main" {
-        return Some(format!("current branch is {branch:?}, expected \"main\""));
+    if branch != base_branch {
+        return Some(format!(
+            "current branch is {branch:?}, expected \"{base_branch}\""
+        ));
     }
     if let (Some(head), Some(upstream), Some(upstream_head)) = (
         report.head.as_deref(),
@@ -308,7 +314,7 @@ fn canonical_checkout_readiness_blocker(report: &CanonicalCheckoutReport) -> Opt
     ) {
         if head != upstream_head {
             return Some(format!(
-                "local main does not match upstream {upstream} at {upstream_head}"
+                "local {base_branch} does not match upstream {upstream} at {upstream_head}"
             ));
         }
     }

--- a/src/commands/forge.rs
+++ b/src/commands/forge.rs
@@ -299,7 +299,7 @@ fn ensure_forge_parent_integration_branch_evidence(
         &parent_issue,
         first_subissue_ref,
         &parent_integration_branch,
-        "main",
+        config.git_base_branch(),
     );
     adapter.upsert_workpad(&parent_issue.identifier, &workpad)?;
     append_tracker_mutation_audit(

--- a/src/commands/workspace/cleanup.rs
+++ b/src/commands/workspace/cleanup.rs
@@ -7,7 +7,7 @@ use shea_symphony::profiles::selected_execution_profile;
 use shea_symphony::tracker::adapter_from_config;
 use shea_symphony::workspace::remove_issue_workspace;
 
-use crate::orchestration::{load_config, DEFAULT_RUN_LOOP_BASE_BRANCH};
+use crate::orchestration::load_config;
 
 pub(crate) fn cleanup_workspaces(
     workflow_path: PathBuf,
@@ -114,7 +114,7 @@ pub(crate) fn workspace_cleanup_plan(
         let plan = match plan_issue_handoff_for_profile(
             &config.workspace.root,
             issue,
-            DEFAULT_RUN_LOOP_BASE_BRANCH,
+            config.git_base_branch(),
             profile_namespace,
         ) {
             Ok(plan) => plan,

--- a/src/commands/workspace/ensure.rs
+++ b/src/commands/workspace/ensure.rs
@@ -118,7 +118,13 @@ pub(crate) fn workspace_ensure(
         return Ok(());
     }
 
-    ensure_inspection_worktree(&repo_root, &workspace_path, &branch_name, pr_number)?;
+    ensure_inspection_worktree(
+        &repo_root,
+        &workspace_path,
+        &branch_name,
+        pr_number,
+        &plan.pull_request.base_branch,
+    )?;
     let worktrees = git_worktree_list(&repo_root)?;
     let candidate =
         validate_workspace_adoption(&issue, &workspace_path, &worktrees).map_err(|error| {
@@ -273,6 +279,7 @@ pub(crate) fn ensure_inspection_worktree(
     workspace_path: &Path,
     branch_name: &str,
     pr_number: Option<u64>,
+    base_branch: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if workspace_path.exists() {
         let candidate = IssueWorkspaceCandidate {
@@ -330,7 +337,14 @@ pub(crate) fn ensure_inspection_worktree(
     }
 
     let output = ProcessCommand::new("git")
-        .args(["worktree", "add", "-b", branch_name, &workspace_arg, "main"])
+        .args([
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            &workspace_arg,
+            base_branch,
+        ])
         .current_dir(repo_root)
         .output()?;
     if !output.status.success() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,9 +8,12 @@ use thiserror::Error;
 
 use crate::workflow::WorkflowDefinition;
 
+pub const DEFAULT_GIT_BASE_BRANCH: &str = "main";
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeConfig {
     pub tracker: TrackerConfig,
+    pub git: GitConfig,
     pub polling: PollingConfig,
     pub workspace: WorkspaceConfig,
     pub worker: WorkerConfig,
@@ -78,6 +81,11 @@ pub struct AssigneeFilter {
 pub struct WorkpadConfig {
     pub source: String,
     pub marker: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GitConfig {
+    pub base_branch: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -274,6 +282,10 @@ pub enum ConfigError {
 }
 
 impl RuntimeConfig {
+    pub fn git_base_branch(&self) -> &str {
+        &self.git.base_branch
+    }
+
     pub fn from_workflow(
         workflow: &WorkflowDefinition,
         workflow_path: &Path,
@@ -282,6 +294,7 @@ impl RuntimeConfig {
         let root = workflow.config.as_object().cloned().unwrap_or_default();
 
         let tracker = parse_tracker(root.get("tracker"), workflow_dir);
+        let git = parse_git(root.get("git"));
         let polling = PollingConfig {
             interval_ms: get_u64(root.get("polling"), "interval_ms").unwrap_or(30_000),
         };
@@ -413,6 +426,7 @@ impl RuntimeConfig {
 
         Ok(Self {
             tracker,
+            git,
             polling,
             workspace,
             worker,
@@ -475,6 +489,7 @@ impl RuntimeConfig {
         }
 
         require_positive("polling.interval_ms", self.polling.interval_ms)?;
+        require_present("git.base_branch", Some(self.git.base_branch.as_str()))?;
         require_positive("hooks.timeout_ms", self.hooks.timeout_ms)?;
         if let Some(limit) = self.worker.max_concurrent_agents_per_host {
             if limit <= 0 {
@@ -558,6 +573,14 @@ impl RuntimeConfig {
             .filter(|state| !state.is_empty())
             .collect()
     }
+}
+
+fn parse_git(value: Option<&Value>) -> GitConfig {
+    let base_branch = get_string(value, "base_branch")
+        .map(|branch| branch.trim().to_string())
+        .filter(|branch| !branch.is_empty())
+        .unwrap_or_else(|| DEFAULT_GIT_BASE_BRANCH.to_string());
+    GitConfig { base_branch }
 }
 
 fn parse_tracker(value: Option<&Value>, workflow_dir: &Path) -> TrackerConfig {
@@ -946,7 +969,22 @@ mod tests {
             config.tracker.workpad.marker,
             "<!-- shea-symphony-workpad -->"
         );
+        assert_eq!(config.git.base_branch, DEFAULT_GIT_BASE_BRANCH);
         assert_eq!(config.tracker.project_owner_type, None);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn git_base_branch_is_workflow_configurable() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\ngit:\n  base_branch: dev-chunteng\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert_eq!(config.git_base_branch(), "dev-chunteng");
         assert!(config.validate().is_ok());
     }
 

--- a/src/git_handoff.rs
+++ b/src/git_handoff.rs
@@ -292,7 +292,7 @@ fn ensure_local_parent_integration_branch(
         .branch_target
         .parent_final_base_branch
         .as_deref()
-        .unwrap_or("main");
+        .unwrap_or(plan.pull_request.base_branch.as_str());
     require_success(
         "git",
         runner.run(

--- a/src/lanes/main_loop/handoff.rs
+++ b/src/lanes/main_loop/handoff.rs
@@ -22,7 +22,7 @@ use shea_symphony::workpad_templates::{render_workpad_template, WorkpadTemplateI
 use shea_symphony::workspace::run_workspace_command;
 
 use super::IssueExecutionResult;
-use crate::orchestration::{current_git_branch, DEFAULT_RUN_LOOP_BASE_BRANCH};
+use crate::orchestration::current_git_branch;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RunLoopLiveHandoff {
@@ -61,7 +61,7 @@ pub(crate) fn run_loop_handoff_plan(
     let mut plan = plan_issue_handoff_for_profile(
         &config.workspace.root,
         issue,
-        DEFAULT_RUN_LOOP_BASE_BRANCH,
+        config.git_base_branch(),
         profile.as_deref(),
     )?;
 

--- a/src/lanes/merge/tick.rs
+++ b/src/lanes/merge/tick.rs
@@ -238,7 +238,8 @@ pub(crate) fn merge_once_tick(
             .ok_or("stale-branch decision missing pull request URL")?;
         let output = update_pull_request_branch(pr_ref, &runner, &std::env::current_dir()?)?;
         if output.status == 0 {
-            let workpad = merge_lane_workpad(&issue, &decision, Some(&output));
+            let workpad =
+                merge_lane_workpad(&issue, &decision, Some(&output), default_expected_base);
             let comment_outcome = record_merge_timeline_comment_with_recovery(
                 &config,
                 adapter.as_ref(),
@@ -265,7 +266,8 @@ pub(crate) fn merge_once_tick(
             single_line(&output.stdout),
             single_line(&output.stderr)
         );
-        let workpad = merge_lane_workpad(&issue, &failed_update, Some(&output));
+        let workpad =
+            merge_lane_workpad(&issue, &failed_update, Some(&output), default_expected_base);
         record_merge_timeline_comment_with_recovery(
             &config,
             adapter.as_ref(),
@@ -326,7 +328,7 @@ pub(crate) fn merge_once_tick(
             );
             output
         };
-        let workpad = merge_lane_workpad(&issue, &decision, Some(&output));
+        let workpad = merge_lane_workpad(&issue, &decision, Some(&output), default_expected_base);
         record_done_merge_lane_completion(
             &config,
             adapter.as_ref(),
@@ -343,7 +345,7 @@ pub(crate) fn merge_once_tick(
         return Ok(MergeOnceOutcome::Merged);
     }
 
-    let workpad = merge_lane_workpad(&issue, &decision, None);
+    let workpad = merge_lane_workpad(&issue, &decision, None, default_expected_base);
     record_merge_timeline_comment_with_recovery(
         &config,
         adapter.as_ref(),

--- a/src/lanes/merge/tick/dirty.rs
+++ b/src/lanes/merge/tick/dirty.rs
@@ -60,6 +60,7 @@ pub(super) fn handle_dirty_merge(
             &repaired_decision,
             Some(&repair.output),
             Some(&evidence),
+            config.git_base_branch(),
         );
         let comment_outcome = record_merge_timeline_comment_with_recovery(
             config,
@@ -102,6 +103,7 @@ pub(super) fn handle_dirty_merge(
             &agent_decision,
             Some(&agent_repair.output),
             Some(&agent_repair.evidence),
+            config.git_base_branch(),
         );
         record_merge_timeline_comment_with_recovery(
             config,
@@ -162,6 +164,7 @@ pub(super) fn handle_dirty_merge(
         &failed_repair,
         Some(&repair.output),
         Some(&evidence),
+        config.git_base_branch(),
     );
     record_merge_timeline_comment_with_recovery(
         config,

--- a/src/main/tests.rs
+++ b/src/main/tests.rs
@@ -152,9 +152,23 @@ fn canonical_checkout_report_accepts_latest_main() {
     let (_temp, repo, _remote) = canonical_git_repo();
 
     assert_eq!(
-        canonical_checkout_report(&repo),
+        canonical_checkout_report(&repo, "main"),
         CanonicalCheckoutReport::Ready
     );
+}
+
+#[test]
+fn canonical_checkout_report_accepts_configured_base_branch() {
+    let (_temp, repo, _remote) = canonical_git_repo();
+    git_ok(&repo, &["checkout", "-b", "dev-chunteng"]);
+    std::fs::write(repo.join("README.md"), "dev\n").unwrap();
+    git_ok(&repo, &["add", "README.md"]);
+    git_ok(&repo, &["commit", "-m", "dev base"]);
+    git_ok(&repo, &["push", "-u", "origin", "dev-chunteng"]);
+
+    let report = canonical_checkout_report(&repo, "dev-chunteng");
+
+    assert_eq!(report, CanonicalCheckoutReport::Ready);
 }
 
 #[test]
@@ -162,7 +176,7 @@ fn canonical_checkout_report_blocks_detached_head() {
     let (_temp, repo, _remote) = canonical_git_repo();
     git_ok(&repo, &["checkout", "--detach", "HEAD"]);
 
-    let report = canonical_checkout_report(&repo);
+    let report = canonical_checkout_report(&repo, "main");
     assert!(matches!(
         report,
         CanonicalCheckoutReport::Blocked { ref reason } if reason.contains("detached")
@@ -174,7 +188,7 @@ fn canonical_checkout_report_blocks_non_main_branch() {
     let (_temp, repo, _remote) = canonical_git_repo();
     git_ok(&repo, &["checkout", "-b", "feature/test"]);
 
-    let report = canonical_checkout_report(&repo);
+    let report = canonical_checkout_report(&repo, "main");
     assert!(matches!(
         report,
         CanonicalCheckoutReport::Blocked { ref reason } if reason.contains("current branch")
@@ -196,7 +210,7 @@ fn canonical_checkout_report_blocks_main_behind_origin_main() {
     git_ok(&other, &["commit", "-m", "advance main"]);
     git_ok(&other, &["push", "origin", "main"]);
 
-    let report = canonical_checkout_report(&repo);
+    let report = canonical_checkout_report(&repo, "main");
     assert!(matches!(
         report,
         CanonicalCheckoutReport::Blocked { ref reason }
@@ -875,13 +889,64 @@ fn workspace_ensure_creates_only_under_configured_workspace_root() {
     let plan = plan_issue_handoff_for_profile(&workspace_root, &issue, "main", None).unwrap();
 
     validate_workspace_path_under_root(&workspace_root, &plan.workspace_path).unwrap();
-    ensure_inspection_worktree(&repo, &plan.workspace_path, &plan.branch_name, None).unwrap();
+    ensure_inspection_worktree(
+        &repo,
+        &plan.workspace_path,
+        &plan.branch_name,
+        None,
+        &plan.pull_request.base_branch,
+    )
+    .unwrap();
 
     assert!(plan.workspace_path.starts_with(&workspace_root));
     assert!(plan.workspace_path.is_dir());
     assert_eq!(
         current_git_branch(&plan.workspace_path).unwrap().as_deref(),
         Some(plan.branch_name.as_str())
+    );
+}
+
+#[test]
+fn workspace_ensure_creates_worktree_from_configured_base_branch() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    ProcessCommand::new("git")
+        .args(["init", "--initial-branch=main", repo.to_str().unwrap()])
+        .status()
+        .unwrap();
+    ProcessCommand::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(&repo)
+        .status()
+        .unwrap();
+    ProcessCommand::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(&repo)
+        .status()
+        .unwrap();
+    std::fs::write(repo.join("README.md"), "main\n").unwrap();
+    git_ok(&repo, &["add", "README.md"]);
+    git_ok(&repo, &["commit", "-qm", "init"]);
+    git_ok(&repo, &["checkout", "-b", "dev-chunteng"]);
+    std::fs::write(repo.join("BASE.txt"), "dev base\n").unwrap();
+    git_ok(&repo, &["add", "BASE.txt"]);
+    git_ok(&repo, &["commit", "-qm", "dev base"]);
+    git_ok(&repo, &["checkout", "main"]);
+
+    let workspace_path = temp.path().join("workspaces").join("issue-448");
+    ensure_inspection_worktree(
+        &repo,
+        &workspace_path,
+        "feature/issue-448-configurable-base",
+        None,
+        "dev-chunteng",
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(workspace_path.join("BASE.txt")).unwrap(),
+        "dev base\n"
     );
 }
 

--- a/src/main/tests/main_loop/handoff.rs
+++ b/src/main/tests/main_loop/handoff.rs
@@ -28,6 +28,21 @@ fn run_loop_handoff_plan_uses_issue_workspace_and_branch_plan() {
 }
 
 #[test]
+fn run_loop_handoff_plan_uses_configured_base_branch() {
+    let mut config = test_config();
+    config.git.base_branch = "dev-chunteng".into();
+    let issue = tracker_issue("In Progress");
+
+    let handoff = run_loop_handoff_plan(&config, &issue).unwrap();
+
+    assert_eq!(handoff.pull_request.base_branch, "dev-chunteng");
+    assert_eq!(
+        handoff.branch_target.pull_request_base_branch,
+        "dev-chunteng"
+    );
+}
+
+#[test]
 fn run_loop_handoff_plan_rejects_branch_for_different_issue() {
     let config = test_config();
     let mut issue = tracker_issue("In Progress");

--- a/src/merge_lane.rs
+++ b/src/merge_lane.rs
@@ -686,8 +686,15 @@ pub fn merge_lane_workpad(
     issue: &TrackerIssue,
     decision: &MergeLaneDecision,
     merge_output: Option<&CommandOutput>,
+    default_base_branch: &str,
 ) -> String {
-    merge_lane_workpad_with_repair_evidence(issue, decision, merge_output, None)
+    merge_lane_workpad_with_repair_evidence(
+        issue,
+        decision,
+        merge_output,
+        None,
+        default_base_branch,
+    )
 }
 
 pub fn merge_lane_workpad_with_repair_evidence(
@@ -695,8 +702,9 @@ pub fn merge_lane_workpad_with_repair_evidence(
     decision: &MergeLaneDecision,
     merge_output: Option<&CommandOutput>,
     repair_evidence: Option<&MergeRepairEvidence>,
+    default_base_branch: &str,
 ) -> String {
-    let branch_target = branch_target_evidence(issue, expected_merge_base_branch_for_workpad());
+    let branch_target = branch_target_evidence(issue, default_base_branch);
     let mut preflight = vec![
         "- This lane only consumes issues already in `Merging`.".to_string(),
         "- It must not move work into `Human Review`.".to_string(),
@@ -892,12 +900,8 @@ fn civil_from_days(days_since_unix_epoch: i64) -> (i64, u32, u32) {
     (year, month as u32, day as u32)
 }
 
-pub fn expected_merge_base_branch(_config: &RuntimeConfig) -> &'static str {
-    "main"
-}
-
-fn expected_merge_base_branch_for_workpad() -> &'static str {
-    "main"
+pub fn expected_merge_base_branch(config: &RuntimeConfig) -> &str {
+    config.git_base_branch()
 }
 
 fn pull_request_status_from_json(
@@ -1177,6 +1181,20 @@ mod tests {
                 conclusion: Some("SUCCESS".into()),
             }],
         }
+    }
+
+    #[test]
+    fn expected_merge_base_uses_configured_git_base_branch() {
+        let workflow = crate::workflow::WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\ngit:\n  base_branch: dev-chunteng\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md"))
+                .unwrap();
+
+        assert_eq!(expected_merge_base_branch(&config), "dev-chunteng");
     }
 
     fn subissue(state: &str, prs: Vec<LinkedPullRequest>) -> TrackerIssue {
@@ -1594,8 +1612,13 @@ branch refs/heads/feature/issue-60
             next_state_rationale: "stay in Merging for reread".into(),
         };
 
-        let workpad =
-            merge_lane_workpad_with_repair_evidence(&issue, &decision, None, Some(&evidence));
+        let workpad = merge_lane_workpad_with_repair_evidence(
+            &issue,
+            &decision,
+            None,
+            Some(&evidence),
+            "main",
+        );
 
         assert!(workpad.contains("### Merge Repair Evidence"));
         assert!(workpad.contains("- Method: `merge_agent`"));
@@ -1634,6 +1657,7 @@ branch refs/heads/feature/issue-60
             &decision,
             Some(&output),
             Some(&evidence),
+            "main",
         );
 
         assert!(workpad.len() < 65_536, "workpad len={}", workpad.len());
@@ -1725,7 +1749,7 @@ branch refs/heads/feature/issue-60
     fn need_human_input_workpad_includes_actionable_question() {
         let issue = issue("Merging", Vec::new());
         let decision = merge_lane_decision(&issue, "Merging", "main", &[], None);
-        let workpad = merge_lane_workpad(&issue, &decision, None);
+        let workpad = merge_lane_workpad(&issue, &decision, None, "main");
 
         assert!(workpad.contains("### Required Human Input"));
         assert!(workpad.contains("Which pull request should this Merging issue land?"));
@@ -1762,7 +1786,7 @@ branch refs/heads/feature/issue-60
             &issue.linked_pull_requests,
             Some(&status),
         );
-        let workpad = merge_lane_workpad(&issue, &decision, None);
+        let workpad = merge_lane_workpad(&issue, &decision, None, "main");
 
         assert_eq!(decision.kind, MergeLaneDecisionKind::ReadyToMerge);
         assert_eq!(decision.target_state, Some("done"));

--- a/src/orchestration/canonical_checkout.rs
+++ b/src/orchestration/canonical_checkout.rs
@@ -99,7 +99,9 @@ pub(crate) fn append_canonical_checkout_gap(config: &RuntimeConfig, gaps: &mut V
         gaps.push("canonical_checkout_blocked: current directory is unavailable".into());
         return;
     };
-    if let Some(reason) = canonical_checkout_report(&current_dir).blocker() {
+    if let Some(reason) =
+        canonical_checkout_report(&current_dir, config.git_base_branch()).blocker()
+    {
         gaps.push(format!("canonical_checkout_blocked: {reason}"));
     }
 }
@@ -119,7 +121,7 @@ impl CanonicalCheckoutReport {
     }
 }
 
-pub(crate) fn canonical_checkout_report(path: &Path) -> CanonicalCheckoutReport {
+pub(crate) fn canonical_checkout_report(path: &Path, base_branch: &str) -> CanonicalCheckoutReport {
     let branch = match git_stdout(path, &["branch", "--show-current"]) {
         Ok(branch) if !branch.trim().is_empty() => branch.trim().to_string(),
         Ok(_) => {
@@ -133,15 +135,15 @@ pub(crate) fn canonical_checkout_report(path: &Path) -> CanonicalCheckoutReport 
             }
         }
     };
-    if branch != "main" {
+    if branch != base_branch {
         return CanonicalCheckoutReport::Blocked {
-            reason: format!("current branch is {branch:?}, expected \"main\""),
+            reason: format!("current branch is {branch:?}, expected \"{base_branch}\""),
         };
     }
 
-    if let Err(error) = git_status(path, &["fetch", "--quiet", "origin", "main"]) {
+    if let Err(error) = git_status(path, &["fetch", "--quiet", "origin", base_branch]) {
         return CanonicalCheckoutReport::Blocked {
-            reason: format!("git fetch origin main failed: {error}"),
+            reason: format!("git fetch origin {base_branch} failed: {error}"),
         };
     }
 
@@ -153,17 +155,18 @@ pub(crate) fn canonical_checkout_report(path: &Path) -> CanonicalCheckoutReport 
             }
         }
     };
-    let origin_main = match git_stdout(path, &["rev-parse", "origin/main"]) {
+    let origin_base = format!("origin/{base_branch}");
+    let origin_head = match git_stdout(path, &["rev-parse", &origin_base]) {
         Ok(value) => value.trim().to_string(),
         Err(error) => {
             return CanonicalCheckoutReport::Blocked {
-                reason: format!("cannot read origin/main: {error}"),
+                reason: format!("cannot read {origin_base}: {error}"),
             }
         }
     };
-    if head != origin_main {
+    if head != origin_head {
         return CanonicalCheckoutReport::Blocked {
-            reason: "local main does not exactly match origin/main".into(),
+            reason: format!("local {base_branch} does not exactly match {origin_base}"),
         };
     }
 

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -43,5 +43,4 @@ pub(crate) use tracker_recovery::{
 };
 pub(crate) use workflow_config::{
     load_config, require_write_intent, warn_if_temporary_workflow_path,
-    DEFAULT_RUN_LOOP_BASE_BRANCH,
 };

--- a/src/orchestration/workflow_config.rs
+++ b/src/orchestration/workflow_config.rs
@@ -3,8 +3,6 @@ use std::path::Path;
 use shea_symphony::config::RuntimeConfig;
 use shea_symphony::workflow::WorkflowDefinition;
 
-pub(crate) const DEFAULT_RUN_LOOP_BASE_BRANCH: &str = "main";
-
 pub(crate) fn require_write_intent(write: bool) -> Result<(), Box<dyn std::error::Error>> {
     if write {
         Ok(())

--- a/workflows/prompts/main-agent.md
+++ b/workflows/prompts/main-agent.md
@@ -83,10 +83,10 @@ Standalone `Shea Symphony Rework Run` comments are append-only trigger or diagno
 
 ## Git And PR Discipline
 
-- Base the issue branch on the current `origin/main` unless the issue says otherwise.
-- For native GitHub subissues, create the normal per-subissue feature branch but open the PR against the parent integration branch recorded in topology evidence. For parent issues with native subissues, the parent final PR uses the parent integration branch as the head and `main` as the base.
+- Base the issue branch on the current workflow git base branch (`git.base_branch`, default `main`) unless the issue says otherwise.
+- For native GitHub subissues, create the normal per-subissue feature branch but open the PR against the parent integration branch recorded in topology evidence. For parent issues with native subissues, the parent final PR uses the parent integration branch as the head and the configured workflow git base branch as the base.
 - Native subissues still stop Main work at `Agent Review`; passing Review Agent evidence routes routine child issues to `Merging`, not direct Human Review, unless the child records `Subissue Human Review Exception: <reason>`.
-- The canonical harness checkout must stay on latest `main`; dogfood branches belong in separate issue worktrees.
+- The canonical harness checkout must stay on the latest workflow git base branch; dogfood branches belong in separate issue worktrees.
 - Use a branch name that includes the issue number.
 - Keep one issue per branch and one branch per PR.
 - Do not rewrite or revert unrelated user changes.

--- a/workflows/prompts/merge-agent.md
+++ b/workflows/prompts/merge-agent.md
@@ -23,13 +23,13 @@ Use Shea Symphony CLI for Project state, Project fields, claim locks, workpad up
 - Confirm exactly one reliable PR target exists.
 - Preserve the assigned structured claim `run=` in merge evidence, timeline comments, and final summaries.
 - Refresh the PR state, review decision, checks, mergeability, base branch, and linked issue evidence before merge.
-- Use native parent/subissue branch target evidence when validating the PR base: subissue PRs merge into the parent integration branch, while parent final PRs merge into `main`.
+- Use native parent/subissue branch target evidence when validating the PR base: subissue PRs merge into the parent integration branch, while parent final PRs merge into the configured workflow git base branch (`git.base_branch`, default `main`).
 - Use `workspace show` before local merge repair. Prefer the canonical Main PR worktree/branch, and do not create a replacement worktree when a usable canonical candidate exists.
 - If multiple strong candidates exist, require an operator `workspace adopt` choice before repairing local conflicts.
 - If no suitable candidate exists and local repair needs files, use `workspace ensure` from the canonical checkout; do not run `gh pr checkout` or switch branches in the canonical checkout.
 - Merge only when the PR is clean, current, and approved by the Project state.
 - Record merge evidence, final commit/merge information, and tracker updates.
-- A merged subissue PR targeting the parent integration branch may move the subissue to `Done`; it is not final parent approval for `main`.
+- A merged subissue PR targeting the parent integration branch may move the subissue to `Done`; it is not final parent approval for the configured workflow git base branch.
 
 ## Blocker Routing
 

--- a/workflows/shea-symphony.md
+++ b/workflows/shea-symphony.md
@@ -34,6 +34,8 @@ tracker:
   workpad:
     source: issue_comment
     marker: "<!-- shea-symphony-workpad -->"
+git:
+  base_branch: main
 prompts:
   main_agent: prompts/main-agent.md
   review_agent: prompts/review-agent.md


### PR DESCRIPTION
## Summary
- Implements #448: Add workflow-configurable git base branch.

## Branch Target Evidence
- Branch target role: `Subissue`
- PR base branch: `integration/issue-447-enable-shea-tauri-gui-to-operate-on-external-target-workspaces`
- Native parent issue: `#447`
- Parent integration branch: `integration/issue-447-enable-shea-tauri-gui-to-operate-on-external-target-workspaces`
- Parent final PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #448
