### PR TITLE
#451: Support target repo-local .codex/skills

### DIFF
--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -215,6 +215,9 @@ broken symlinks, file-shaped aliases, missing `SKILL.md`, and optional
 current-session visibility. Without `--session-skills` or
 `--session-skills-file`, current-session visibility is `unknown` and is not a
 failure. Gemini absence is a blocker only when `--require-gemini` is used.
+Codex readiness defaults to the selected profile working directory's
+`.codex/skills`, then the workflow repo's `.codex/skills`; it does not read
+`CODEX_HOME`. Use an explicit `--codex-dir` only for an intentional override.
 
 ## Main Implementation Runtime
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -466,6 +466,10 @@ rendered metadata freshness, broken links, alias/file-shaped installs, missing
 is provided, session visibility is `unknown`; that is diagnostic context, not a
 failure. Gemini absence is not a failure unless the operator explicitly requires
 Gemini for the current environment.
+For target workspaces, Codex readiness inspects the selected profile working
+directory's `.codex/skills`; without a target profile working directory it falls
+back to the workflow repo's `.codex/skills`. It does not use `CODEX_HOME` or a
+home-directory Codex skill root.
 
 The packaged skills preserve the same lane boundaries as the Shea Symphony CLI:
 Issue Forge, Reflect, and Dream handle conversation, draft shaping, backlog

--- a/skills/shea-symphony/README.md
+++ b/skills/shea-symphony/README.md
@@ -51,8 +51,11 @@ optional current-session skill visibility. Source suite discovery is
 `skills/shea-symphony/suite`, then installed-only mode. Missing session input is
 reported as `unknown`, not as a failure. Gemini is optional unless the operator
 passes `--require-gemini` or otherwise configures a Gemini skill root.
+Codex readiness defaults to the selected profile working directory's
+`.codex/skills`, or this workflow repo's `.codex/skills` when no target profile
+working directory is configured. It does not use `CODEX_HOME`.
 
-The installer detects:
+The legacy self-repo installer detects:
 
 - Codex target from `CODEX_HOME/skills`, then `$HOME/.codex/skills`.
 - Gemini target from `GEMINI_HOME/local-skills`, then `$HOME/.gemini/local-skills`.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2934,6 +2934,7 @@ done
         let temp = tempfile::tempdir().unwrap();
         let (codex, trace_path) = fake_codex_app_server(temp.path());
         let workspace = temp.path().join("workspace");
+        let workspace_cwd = workspace.display().to_string();
         fs::create_dir_all(&workspace).unwrap();
         let config = codex_config(&format!("{} app-server", codex.display()), 5_000);
         let backend = CodexBackend;
@@ -2941,6 +2942,7 @@ done
             .prepare(workspace, "hello app-server".into(), &config)
             .unwrap();
         prepared.prompt_artifact_path = Some(temp.path().join("logs/prompts/app-server.prompt.md"));
+        prepared.session_registry_path = Some(temp.path().join("sessions/session-registry.json"));
         prepared.issue_identifier = Some("#368".into());
         prepared.issue_title = Some("Add Codex app-server transport backend harness".into());
         prepared
@@ -2988,6 +2990,10 @@ done
         assert!(trace.contains("\"method\":\"thread/start\""));
         assert!(trace.contains("\"method\":\"turn/start\""));
         assert!(trace.contains("\"approvalPolicy\":\"never\""));
+        assert!(trace.contains(&format!(
+            "\"cwd\":{}",
+            serde_json::to_string(&workspace_cwd).unwrap()
+        )));
         assert_eq!(trace.matches("\"reasoningEffort\":\"high\"").count(), 2);
         assert!(trace.contains("hello app-server"));
     }
@@ -3005,6 +3011,7 @@ done
             .prepare(workspace, "Continue".into(), &config)
             .unwrap();
         prepared.prompt_artifact_path = Some(temp.path().join("logs/prompts/app-server.prompt.md"));
+        prepared.session_registry_path = Some(temp.path().join("sessions/session-registry.json"));
         prepared.issue_identifier = Some("#368".into());
         prepared.app_server_resume_thread_id = Some("thread-368".into());
         prepared
