### PR TITLE
#449: Add Tauri external workspace target profile

### DIFF
--- a/app/src-tauri/src/autoloop.rs
+++ b/app/src-tauri/src/autoloop.rs
@@ -16,24 +16,34 @@ use crate::autoloop_state::{
     default_lanes, AutoloopError, AutoloopLine, AutoloopOptions, AutoloopStarted, AutoloopStopped,
     LoopManager, LoopRuntime, LoopStateSnapshot,
 };
-use crate::cli::{command_preview, now_ms, shea_command, DEFAULT_WORKFLOW_PATH};
+use crate::cli::{command_preview_for_workspace, now_ms, shea_command_for_workspace};
+use crate::workspace::WorkspaceManager;
 
 #[tauri::command]
-pub fn get_loop_state(manager: State<'_, LoopManager>) -> Result<LoopStateSnapshot, String> {
-    Ok(manager
+pub fn get_loop_state(
+    manager: State<'_, LoopManager>,
+    workspace: State<'_, WorkspaceManager>,
+) -> Result<LoopStateSnapshot, String> {
+    let mut state = manager
         .inner
         .lock()
         .map_err(|error| error.to_string())?
         .state
-        .clone())
+        .clone();
+    if !state.running {
+        state.workflow_path = workspace.current().workflow_path;
+    }
+    Ok(state)
 }
 
 #[tauri::command]
 pub fn start_autoloop(
     app: AppHandle,
     manager: State<'_, LoopManager>,
+    workspace: State<'_, WorkspaceManager>,
     options: Option<AutoloopOptions>,
 ) -> Result<LoopStateSnapshot, String> {
+    let workspace_profile = workspace.current();
     let options = options.unwrap_or(AutoloopOptions {
         workflow_path: None,
         max_iterations: Some(1),
@@ -49,7 +59,7 @@ pub fn start_autoloop(
     let workflow_path = options
         .workflow_path
         .clone()
-        .unwrap_or_else(|| DEFAULT_WORKFLOW_PATH.into());
+        .unwrap_or_else(|| workspace_profile.workflow_path.clone());
     let write = options.write.unwrap_or(false);
     let mode = if write { "write" } else { "dry-run" }.to_string();
     let mut args = vec![
@@ -113,9 +123,12 @@ pub fn start_autoloop(
         };
     }
 
-    let mut command = shea_command(&args.iter().map(String::as_str).collect::<Vec<_>>());
+    let mut command = shea_command_for_workspace(
+        &args.iter().map(String::as_str).collect::<Vec<_>>(),
+        &workspace_profile,
+    );
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let command_for_event = command_preview(&args);
+    let command_for_event = command_preview_for_workspace(&args, &workspace_profile);
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {
@@ -188,20 +201,25 @@ pub fn start_autoloop(
         }
     });
 
-    get_loop_state(manager)
+    get_loop_state(manager, workspace)
 }
 
 #[tauri::command]
 pub fn stop_autoloop(
     app: AppHandle,
     manager: State<'_, LoopManager>,
+    workspace: State<'_, WorkspaceManager>,
 ) -> Result<LoopStateSnapshot, String> {
     let pid = {
         let mut runtime = manager.inner.lock().map_err(|error| error.to_string())?;
         let Some(pid) = runtime.state.pid else {
             runtime.state.running = false;
             runtime.state.stopping = false;
-            return Ok(runtime.state.clone());
+            let mut state = runtime.state.clone();
+            if !state.running {
+                state.workflow_path = workspace.current().workflow_path;
+            }
+            return Ok(state);
         };
         runtime.state.stopping = true;
         pid
@@ -226,7 +244,7 @@ pub fn stop_autoloop(
         return Err(format!("failed to signal autoloop stop: {error}"));
     }
 
-    get_loop_state(manager)
+    get_loop_state(manager, workspace)
 }
 
 fn spawn_line_reader<R: std::io::Read + Send + 'static>(

--- a/app/src-tauri/src/autoloop_events.rs
+++ b/app/src-tauri/src/autoloop_events.rs
@@ -439,7 +439,7 @@ fn apply_json_settings(state: &mut LoopStateSnapshot, settings: Option<&Value>) 
     for (lane, field) in lane_concurrency {
         if let Some(value) = settings
             .get(field)
-            .or_else(|| settings.get(&snake_to_camel(field)))
+            .or_else(|| settings.get(snake_to_camel(field)))
             .and_then(Value::as_u64)
         {
             state
@@ -486,7 +486,7 @@ fn string_json_field(payload: &Value, key: &str) -> Option<String> {
         .map(str::to_string)
         .or_else(|| {
             payload
-                .get(&snake_to_camel(key))
+                .get(snake_to_camel(key))
                 .and_then(Value::as_str)
                 .map(str::to_string)
         })
@@ -495,7 +495,7 @@ fn string_json_field(payload: &Value, key: &str) -> Option<String> {
 fn count_json_field(payload: &Value, key: &str) -> Option<usize> {
     payload
         .get(key)
-        .or_else(|| payload.get(&snake_to_camel(key)))
+        .or_else(|| payload.get(snake_to_camel(key)))
         .and_then(Value::as_u64)
         .map(|value| value as usize)
 }

--- a/app/src-tauri/src/cli.rs
+++ b/app/src-tauri/src/cli.rs
@@ -1,11 +1,13 @@
 use std::{
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::{Command, Stdio},
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 use serde::Serialize;
 use serde_json::{json, Value};
+
+use crate::workspace::WorkspaceProfile;
 
 pub const DEFAULT_WORKFLOW_PATH: &str = "workflows/shea-symphony.md";
 
@@ -28,10 +30,10 @@ pub struct CommandRun {
     pub stdout: String,
 }
 
-pub fn run_shea_read(args: &[String]) -> CommandRun {
+pub fn run_shea_read_for_workspace(args: &[String], workspace: &WorkspaceProfile) -> CommandRun {
     let started_at = Instant::now();
     let string_args = args.iter().map(String::as_str).collect::<Vec<_>>();
-    let mut command = shea_command(&string_args);
+    let mut command = shea_command_for_workspace(&string_args, workspace);
     match command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -78,40 +80,63 @@ pub fn now_ms() -> u128 {
         .unwrap_or(0)
 }
 
-pub fn shea_command(args: &[&str]) -> Command {
-    let repo_root = repo_root();
-    if should_use_cargo_runner() {
-        let mut command = Command::new("cargo");
-        command
-            .args(["run", "--quiet", "--"])
-            .args(args)
-            .current_dir(repo_root);
-        command
+pub fn shea_command_for_workspace(args: &[&str], workspace: &WorkspaceProfile) -> Command {
+    command_from_spec(shea_command_spec(args, workspace))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SheaCommandSpec {
+    pub program: PathBuf,
+    pub args: Vec<String>,
+    pub current_dir: PathBuf,
+}
+
+pub fn shea_command_spec(args: &[&str], workspace: &WorkspaceProfile) -> SheaCommandSpec {
+    let engine_root = workspace.engine_path();
+    let target_root = workspace.target_path();
+    if should_use_cargo_runner_for_engine(&engine_root) {
+        let mut command_args = vec![
+            "run".into(),
+            "--quiet".into(),
+            "--manifest-path".into(),
+            engine_root.join("Cargo.toml").display().to_string(),
+            "--".into(),
+        ];
+        command_args.extend(args.iter().map(|arg| (*arg).to_string()));
+        SheaCommandSpec {
+            program: PathBuf::from("cargo"),
+            args: command_args,
+            current_dir: target_root,
+        }
     } else {
-        let binary = repo_root.join("target").join("debug").join("shea-symphony");
-        let mut command = Command::new(binary);
-        command.args(args).current_dir(repo_root);
-        command
+        SheaCommandSpec {
+            program: engine_root
+                .join("target")
+                .join("debug")
+                .join("shea-symphony"),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            current_dir: target_root,
+        }
     }
 }
 
-pub fn command_preview(args: &[String]) -> Vec<String> {
-    if should_use_cargo_runner() {
-        let mut preview = vec!["cargo".into(), "run".into(), "--quiet".into(), "--".into()];
-        preview.extend(args.iter().cloned());
-        preview
-    } else {
-        let repo_root = repo_root();
-        let binary = repo_root.join("target").join("debug").join("shea-symphony");
-        let mut preview = vec![binary.display().to_string()];
-        preview.extend(args.iter().cloned());
-        preview
-    }
+pub fn command_preview_for_workspace(args: &[String], workspace: &WorkspaceProfile) -> Vec<String> {
+    let string_args = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let spec = shea_command_spec(&string_args, workspace);
+    let mut preview = vec![spec.program.display().to_string()];
+    preview.extend(spec.args);
+    preview
 }
 
-fn should_use_cargo_runner() -> bool {
+fn command_from_spec(spec: SheaCommandSpec) -> Command {
+    let mut command = Command::new(spec.program);
+    command.args(spec.args).current_dir(spec.current_dir);
+    command
+}
+
+fn should_use_cargo_runner_for_engine(engine_root: &Path) -> bool {
     cfg!(debug_assertions)
-        || !repo_root()
+        || !engine_root
             .join("target")
             .join("debug")
             .join("shea-symphony")
@@ -168,7 +193,7 @@ fn command_run_from_error(args: &[String], started_at: Instant, error: String) -
     }
 }
 
-fn repo_root() -> PathBuf {
+pub fn repo_root() -> PathBuf {
     let source_root = source_repo_root();
     canonical_main_worktree(&source_root).unwrap_or(source_root)
 }
@@ -212,7 +237,8 @@ fn parse_canonical_main_worktree(text: &str) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_canonical_main_worktree;
+    use super::{parse_canonical_main_worktree, shea_command_spec};
+    use crate::workspace::WorkspaceProfile;
     use std::path::PathBuf;
 
     #[test]
@@ -230,6 +256,40 @@ branch refs/heads/main
         assert_eq!(
             parse_canonical_main_worktree(output),
             Some(PathBuf::from("/repo/main"))
+        );
+    }
+
+    #[test]
+    fn command_spec_uses_engine_manifest_and_target_cwd() {
+        let engine_root = PathBuf::from("/engine/shea-symphony");
+        let target_root = PathBuf::from("/target/repo");
+        let profile = WorkspaceProfile {
+            engine_root: engine_root.display().to_string(),
+            target_root: target_root.display().to_string(),
+            workflow_path: "workflows/shea-symphony.md".into(),
+            source: "test".into(),
+            error: None,
+        };
+
+        let spec = shea_command_spec(
+            &["autopilot", "plan", "workflows/shea-symphony.md"],
+            &profile,
+        );
+
+        assert_eq!(spec.program, PathBuf::from("cargo"));
+        assert_eq!(spec.current_dir, target_root);
+        assert_eq!(
+            spec.args,
+            vec![
+                "run",
+                "--quiet",
+                "--manifest-path",
+                "/engine/shea-symphony/Cargo.toml",
+                "--",
+                "autopilot",
+                "plan",
+                "workflows/shea-symphony.md",
+            ]
         );
     }
 }

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -5,13 +5,27 @@ mod cli;
 mod external_links;
 mod github;
 mod read_surfaces;
+mod workspace;
 
 use autoloop_state::LoopManager;
+use workspace::{default_profile_path, initial_workspace_profile, WorkspaceManager};
 
 fn main() {
+    let engine_root = cli::repo_root();
+    let profile_path = default_profile_path();
+    let args = std::env::args_os().collect::<Vec<_>>();
+    let workspace_profile = initial_workspace_profile(engine_root.clone(), &args, &profile_path);
+
     tauri::Builder::default()
         .manage(LoopManager::default())
+        .manage(WorkspaceManager::new(
+            engine_root,
+            workspace_profile,
+            profile_path,
+        ))
         .invoke_handler(tauri::generate_handler![
+            workspace::get_workspace_profile,
+            workspace::set_active_workspace,
             autoloop::start_autoloop,
             autoloop::stop_autoloop,
             autoloop::get_loop_state,

--- a/app/src-tauri/src/read_surfaces.rs
+++ b/app/src-tauri/src/read_surfaces.rs
@@ -11,9 +11,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::cli::{
-    command_summary_value, parse_json_output, pending_result, run_shea_read, shea_command,
-    timestamp_iso_like, CommandRun, DEFAULT_WORKFLOW_PATH,
+    command_summary_value, parse_json_output, pending_result, run_shea_read_for_workspace,
+    shea_command_for_workspace, timestamp_iso_like, CommandRun,
 };
+use crate::workspace::{WorkspaceManager, WorkspaceProfile};
 
 const DEFAULT_PROJECT_RATE_LIMIT_COOLDOWN_MS: u128 = 10 * 60 * 1000;
 const PROJECT_READ_SURFACES: &[&str] = &["autopilot", "doctor", "review", "githubQueue"];
@@ -26,11 +27,22 @@ pub struct OverviewOptions {
 }
 
 #[tauri::command]
-pub async fn get_runtime_snapshot() -> Result<serde_json::Value, String> {
-    tauri::async_runtime::spawn_blocking(|| {
-        let output = shea_command(&["status", "show", DEFAULT_WORKFLOW_PATH, "--json"])
-            .output()
-            .map_err(|error| format!("failed to run status snapshot: {error}"))?;
+pub async fn get_runtime_snapshot(
+    workspace: tauri::State<'_, WorkspaceManager>,
+) -> Result<serde_json::Value, String> {
+    let workspace_profile = workspace.current();
+    tauri::async_runtime::spawn_blocking(move || {
+        let output = shea_command_for_workspace(
+            &[
+                "status",
+                "show",
+                workspace_profile.workflow_path.as_str(),
+                "--json",
+            ],
+            &workspace_profile,
+        )
+        .output()
+        .map_err(|error| format!("failed to run status snapshot: {error}"))?;
         if !output.status.success() {
             return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
         }
@@ -42,25 +54,37 @@ pub async fn get_runtime_snapshot() -> Result<serde_json::Value, String> {
 }
 
 #[tauri::command]
-pub async fn get_operator_overview(options: Option<OverviewOptions>) -> Result<Value, String> {
+pub async fn get_operator_overview(
+    workspace: tauri::State<'_, WorkspaceManager>,
+    options: Option<OverviewOptions>,
+) -> Result<Value, String> {
     let scope = options
         .as_ref()
         .and_then(|options| options.scope.as_deref())
         .unwrap_or("full")
         .to_string();
-    tauri::async_runtime::spawn_blocking(move || build_operator_overview(&scope))
-        .await
-        .map_err(|error| format!("operator overview task failed: {error}"))?
+    let workspace_profile = workspace.current();
+    tauri::async_runtime::spawn_blocking(move || {
+        build_operator_overview(&scope, &workspace_profile)
+    })
+    .await
+    .map_err(|error| format!("operator overview task failed: {error}"))?
 }
 
 #[tauri::command]
 pub async fn get_read_surface(
+    workspace: tauri::State<'_, WorkspaceManager>,
     name: String,
     _force: Option<bool>,
     allow_project_fallback: Option<bool>,
 ) -> Result<Value, String> {
+    let workspace_profile = workspace.current();
     tauri::async_runtime::spawn_blocking(move || {
-        build_read_surface(&name, allow_project_fallback.unwrap_or(false))
+        build_read_surface(
+            &name,
+            allow_project_fallback.unwrap_or(false),
+            &workspace_profile,
+        )
     })
     .await
     .map_err(|error| format!("read surface task failed: {error}"))?
@@ -68,18 +92,25 @@ pub async fn get_read_surface(
 
 #[tauri::command]
 pub async fn get_codex_transcript(
+    workspace: tauri::State<'_, WorkspaceManager>,
     issue_ref: String,
     session_id: Option<String>,
 ) -> Result<Value, String> {
+    let workspace_profile = workspace.current();
     tauri::async_runtime::spawn_blocking(move || {
-        build_codex_transcript(&issue_ref, session_id.as_deref())
+        build_codex_transcript(&issue_ref, session_id.as_deref(), &workspace_profile)
     })
     .await
     .map_err(|error| format!("transcript read task failed: {error}"))?
 }
 
-fn build_read_surface(name: &str, allow_project_fallback: bool) -> Result<Value, String> {
-    let args = read_surface_args(name).ok_or_else(|| format!("unknown read surface: {name}"))?;
+fn build_read_surface(
+    name: &str,
+    allow_project_fallback: bool,
+    workspace: &WorkspaceProfile,
+) -> Result<Value, String> {
+    let args = read_surface_args(name, workspace)
+        .ok_or_else(|| format!("unknown read surface: {name}"))?;
     let result = if project_backed_surface(name) {
         match project_read_cooldown() {
             Some(cooldown) => {
@@ -88,15 +119,16 @@ fn build_read_surface(name: &str, allow_project_fallback: bool) -> Result<Value,
                     skipped_project_read_command(&args, &cooldown),
                     project_read_paused_payload(&cooldown),
                     String::new(),
+                    workspace,
                 ));
             }
-            None => run_project_read_surface(&args),
+            None => run_project_read_surface(&args, workspace),
         }
     } else {
-        run_shea_read(&args)
+        run_shea_read_for_workspace(&args, workspace)
     };
     let parsed = if name == "status" {
-        runtime_status_summary(&result, allow_project_fallback)
+        runtime_status_summary(&result, allow_project_fallback, workspace)
     } else {
         parse_json_output(&result.stdout)
     };
@@ -109,11 +141,19 @@ fn build_read_surface(name: &str, allow_project_fallback: bool) -> Result<Value,
         } else {
             String::new()
         },
+        workspace,
     ))
 }
 
-fn build_codex_transcript(issue_ref: &str, session_id: Option<&str>) -> Result<Value, String> {
-    let local_status = run_shea_read(&read_surface_args("status").unwrap_or_default());
+fn build_codex_transcript(
+    issue_ref: &str,
+    session_id: Option<&str>,
+    workspace: &WorkspaceProfile,
+) -> Result<Value, String> {
+    let local_status = run_shea_read_for_workspace(
+        &read_surface_args("status", workspace).unwrap_or_default(),
+        workspace,
+    );
     let snapshot = parse_json_output(&local_status.stdout);
     let normalized_issue = normalize_issue_ref(issue_ref);
     let candidates = transcript_candidates(&snapshot, normalized_issue.as_deref(), session_id);
@@ -238,9 +278,7 @@ fn codex_conversation_summary(content: &str, path: &Path) -> Value {
 }
 
 fn protocol_message_from_record(record: &Value) -> Option<Value> {
-    if record.get("direction").and_then(Value::as_str).is_none() {
-        return None;
-    }
+    record.get("direction").and_then(Value::as_str)?;
     let line = record.get("line").and_then(Value::as_str)?;
     serde_json::from_str::<Value>(line).ok()
 }
@@ -699,23 +737,25 @@ fn normalize_issue_ref(value: &str) -> Option<String> {
     }
 }
 
-fn build_operator_overview(scope: &str) -> Result<Value, String> {
+fn build_operator_overview(scope: &str, workspace: &WorkspaceProfile) -> Result<Value, String> {
     let generated_at = timestamp_iso_like();
-    let github_queue_args = read_surface_args("githubQueue").unwrap_or_default();
+    let github_queue_args = read_surface_args("githubQueue", workspace).unwrap_or_default();
+    let workflow_path = workspace.workflow_path.as_str();
 
     if scope == "fast" {
         let commands = json!({
-            "autopilot": pending_result(&["autopilot", "plan", DEFAULT_WORKFLOW_PATH, "--json"], "Deferred to full overview."),
-            "doctor": pending_result(&["doctor", DEFAULT_WORKFLOW_PATH, "--json"], "Deferred to full overview."),
-            "review": pending_result(&["review", "status", DEFAULT_WORKFLOW_PATH, "--json"], "Deferred to full overview."),
-            "skills": pending_result(&["skills", "status", DEFAULT_WORKFLOW_PATH, "--json"], "Deferred to background read."),
-            "sessions": pending_result(&["session", "list", DEFAULT_WORKFLOW_PATH], "Deferred to background read."),
-            "status": pending_result(&["status", "show", DEFAULT_WORKFLOW_PATH, "--json"], "Deferred to background read."),
-            "githubQueue": pending_result(&["project", "state", DEFAULT_WORKFLOW_PATH, "--json"], "Deferred to background Project queue read."),
+            "autopilot": pending_result(&["autopilot", "plan", workflow_path, "--json"], "Deferred to full overview."),
+            "doctor": pending_result(&["doctor", workflow_path, "--json"], "Deferred to full overview."),
+            "review": pending_result(&["review", "status", workflow_path, "--json"], "Deferred to full overview."),
+            "skills": pending_result(&["skills", "status", workflow_path, "--json"], "Deferred to background read."),
+            "sessions": pending_result(&["session", "list", workflow_path], "Deferred to background read."),
+            "status": pending_result(&["status", "show", workflow_path, "--json"], "Deferred to background read."),
+            "githubQueue": pending_result(&["project", "state", workflow_path, "--json"], "Deferred to background Project queue read."),
         });
         return Ok(json!({
             "generatedAt": generated_at,
-            "workflowPath": DEFAULT_WORKFLOW_PATH,
+            "workflowPath": workflow_path,
+            "workspace": workspace,
             "scope": "fast",
             "commands": commands,
             "autopilot": Value::Null,
@@ -729,14 +769,31 @@ fn build_operator_overview(scope: &str) -> Result<Value, String> {
         }));
     }
 
-    let runtime = run_shea_read(&read_surface_args("status").unwrap_or_default());
-    let autopilot =
-        run_project_read_surface_or_skip(&read_surface_args("autopilot").unwrap_or_default());
-    let doctor = run_project_read_surface_or_skip(&read_surface_args("doctor").unwrap_or_default());
-    let review = run_project_read_surface_or_skip(&read_surface_args("review").unwrap_or_default());
-    let skills = run_shea_read(&read_surface_args("skills").unwrap_or_default());
-    let sessions = run_shea_read(&read_surface_args("sessions").unwrap_or_default());
-    let github_queue = run_project_read_surface_or_skip(&github_queue_args);
+    let runtime = run_shea_read_for_workspace(
+        &read_surface_args("status", workspace).unwrap_or_default(),
+        workspace,
+    );
+    let autopilot = run_project_read_surface_or_skip(
+        &read_surface_args("autopilot", workspace).unwrap_or_default(),
+        workspace,
+    );
+    let doctor = run_project_read_surface_or_skip(
+        &read_surface_args("doctor", workspace).unwrap_or_default(),
+        workspace,
+    );
+    let review = run_project_read_surface_or_skip(
+        &read_surface_args("review", workspace).unwrap_or_default(),
+        workspace,
+    );
+    let skills = run_shea_read_for_workspace(
+        &read_surface_args("skills", workspace).unwrap_or_default(),
+        workspace,
+    );
+    let sessions = run_shea_read_for_workspace(
+        &read_surface_args("sessions", workspace).unwrap_or_default(),
+        workspace,
+    );
+    let github_queue = run_project_read_surface_or_skip(&github_queue_args, workspace);
     let healthy = [
         autopilot.summary.ok,
         doctor.summary.ok,
@@ -748,7 +805,8 @@ fn build_operator_overview(scope: &str) -> Result<Value, String> {
 
     Ok(json!({
         "generatedAt": generated_at,
-        "workflowPath": DEFAULT_WORKFLOW_PATH,
+        "workflowPath": workflow_path,
+        "workspace": workspace,
         "commands": {
             "autopilot": command_summary_value(&autopilot.summary),
             "doctor": command_summary_value(&doctor.summary),
@@ -763,59 +821,56 @@ fn build_operator_overview(scope: &str) -> Result<Value, String> {
         "review": parse_json_output(&review.stdout),
         "skills": parse_json_output(&skills.stdout),
         "sessionsText": sessions.stdout.trim(),
-        "localStatus": runtime_status_summary(&runtime, false),
+        "localStatus": runtime_status_summary(&runtime, false, workspace),
         "githubQueue": parse_json_output(&github_queue.stdout),
         "healthy": healthy,
     }))
 }
 
-fn read_surface_args(name: &str) -> Option<Vec<String>> {
+fn read_surface_args(name: &str, workspace: &WorkspaceProfile) -> Option<Vec<String>> {
+    let workflow_path = workspace.workflow_path.clone();
     match name {
         "autopilot" => Some(vec![
             "autopilot".into(),
             "plan".into(),
-            DEFAULT_WORKFLOW_PATH.into(),
+            workflow_path,
             "--json".into(),
         ]),
-        "doctor" => Some(vec![
-            "doctor".into(),
-            DEFAULT_WORKFLOW_PATH.into(),
-            "--json".into(),
-        ]),
+        "doctor" => Some(vec!["doctor".into(), workflow_path, "--json".into()]),
         "review" => Some(vec![
             "review".into(),
             "status".into(),
-            DEFAULT_WORKFLOW_PATH.into(),
+            workflow_path,
             "--json".into(),
         ]),
         "skills" => Some(vec![
             "skills".into(),
             "status".into(),
-            DEFAULT_WORKFLOW_PATH.into(),
+            workflow_path,
             "--json".into(),
         ]),
-        "sessions" => Some(vec![
-            "session".into(),
-            "list".into(),
-            DEFAULT_WORKFLOW_PATH.into(),
-        ]),
+        "sessions" => Some(vec!["session".into(), "list".into(), workflow_path]),
         "status" => Some(vec![
             "status".into(),
             "show".into(),
-            DEFAULT_WORKFLOW_PATH.into(),
+            workflow_path,
             "--json".into(),
         ]),
         "githubQueue" => Some(vec![
             "project".into(),
             "state".into(),
-            DEFAULT_WORKFLOW_PATH.into(),
+            workflow_path,
             "--json".into(),
         ]),
         _ => None,
     }
 }
 
-fn runtime_status_summary(result: &CommandRun, allow_project_fallback: bool) -> Value {
+fn runtime_status_summary(
+    result: &CommandRun,
+    allow_project_fallback: bool,
+    workspace: &WorkspaceProfile,
+) -> Value {
     let snapshot = parse_json_output(&result.stdout);
     if snapshot.is_null() {
         return Value::Null;
@@ -845,9 +900,9 @@ fn runtime_status_summary(result: &CommandRun, allow_project_fallback: bool) -> 
         .and_then(Value::as_array)
         .map(Vec::len)
         .unwrap_or(0);
-    let issue_worktrees = git_worktree_issue_inventory();
+    let issue_worktrees = git_worktree_issue_inventory(workspace);
     let project_issues = if allow_project_fallback && project_read_cooldown().is_none() {
-        project_issue_readbacks(&issue_worktrees, &snapshot)
+        project_issue_readbacks(&issue_worktrees, &snapshot, workspace)
     } else {
         Value::Array(vec![])
     };
@@ -1030,7 +1085,11 @@ fn completed_issue_worktrees(
     Value::Array(completed.into_values().collect())
 }
 
-fn project_issue_readbacks(issue_worktrees: &Value, snapshot: &Value) -> Value {
+fn project_issue_readbacks(
+    issue_worktrees: &Value,
+    snapshot: &Value,
+    workspace: &WorkspaceProfile,
+) -> Value {
     let registry_issues = session_registry_issue_refs(snapshot);
     let mut issues = BTreeMap::new();
     for worktree in issue_worktrees.as_array().into_iter().flatten() {
@@ -1040,7 +1099,7 @@ fn project_issue_readbacks(issue_worktrees: &Value, snapshot: &Value) -> Value {
         if registry_issues.contains_key(issue) || issues.contains_key(issue) {
             continue;
         }
-        if let Some(readback) = project_issue_readback(issue) {
+        if let Some(readback) = project_issue_readback(issue, workspace) {
             let _ = write_project_readback_session(snapshot, worktree, &readback);
             issues.insert(issue.to_string(), readback);
         }
@@ -1081,13 +1140,22 @@ fn session_registry_issue_refs(snapshot: &Value) -> BTreeMap<String, Value> {
     issues
 }
 
-fn project_issue_readback(issue: &str) -> Option<Value> {
+fn project_issue_readback(issue: &str, workspace: &WorkspaceProfile) -> Option<Value> {
     if project_read_cooldown().is_some() {
         return None;
     }
-    let output = shea_command(&["project", "issue", DEFAULT_WORKFLOW_PATH, issue, "--json"])
-        .output()
-        .ok()?;
+    let output = shea_command_for_workspace(
+        &[
+            "project",
+            "issue",
+            workspace.workflow_path.as_str(),
+            issue,
+            "--json",
+        ],
+        workspace,
+    )
+    .output()
+    .ok()?;
     let stderr = String::from_utf8_lossy(&output.stderr);
     if project_rate_limit_detected(&stderr) {
         record_project_rate_limit_cooldown(&stderr);
@@ -1174,8 +1242,10 @@ fn unix_timestamp_ms() -> u64 {
         .unwrap_or(0)
 }
 
-fn git_worktree_issue_inventory() -> Value {
+fn git_worktree_issue_inventory(workspace: &WorkspaceProfile) -> Value {
     let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace.target_path())
         .args(["worktree", "list", "--porcelain"])
         .output();
     let Ok(output) = output else {
@@ -1346,11 +1416,18 @@ fn should_count_modified_time(path: &Path) -> bool {
     })
 }
 
-fn surface_payload(name: &str, command: Value, parsed: Value, text: String) -> Value {
+fn surface_payload(
+    name: &str,
+    command: Value,
+    parsed: Value,
+    text: String,
+    workspace: &WorkspaceProfile,
+) -> Value {
     json!({
         "name": name,
         "generatedAt": timestamp_iso_like(),
-        "workflowPath": DEFAULT_WORKFLOW_PATH,
+        "workflowPath": workspace.workflow_path.as_str(),
+        "workspace": workspace,
         "command": command,
         "parsed": parsed,
         "text": text,
@@ -1372,15 +1449,15 @@ fn project_backed_surface(name: &str) -> bool {
     PROJECT_READ_SURFACES.contains(&name)
 }
 
-fn run_project_read_surface_or_skip(args: &[String]) -> CommandRun {
+fn run_project_read_surface_or_skip(args: &[String], workspace: &WorkspaceProfile) -> CommandRun {
     if let Some(cooldown) = project_read_cooldown() {
         return skipped_command_run(args, skipped_project_read_stderr(&cooldown));
     }
-    run_project_read_surface(args)
+    run_project_read_surface(args, workspace)
 }
 
-fn run_project_read_surface(args: &[String]) -> CommandRun {
-    let result = run_shea_read(args);
+fn run_project_read_surface(args: &[String], workspace: &WorkspaceProfile) -> CommandRun {
+    let result = run_shea_read_for_workspace(args, workspace);
     if !result.summary.ok
         && (project_rate_limit_detected(&result.summary.stderr)
             || project_rate_limit_detected(&result.summary.stdout_preview)

--- a/app/src-tauri/src/workspace.rs
+++ b/app/src-tauri/src/workspace.rs
@@ -1,0 +1,334 @@
+use std::{
+    env,
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::cli::DEFAULT_WORKFLOW_PATH;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceProfile {
+    pub engine_root: String,
+    pub target_root: String,
+    pub workflow_path: String,
+    pub source: String,
+    pub error: Option<String>,
+}
+
+impl WorkspaceProfile {
+    pub fn self_targeted(engine_root: PathBuf) -> Self {
+        let root = canonicalize_or_keep(engine_root);
+        Self {
+            engine_root: root.display().to_string(),
+            target_root: root.display().to_string(),
+            workflow_path: DEFAULT_WORKFLOW_PATH.into(),
+            source: "self".into(),
+            error: None,
+        }
+    }
+
+    pub fn engine_path(&self) -> PathBuf {
+        PathBuf::from(&self.engine_root)
+    }
+
+    pub fn target_path(&self) -> PathBuf {
+        PathBuf::from(&self.target_root)
+    }
+
+    fn with_error(mut self, error: String) -> Self {
+        self.error = Some(error);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredWorkspaceProfile {
+    target_root: String,
+    workflow_path: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct WorkspaceManager {
+    inner: Arc<Mutex<WorkspaceProfile>>,
+    engine_root: PathBuf,
+    store_path: PathBuf,
+}
+
+impl WorkspaceManager {
+    pub fn new(engine_root: PathBuf, profile: WorkspaceProfile, store_path: PathBuf) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(profile)),
+            engine_root,
+            store_path,
+        }
+    }
+
+    pub fn current(&self) -> WorkspaceProfile {
+        self.inner
+            .lock()
+            .map(|profile| profile.clone())
+            .unwrap_or_else(|_| WorkspaceProfile::self_targeted(self.engine_root.clone()))
+    }
+
+    pub fn set_target(&self, target_root: Option<String>) -> Result<WorkspaceProfile, String> {
+        let trimmed = target_root.unwrap_or_default().trim().to_string();
+        let profile = if trimmed.is_empty() {
+            clear_stored_profile(&self.store_path)?;
+            WorkspaceProfile::self_targeted(self.engine_root.clone())
+        } else {
+            let profile = profile_from_target(&self.engine_root, Path::new(&trimmed), "saved")?;
+            save_stored_profile(&self.store_path, &profile)?;
+            profile
+        };
+        *self.inner.lock().map_err(|error| error.to_string())? = profile.clone();
+        Ok(profile)
+    }
+}
+
+#[tauri::command]
+pub fn get_workspace_profile(
+    manager: State<'_, WorkspaceManager>,
+) -> Result<WorkspaceProfile, String> {
+    Ok(manager.current())
+}
+
+#[tauri::command]
+pub fn set_active_workspace(
+    manager: State<'_, WorkspaceManager>,
+    target_root: Option<String>,
+) -> Result<WorkspaceProfile, String> {
+    manager.set_target(target_root)
+}
+
+pub fn default_profile_path() -> PathBuf {
+    if let Ok(path) = env::var("SHEA_SYMPHONY_APP_PROFILE_PATH") {
+        return PathBuf::from(path);
+    }
+    if let Ok(root) = env::var("SHEA_SYMPHONY_ARTIFACT_ROOT") {
+        return PathBuf::from(root).join("app-workspace-profile.json");
+    }
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".shea-symphony")
+        .join("app-workspace-profile.json")
+}
+
+pub fn initial_workspace_profile(
+    engine_root: PathBuf,
+    args: &[OsString],
+    store_path: &Path,
+) -> WorkspaceProfile {
+    match parse_workdir_arg(args) {
+        Ok(Some(path)) => match profile_from_target(&engine_root, &path, "launch") {
+            Ok(profile) => {
+                if let Err(error) = save_stored_profile(store_path, &profile) {
+                    profile.with_error(format!("workspace selected but not saved: {error}"))
+                } else {
+                    profile
+                }
+            }
+            Err(error) => WorkspaceProfile::self_targeted(engine_root).with_error(error),
+        },
+        Ok(None) => load_stored_profile(&engine_root, store_path)
+            .unwrap_or_else(|| WorkspaceProfile::self_targeted(engine_root)),
+        Err(error) => WorkspaceProfile::self_targeted(engine_root).with_error(error),
+    }
+}
+
+pub fn parse_workdir_arg(args: &[OsString]) -> Result<Option<PathBuf>, String> {
+    let mut index = 1;
+    while index < args.len() {
+        let arg = args[index].to_string_lossy();
+        if arg == "--workdir" {
+            let Some(value) = args.get(index + 1) else {
+                return Err("--workdir requires a target directory".into());
+            };
+            if value.to_string_lossy().starts_with("--") {
+                return Err("--workdir requires a target directory".into());
+            }
+            return Ok(Some(PathBuf::from(value)));
+        }
+        if let Some(value) = arg.strip_prefix("--workdir=") {
+            if value.is_empty() {
+                return Err("--workdir requires a target directory".into());
+            }
+            return Ok(Some(PathBuf::from(value)));
+        }
+        index += 1;
+    }
+    Ok(None)
+}
+
+fn load_stored_profile(engine_root: &Path, store_path: &Path) -> Option<WorkspaceProfile> {
+    let text = fs::read_to_string(store_path).ok()?;
+    let stored: StoredWorkspaceProfile = serde_json::from_str(&text).ok()?;
+    match profile_from_target(engine_root, Path::new(&stored.target_root), "saved") {
+        Ok(mut profile) => {
+            if let Some(workflow_path) = stored
+                .workflow_path
+                .filter(|value| !value.trim().is_empty())
+            {
+                profile.workflow_path = workflow_path;
+            }
+            Some(profile)
+        }
+        Err(error) => Some(
+            WorkspaceProfile::self_targeted(engine_root.to_path_buf())
+                .with_error(format!("saved workspace is unavailable: {error}")),
+        ),
+    }
+}
+
+fn profile_from_target(
+    engine_root: &Path,
+    target_root: &Path,
+    source: &str,
+) -> Result<WorkspaceProfile, String> {
+    let target = fs::canonicalize(target_root)
+        .map_err(|_| format!("target workspace does not exist: {}", target_root.display()))?;
+    if !target.is_dir() {
+        return Err(format!(
+            "target workspace is not a directory: {}",
+            target.display()
+        ));
+    }
+    Ok(WorkspaceProfile {
+        engine_root: canonicalize_or_keep(engine_root.to_path_buf())
+            .display()
+            .to_string(),
+        target_root: target.display().to_string(),
+        workflow_path: DEFAULT_WORKFLOW_PATH.into(),
+        source: source.into(),
+        error: None,
+    })
+}
+
+fn save_stored_profile(store_path: &Path, profile: &WorkspaceProfile) -> Result<(), String> {
+    if profile.target_root == profile.engine_root {
+        return clear_stored_profile(store_path);
+    }
+    if let Some(parent) = store_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    }
+    let stored = StoredWorkspaceProfile {
+        target_root: profile.target_root.clone(),
+        workflow_path: Some(profile.workflow_path.clone()),
+    };
+    fs::write(
+        store_path,
+        serde_json::to_string_pretty(&stored).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn clear_stored_profile(store_path: &Path) -> Result<(), String> {
+    match fs::remove_file(store_path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn canonicalize_or_keep(path: PathBuf) -> PathBuf {
+    fs::canonicalize(&path).unwrap_or(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{initial_workspace_profile, parse_workdir_arg};
+    use std::{
+        ffi::OsString,
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    #[test]
+    fn parses_valid_workdir_arg() {
+        let target = temp_dir("parse-valid-target");
+        let args = vec![
+            OsString::from("shea-symphony-app"),
+            OsString::from("--workdir"),
+            target.clone().into_os_string(),
+        ];
+
+        assert_eq!(parse_workdir_arg(&args).unwrap(), Some(target));
+    }
+
+    #[test]
+    fn rejects_missing_workdir_value() {
+        let args = vec![
+            OsString::from("shea-symphony-app"),
+            OsString::from("--workdir"),
+        ];
+
+        assert!(parse_workdir_arg(&args).is_err());
+    }
+
+    #[test]
+    fn invalid_launch_workdir_falls_back_to_self_with_error() {
+        let engine = temp_dir("invalid-engine");
+        let store_path = temp_dir("invalid-store").join("profile.json");
+        let missing = temp_path("missing-target");
+        let args = vec![
+            OsString::from("shea-symphony-app"),
+            OsString::from("--workdir"),
+            missing.into_os_string(),
+        ];
+
+        let profile = initial_workspace_profile(engine.clone(), &args, &store_path);
+
+        assert_eq!(
+            PathBuf::from(profile.target_root),
+            fs::canonicalize(engine).unwrap()
+        );
+        assert!(profile.error.unwrap_or_default().contains("does not exist"));
+    }
+
+    #[test]
+    fn launch_workdir_is_saved_and_restored() {
+        let engine = temp_dir("restore-engine");
+        let target = temp_dir("restore-target");
+        let store_path = temp_dir("restore-store").join("profile.json");
+        let args = vec![
+            OsString::from("shea-symphony-app"),
+            OsString::from("--workdir"),
+            target.clone().into_os_string(),
+        ];
+
+        let selected = initial_workspace_profile(engine.clone(), &args, &store_path);
+        let restored =
+            initial_workspace_profile(engine, &[OsString::from("shea-symphony-app")], &store_path);
+
+        assert_eq!(
+            selected.target_root,
+            fs::canonicalize(&target).unwrap().display().to_string()
+        );
+        assert_eq!(restored.target_root, selected.target_root);
+        assert_eq!(restored.source, "saved");
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let path = temp_path(name);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "shea-symphony-app-{name}-{}-{unique}",
+            std::process::id()
+        ))
+    }
+}

--- a/app/src/OperatorDesk.svelte
+++ b/app/src/OperatorDesk.svelte
@@ -59,6 +59,7 @@
     running: autoloopState.running,
     mode: autoloopState.mode,
     workflowPath: autoloopState.workflowPath,
+    targetRoot: '',
     latestLine: latestAutoloopLine,
     laneMaxSummary: laneMaxSummary(autoloopLanes)
   });
@@ -278,6 +279,7 @@
         running: false,
         mode: 'dry-run',
         workflowPath: 'workflows/shea-symphony.md',
+        targetRoot: '',
         latestLine: 'No recent autoloop result',
         laneMaxSummary: ''
       });

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -1428,6 +1428,13 @@ a {
   text-transform: uppercase;
 }
 
+.settings-section small {
+  min-width: 0;
+  color: var(--muted);
+  font-size: var(--text-xs);
+  overflow-wrap: anywhere;
+}
+
 .settings-select-row {
   gap: var(--space-2);
 }
@@ -1455,6 +1462,41 @@ a {
     6px 6px;
   background-repeat: no-repeat;
   line-height: 38px;
+}
+
+.settings-field {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.settings-field span {
+  color: var(--muted);
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.settings-field input {
+  width: 100%;
+  min-width: 0;
+  height: 38px;
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--fg);
+  background: var(--surface);
+  font: inherit;
+  font-size: var(--text-sm);
+}
+
+.settings-actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.settings-section small.settings-error {
+  color: var(--danger);
 }
 
 .handoff-picker,

--- a/app/src/lib/AppShell.svelte
+++ b/app/src/lib/AppShell.svelte
@@ -19,17 +19,21 @@
     resetFixtureOverview,
     setDataMode,
     setDefaultHandoffTarget,
+    workspaceProfileStore,
     updateCliLog
   } from './uiState.ts';
   import {
     appendAutoloopLine,
     defaultLoopState,
+    defaultWorkspaceProfile,
     getGitHubUser,
     getLoopState,
+    getWorkspaceProfile,
     isTauriRuntime,
     mergeLaneSnapshot,
     operatorLoopStatusDetail,
     operatorRunLogLines,
+    setActiveWorkspace,
     startAutoloop,
     stopAutoloop,
     subscribeAutoloopEvents,
@@ -37,7 +41,8 @@
     type LaneSnapshot,
     type LoopStateSnapshot,
     type RunLogVerbosity,
-    type GitHubUserSnapshot
+    type GitHubUserSnapshot,
+    type WorkspaceProfile
   } from './tauriAutoloop.ts';
   import CliLogModal from './shell/CliLogModal.svelte';
   import DeveloperToolsPanel from './shell/DeveloperToolsPanel.svelte';
@@ -78,9 +83,13 @@
   let runLogVerbosity: RunLogVerbosity = 'normal';
   let expandedRunLogRows = new Set<string>();
   let autoloopBusy = false;
+  let workspaceBusy = false;
   let tauriAvailable = false;
   let tauriError = '';
   let autoloopState: LoopStateSnapshot = defaultLoopState();
+  let workspaceProfile: WorkspaceProfile = defaultWorkspaceProfile();
+  let workspacePathInput = '';
+  let workspaceError = '';
   let settingsOpen = false;
   let developerToolsOpen = true;
   let developerToolsCollapsed = false;
@@ -106,16 +115,20 @@
   $: autoloopStdoutLines = latestAutoloopStdout(autoloopState, autoloopLogLines);
   $: visibleRunLogLines = autoloopStdoutLines.slice(-runLogDisplayLimit(runLogVerbosity));
   $: latestAutoloopLine = autoloopStdoutLines.slice(-1)[0]?.line ?? (autoloopState.running ? 'Loop is running' : 'No recent autoloop result');
+  $: activeWorkflowPath = workspaceProfile.workflowPath || 'workflows/shea-symphony.md';
+  $: activeTargetRoot = workspaceProfile.targetRoot || workspaceProfile.engineRoot || '';
   $: autoloopControlStore.set({
     tauriAvailable,
     busy: autoloopBusy,
     running: autoloopState.running,
     mode: autoloopState.mode,
-    workflowPath: autoloopState.workflowPath,
+    workflowPath: autoloopState.running ? autoloopState.workflowPath : activeWorkflowPath,
+    targetRoot: activeTargetRoot,
     latestLine: latestAutoloopLine,
     laneMaxSummary: laneMaxSummary(autoloopState?.lanes)
   });
   $: autoloopStateStore.set(autoloopState);
+  $: workspaceProfileStore.set(workspaceProfile);
   $: refreshRunning = $refreshStatusStore.running;
   $: refreshLabel = refreshRunning ? `Refreshing${$refreshStatusStore.remaining ? ` (${$refreshStatusStore.remaining})` : ''}` : 'Refresh';
   $: selectedRefreshOption =
@@ -551,6 +564,50 @@
     }
   }
 
+  async function refreshWorkspaceProfile() {
+    try {
+      tauriAvailable = isTauriRuntime();
+      workspaceProfile = await getWorkspaceProfile();
+      workspacePathInput = workspaceProfile.targetRoot;
+      workspaceError = workspaceProfile.error ?? '';
+    } catch (error) {
+      workspaceError = error.message;
+    }
+  }
+
+  async function saveWorkspaceProfile() {
+    if (!tauriAvailable || workspaceBusy) return;
+    workspaceBusy = true;
+    workspaceError = '';
+    try {
+      workspaceProfile = await setActiveWorkspace(workspacePathInput.trim() || null);
+      workspacePathInput = workspaceProfile.targetRoot;
+      workspaceError = workspaceProfile.error ?? '';
+      await refreshAutoloopState();
+      requestRefresh('workspace');
+    } catch (error) {
+      workspaceError = error.message;
+    } finally {
+      workspaceBusy = false;
+    }
+  }
+
+  async function resetWorkspaceProfile() {
+    if (!tauriAvailable || workspaceBusy) return;
+    workspaceBusy = true;
+    workspaceError = '';
+    try {
+      workspaceProfile = await setActiveWorkspace(null);
+      workspacePathInput = workspaceProfile.targetRoot;
+      await refreshAutoloopState();
+      requestRefresh('workspace-reset');
+    } catch (error) {
+      workspaceError = error.message;
+    } finally {
+      workspaceBusy = false;
+    }
+  }
+
   function laneConcurrency(lane: AutoloopLaneTarget) {
     if (lane === 'autoloop') return {};
     return {
@@ -567,9 +624,10 @@
     const startedAt = performance.now();
     const modeLabel = write ? 'write' : 'dry-run';
     const continuous = maxIterations == null;
+    const workflowPath = activeWorkflowPath;
     const loopArgs = continuous
-      ? ['autopilot', 'loop', 'workflows/shea-symphony.md', '--continuous', write ? '--write' : '--dry-run']
-      : ['autopilot', 'loop', 'workflows/shea-symphony.md', '--max-iterations', String(maxIterations), write ? '--write' : '--dry-run'];
+      ? ['autopilot', 'loop', workflowPath, '--continuous', write ? '--write' : '--dry-run']
+      : ['autopilot', 'loop', workflowPath, '--max-iterations', String(maxIterations), write ? '--write' : '--dry-run'];
     const laneOptions = laneConcurrency(lane);
     if (lane !== 'autoloop') {
       loopArgs.push('--main-max-concurrent', String(laneOptions.mainMaxConcurrent));
@@ -582,11 +640,11 @@
       status: 'running',
       detail: `Starting ${lane === 'autoloop' ? 'autoloop' : lane} ${modeLabel} ${continuous ? 'continuous' : `${maxIterations} iteration`} loop.`,
       args: loopArgs,
-      raw: { args: loopArgs, lane, write, maxIterations: maxIterations ?? null, continuous, ...laneOptions }
+      raw: { args: loopArgs, lane, write, maxIterations: maxIterations ?? null, continuous, workspace: workspaceProfile, ...laneOptions }
     });
     try {
       autoloopState = await startAutoloop({
-        workflowPath: 'workflows/shea-symphony.md',
+        workflowPath,
         maxIterations,
         continuous,
         write,
@@ -682,6 +740,7 @@
         error: error.message
       };
     });
+    refreshWorkspaceProfile();
     refreshAutoloopState();
     let unlistenAutoloop: (() => void) | undefined;
     subscribeAutoloopEvents((event) => {
@@ -808,10 +867,17 @@
     handoffTargets={HANDOFF_TARGETS}
     {handoffTarget}
     {developerToolsOpen}
+    {workspaceProfile}
+    {workspacePathInput}
+    {workspaceBusy}
+    {workspaceError}
     onClose={() => (settingsOpen = false)}
     onHandoffTargetChange={updateHandoffTarget}
     onHandoffTargetSelect={updateHandoffTargetValue}
     onDeveloperToolsVisibilityChange={updateDeveloperToolsVisibility}
+    onWorkspacePathInput={(event) => (workspacePathInput = (event.currentTarget as HTMLInputElement).value)}
+    onWorkspaceSave={saveWorkspaceProfile}
+    onWorkspaceReset={resetWorkspaceProfile}
   />
 {/if}
 

--- a/app/src/lib/shell/DeveloperToolsPanel.svelte
+++ b/app/src/lib/shell/DeveloperToolsPanel.svelte
@@ -22,6 +22,7 @@
     running: false,
     mode: 'dry-run',
     workflowPath: 'workflows/shea-symphony.md',
+    targetRoot: '',
     latestLine: 'No recent autoloop result',
     laneMaxSummary: ''
   };
@@ -176,6 +177,9 @@
         ? `${autoloopControl.mode} · ${autoloopControl.workflowPath}`
         : 'Open in Shea Symphony App desktop shell for live loop control.'}
     </p>
+    {#if autoloopControl.targetRoot}
+      <p class="developer-tool-note">{autoloopControl.targetRoot}</p>
+    {/if}
     {#if autoloopControl.laneMaxSummary}
       <p class="developer-tool-note">{autoloopControl.laneMaxSummary}</p>
     {/if}

--- a/app/src/lib/shell/SettingsModal.svelte
+++ b/app/src/lib/shell/SettingsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { GitHubUserSnapshot } from '../tauriAutoloop.ts';
+  import type { GitHubUserSnapshot, WorkspaceProfile } from '../tauriAutoloop.ts';
 
   type HandoffTarget = 'codex-app' | 'claude-code' | 'gemini-cli';
   type HandoffIcon = 'codex' | 'claude' | 'gemini';
@@ -10,10 +10,23 @@
   export let handoffTargets: { id: string; label: string; icon?: string }[] = [];
   export let handoffTarget: HandoffTarget = 'codex-app';
   export let developerToolsOpen = true;
+  export let workspaceProfile: WorkspaceProfile = {
+    engineRoot: '',
+    targetRoot: '',
+    workflowPath: 'workflows/shea-symphony.md',
+    source: 'self',
+    error: null
+  };
+  export let workspacePathInput = '';
+  export let workspaceBusy = false;
+  export let workspaceError = '';
   export let onClose: () => void = () => {};
   export let onHandoffTargetChange: (event: Event) => void = () => {};
   export let onHandoffTargetSelect: (target: HandoffTarget) => void = () => {};
   export let onDeveloperToolsVisibilityChange: (event: Event) => void = () => {};
+  export let onWorkspacePathInput: (event: Event) => void = () => {};
+  export let onWorkspaceSave: () => void = () => {};
+  export let onWorkspaceReset: () => void = () => {};
 
   let handoffMenuOpen = false;
 
@@ -79,6 +92,27 @@
           {/if}
           <small>{githubUserDetail}</small>
         </div>
+      </section>
+
+      <section class="settings-section">
+        <span class="settings-section-label">Workspace</span>
+        <label class="settings-field">
+          <span>Target root</span>
+          <input
+            type="text"
+            value={workspacePathInput}
+            placeholder={workspaceProfile.engineRoot || '/path/to/repository'}
+            disabled={workspaceBusy}
+            oninput={onWorkspacePathInput}
+          />
+        </label>
+        <div class="settings-actions-row">
+          <button class="btn btn-primary" type="button" disabled={workspaceBusy} onclick={onWorkspaceSave}>Save</button>
+          <button class="btn btn-ghost" type="button" disabled={workspaceBusy} onclick={onWorkspaceReset}>Use Shea checkout</button>
+        </div>
+        <small class:settings-error={workspaceError}>
+          {workspaceError || `${workspaceProfile.source} · ${workspaceProfile.targetRoot || workspaceProfile.engineRoot}`}
+        </small>
       </section>
 
       <section class="settings-section settings-section-inline">

--- a/app/src/lib/tauriAutoloop.ts
+++ b/app/src/lib/tauriAutoloop.ts
@@ -43,6 +43,14 @@ export type LoopStateSnapshot = {
   recentLines: AutoloopLine[];
 };
 
+export type WorkspaceProfile = {
+  engineRoot: string;
+  targetRoot: string;
+  workflowPath: string;
+  source: string;
+  error?: string | null;
+};
+
 export type RuntimeSnapshot = Record<string, unknown>;
 export type OperatorOverview = Record<string, unknown>;
 export type ReadSurface = Record<string, unknown>;
@@ -116,10 +124,32 @@ export function defaultLoopState() {
   return structuredClone(defaultState);
 }
 
+export function defaultWorkspaceProfile(): WorkspaceProfile {
+  return {
+    engineRoot: '',
+    targetRoot: '',
+    workflowPath: 'workflows/shea-symphony.md',
+    source: 'self',
+    error: null
+  };
+}
+
 export async function getLoopState(): Promise<LoopStateSnapshot> {
   if (!isTauriRuntime()) return defaultLoopState();
   const { invoke } = await import('@tauri-apps/api/core');
   return invoke<LoopStateSnapshot>('get_loop_state');
+}
+
+export async function getWorkspaceProfile(): Promise<WorkspaceProfile> {
+  if (!isTauriRuntime()) return defaultWorkspaceProfile();
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<WorkspaceProfile>('get_workspace_profile');
+}
+
+export async function setActiveWorkspace(targetRoot: string | null): Promise<WorkspaceProfile> {
+  if (!isTauriRuntime()) return defaultWorkspaceProfile();
+  const { invoke } = await import('@tauri-apps/api/core');
+  return invoke<WorkspaceProfile>('set_active_workspace', { targetRoot });
 }
 
 export async function getRuntimeSnapshot(): Promise<RuntimeSnapshot | null> {

--- a/app/src/lib/uiState.ts
+++ b/app/src/lib/uiState.ts
@@ -1,4 +1,5 @@
 import { writable } from 'svelte/store';
+import { defaultWorkspaceProfile, type WorkspaceProfile } from './tauriAutoloop.ts';
 
 export type CliLogEntry = {
   id: number;
@@ -29,6 +30,7 @@ export const HANDOFF_TARGETS = [
 ];
 
 export const defaultHandoffTargetStore = writable('codex-app');
+export const workspaceProfileStore = writable<WorkspaceProfile>(defaultWorkspaceProfile());
 export const autoloopStateStore = writable(null);
 export const cliLogStore = writable<CliLogEntry[]>([]);
 export const autoloopControlStore = writable({
@@ -37,6 +39,7 @@ export const autoloopControlStore = writable({
   running: false,
   mode: 'dry-run',
   workflowPath: 'workflows/shea-symphony.md',
+  targetRoot: '',
   latestLine: 'No recent autoloop result',
   laneMaxSummary: ''
 });

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -465,10 +465,7 @@ struct AutopilotPlanArgs {
 struct AutopilotLoopArgs {
     #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
     workflow_path: PathBuf,
-    #[arg(
-        long,
-        help = "Bounded number of foreground Autoloop iterations to run"
-    )]
+    #[arg(long, help = "Bounded number of foreground Autoloop iterations to run")]
     max_iterations: Option<usize>,
     #[arg(
         long,


### PR DESCRIPTION
## Summary
- Implements #449: Add Tauri external workspace target profile.

## Branch Target Evidence
- Branch target role: `Subissue`
- PR base branch: `integration/issue-447-enable-shea-tauri-gui-to-operate-on-external-target-workspaces`
- Native parent issue: `#447`
- Parent integration branch: `integration/issue-447-enable-shea-tauri-gui-to-operate-on-external-target-workspaces`
- Parent final PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #449