@@ -3124,6 +3131,8 @@ done
                 .unwrap();
             prepared.prompt_artifact_path =
                 Some(temp.path().join("logs/prompts/app-server.prompt.md"));
+            prepared.session_registry_path =
+                Some(temp.path().join("sessions/session-registry.json"));
             prepared
                 .env
                 .insert("FAKE_CODEX_TRACE".into(), trace_path.display().to_string());
@@ -3155,6 +3164,8 @@ done
                 .unwrap();
             prepared.prompt_artifact_path =
                 Some(temp.path().join("logs/prompts/app-server.prompt.md"));
+            prepared.session_registry_path =
+                Some(temp.path().join("sessions/session-registry.json"));
             prepared
                 .env
                 .insert("FAKE_CODEX_TRACE".into(), trace_path.display().to_string());
@@ -3181,6 +3192,7 @@ done
             .prepare(workspace, "silent turn".into(), &config)
             .unwrap();
         prepared.prompt_artifact_path = Some(temp.path().join("logs/prompts/app-server.prompt.md"));
+        prepared.session_registry_path = Some(temp.path().join("sessions/session-registry.json"));
         prepared
             .env
             .insert("FAKE_CODEX_TRACE".into(), trace_path.display().to_string());
@@ -3212,6 +3224,7 @@ done
             .prepare(workspace, "partial stream".into(), &config)
             .unwrap();
         prepared.prompt_artifact_path = Some(temp.path().join("logs/prompts/app-server.prompt.md"));
+        prepared.session_registry_path = Some(temp.path().join("sessions/session-registry.json"));
         prepared
             .env
             .insert("FAKE_CODEX_TRACE".into(), trace_path.display().to_string());
@@ -3262,9 +3275,10 @@ done
         assert_eq!(prepared.profile_id.as_deref(), Some("codex-alpha"));
         assert_eq!(prepared.instance_name.as_deref(), Some("codex-alpha"));
         assert_eq!(
-            prepared.env.get("CODEX_HOME"),
+            prepared.env.get("SHEA_SYMPHONY_PROFILE_HOME"),
             Some(&"/tmp/cockpit/codex-alpha".into())
         );
+        assert!(!prepared.env.contains_key("CODEX_HOME"));
         assert_eq!(
             session_id_with_profile("codex-subprocess", &prepared),
             "codex-subprocess:codex-alpha"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -465,10 +465,7 @@ struct AutopilotPlanArgs {
 struct AutopilotLoopArgs {
     #[arg(value_name = "path-to-WORKFLOW.md", default_value = "WORKFLOW.md")]
     workflow_path: PathBuf,
-    #[arg(
-        long,
-        help = "Bounded number of foreground Autoloop iterations to run"
-    )]
+    #[arg(long, help = "Bounded number of foreground Autoloop iterations to run")]
     max_iterations: Option<usize>,
     #[arg(
         long,

--- a/src/profiles.rs
+++ b/src/profiles.rs
@@ -25,6 +25,9 @@ pub struct ExecutionProfile {
 impl ExecutionProfile {
     pub fn environment_for_backend(&self, backend: &str) -> BTreeMap<String, String> {
         let mut env = self.env.clone();
+        if backend == "codex" {
+            env.remove("CODEX_HOME");
+        }
         env.insert("SHEA_SYMPHONY_PROFILE_ID".into(), self.profile_id.clone());
         env.insert(
             "SHEA_SYMPHONY_INSTANCE_NAME".into(),
@@ -36,9 +39,6 @@ impl ExecutionProfile {
                 "SHEA_SYMPHONY_PROFILE_HOME".into(),
                 path.display().to_string(),
             );
-            if backend == "codex" {
-                env.insert("CODEX_HOME".into(), path.display().to_string());
-            }
         }
         if let Some(args) = &self.extra_args {
             if !args.trim().is_empty() {
@@ -229,7 +229,7 @@ mod tests {
     }
 
     #[test]
-    fn cockpit_profile_environment_sets_backend_context_without_account_ids() {
+    fn cockpit_profile_environment_sets_backend_context_without_account_ids_or_codex_home() {
         let profile = load_cockpit_codex_profiles(Path::new(
             "examples/fixtures/cockpit-tools-codex-instances.json",
         ))
@@ -247,10 +247,27 @@ mod tests {
             Some(&"codex-alpha".into())
         );
         assert_eq!(
-            env.get("CODEX_HOME"),
+            env.get("SHEA_SYMPHONY_PROFILE_HOME"),
             Some(&"/tmp/cockpit/codex-alpha".into())
         );
+        assert!(!env.contains_key("CODEX_HOME"));
         assert!(!env.contains_key("bindAccountId"));
         assert!(!env.contains_key("BIND_ACCOUNT_ID"));
+    }
+
+    #[test]
+    fn codex_profile_environment_ignores_configured_codex_home() {
+        let mut profile = load_cockpit_codex_profiles(Path::new(
+            "examples/fixtures/cockpit-tools-codex-instances.json",
+        ))
+        .unwrap()
+        .remove(0);
+        profile
+            .env
+            .insert("CODEX_HOME".into(), "/tmp/global".into());
+
+        let env = profile.environment_for_backend("codex");
+
+        assert!(!env.contains_key("CODEX_HOME"));
     }
 }

--- a/src/skill_status.rs
+++ b/src/skill_status.rs
@@ -4,6 +4,10 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
+use crate::config::RuntimeConfig;
+use crate::profiles::selected_execution_profile;
+use crate::workflow::WorkflowDefinition;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkillStatusInput {
     pub workflow_path: PathBuf,
@@ -480,13 +484,17 @@ fn manifest_line_value(line: &str, key: &str) -> Option<String> {
 }
 
 fn target_specs(input: &SkillStatusInput) -> Vec<TargetSpec> {
+    let codex_root = input
+        .codex_dir
+        .clone()
+        .unwrap_or_else(|| default_codex_root(input));
     vec![
         TargetSpec {
             label: "codex".into(),
-            root: input.codex_dir.clone().unwrap_or_else(default_codex_root),
+            root: codex_root,
             configured: input.codex_dir.is_some()
                 || nonempty_env_path("SHEA_SYMPHONY_CODEX_SKILLS_DIR").is_some()
-                || nonempty_env_path("CODEX_HOME").is_some(),
+                || profile_working_dir_from_workflow(&input.workflow_path).is_some(),
             required: true,
         },
         TargetSpec {
@@ -502,14 +510,16 @@ fn target_specs(input: &SkillStatusInput) -> Vec<TargetSpec> {
     ]
 }
 
-fn default_codex_root() -> PathBuf {
+fn default_codex_root(input: &SkillStatusInput) -> PathBuf {
     if let Some(path) = nonempty_env_path("SHEA_SYMPHONY_CODEX_SKILLS_DIR") {
         return path;
     }
-    if let Some(home) = nonempty_env_path("CODEX_HOME") {
-        return home.join("skills");
+    if let Some(path) = profile_working_dir_from_workflow(&input.workflow_path) {
+        return path.join(".codex").join("skills");
     }
-    home_dir().join(".codex").join("skills")
+    workflow_repo_root(&input.workflow_path)
+        .join(".codex")
+        .join("skills")
 }
 
 fn default_gemini_root() -> PathBuf {
@@ -520,6 +530,56 @@ fn default_gemini_root() -> PathBuf {
         return home.join("local-skills");
     }
     home_dir().join(".gemini").join("local-skills")
+}
+
+fn profile_working_dir_from_workflow(workflow_path: &Path) -> Option<PathBuf> {
+    let path = absolute_workflow_path(workflow_path)?;
+    let text = fs::read_to_string(&path).ok()?;
+    let workflow = WorkflowDefinition::parse(&path, &text).ok()?;
+    let config = RuntimeConfig::from_workflow(&workflow, &path).ok()?;
+    selected_execution_profile(&config.profiles)
+        .ok()
+        .flatten()
+        .and_then(|profile| profile.working_dir)
+}
+
+fn workflow_repo_root(workflow_path: &Path) -> PathBuf {
+    let Some(start) = absolute_workflow_path(workflow_path) else {
+        return std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    };
+    let mut cursor = start
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let fallback = if cursor.file_name().and_then(|name| name.to_str()) == Some("workflows") {
+        cursor
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| cursor.clone())
+    } else {
+        cursor.clone()
+    };
+    loop {
+        if cursor.join(".git").exists()
+            || cursor.join(".codex").exists()
+            || cursor.join("skills").join("shea-symphony").exists()
+        {
+            return cursor;
+        }
+        if !cursor.pop() {
+            return fallback;
+        }
+    }
+}
+
+fn absolute_workflow_path(workflow_path: &Path) -> Option<PathBuf> {
+    if workflow_path.is_absolute() {
+        Some(workflow_path.to_path_buf())
+    } else {
+        std::env::current_dir()
+            .ok()
+            .map(|cwd| cwd.join(workflow_path))
+    }
 }
 
 fn home_dir() -> PathBuf {
@@ -1361,5 +1421,77 @@ path = "suite/shea-symphony-issue-forge-dream"
         ));
         assert_eq!(report.summary.blockers, 0);
         assert_eq!(report.summary.gemini_status, "missing_optional");
+    }
+
+    #[test]
+    fn default_codex_target_is_workflow_repo_local_skills() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        write(&repo.join("workflows/shea-symphony.md"), "---\n---\nPrompt");
+        let source_suite = suite(&repo);
+        let repo_codex = repo.join(".codex/skills");
+        write(
+            &repo_codex.join("shea-symphony-doctor/SKILL.md"),
+            &fs::read_to_string(source_suite.join("shea-symphony-doctor/SKILL.md")).unwrap(),
+        );
+
+        let report = build_skill_readiness_report(SkillStatusInput {
+            workflow_path: repo.join("workflows/shea-symphony.md"),
+            suite_path: Some(source_suite),
+            codex_dir: None,
+            gemini_dir: Some(temp.path().join("missing-gemini")),
+            require_gemini: false,
+            session_skills: Vec::new(),
+            session_skills_file: None,
+        });
+
+        let codex_target = report
+            .targets
+            .iter()
+            .find(|target| target.label == "codex")
+            .unwrap();
+        assert_eq!(codex_target.root, repo_codex);
+        assert_eq!(codex_target.status, "present");
+    }
+
+    #[test]
+    fn selected_profile_working_dir_sets_target_codex_skills_root() {
+        let temp = TempDir::new().unwrap();
+        let engine = temp.path().join("engine");
+        let target = temp.path().join("target-repo");
+        let workflow_path = engine.join("workflows/shea-symphony.md");
+        fs::create_dir_all(engine.join(".git")).unwrap();
+        let source_suite = suite(&engine);
+        write(
+            &workflow_path,
+            &format!(
+                "---\nprofiles:\n  default: target\n  entries:\n    - id: target\n      working_dir: {:?}\n---\nPrompt",
+                target.display().to_string()
+            ),
+        );
+        let target_codex = target.join(".codex/skills");
+        write(
+            &target_codex.join("shea-symphony-doctor/SKILL.md"),
+            &fs::read_to_string(source_suite.join("shea-symphony-doctor/SKILL.md")).unwrap(),
+        );
+
+        let report = build_skill_readiness_report(SkillStatusInput {
+            workflow_path,
+            suite_path: Some(source_suite),
+            codex_dir: None,
+            gemini_dir: Some(temp.path().join("missing-gemini")),
+            require_gemini: false,
+            session_skills: Vec::new(),
+            session_skills_file: None,
+        });
+
+        let codex_target = report
+            .targets
+            .iter()
+            .find(|target| target.label == "codex")
+            .unwrap();
+        assert_eq!(codex_target.root, target_codex);
+        assert_eq!(codex_target.status, "present");
     }
 }


### PR DESCRIPTION
## Summary
- Implements #451: Support target repo-local .codex/skills.

## Branch Target Evidence
- Branch target role: `Subissue`
- PR base branch: `integration/issue-447-enable-shea-tauri-gui-to-operate-on-external-target-workspaces`
- Native parent issue: `#447`
- Parent integration branch: `integration/issue-447-enable-shea-tauri-gui-to-operate-on-external-target-workspaces`
- Parent final PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #451
