### PR TITLE
#458: Hide incomplete native parent issues from executable lane board

### DIFF
--- a/app/src/lib/viewModel/queueIssues.ts
+++ b/app/src/lib/viewModel/queueIssues.ts
@@ -12,6 +12,7 @@ export function buildQueueIssues(githubQueue: any, attentionTasks: any[] = []) {
   const fromGithub = (githubQueue?.issues ?? [])
     .map((issue) => {
       const state = normalizeStateName(issue.state);
+      if (isBlockedMainQueueState(state) && hasIncompleteNativeSubissues(issue)) return null;
       const blockedBy = normalizedBlockers(issue.blockedBy ?? issue.blocked_by);
       const unresolvedBlocked = isBlockedMainQueueState(state) && hasUnresolvedBlockers(blockedBy);
       const blockedReason = textFromValue(issue.blockedReason ?? issue.blocked_reason, 'issue has unresolved tracker dependencies');
@@ -38,7 +39,7 @@ export function buildQueueIssues(githubQueue: any, attentionTasks: any[] = []) {
         source: 'githubQueue'
       };
     })
-    .filter((issue) => isLaneQueueState(issue.state) && issue.lane !== 'Unknown');
+    .filter((issue) => issue && isLaneQueueState(issue.state) && issue.lane !== 'Unknown');
 
   if (fromGithub.length) return fromGithub.sort(queueIssueSort);
 
@@ -175,6 +176,61 @@ function normalizedBlockers(blockedBy: any) {
 
 function hasUnresolvedBlockers(blockedBy: any[] = []) {
   return blockedBy.some((blocker) => !isTerminalBlockerState(blocker?.state));
+}
+
+function hasIncompleteNativeSubissues(issue: any) {
+  const subissues = normalizedNativeSubissues(issue);
+  return subissues.some((subissue) => normalizeStateName(subissue.projectState) !== 'Done');
+}
+
+function normalizedNativeSubissues(issue: any) {
+  const fields = issue?.projectFields ?? issue?.project_fields ?? {};
+  const byId = new Map();
+  const push = (subissue: any, projectState: any = null) => {
+    const identifier = issueRefFromValue(subissue);
+    if (!identifier) return;
+    const existing = byId.get(identifier) ?? { identifier, projectState: null };
+    existing.projectState = existing.projectState
+      ?? projectState
+      ?? subissue?.projectState
+      ?? subissue?.project_state
+      ?? subissue?.projectStatus
+      ?? subissue?.project_status
+      ?? subissue?.status
+      ?? null;
+    byId.set(identifier, existing);
+  };
+
+  for (const value of [
+    issue?.nativeSubissues,
+    issue?.native_subissues,
+    issue?.subIssues,
+    issue?.sub_issues,
+    fields?.['GitHub Native Subissues']
+  ]) {
+    for (const subissue of nativeSubissueArray(value)) push(subissue);
+  }
+
+  for (const identifier of String(fields?.['Native Subissues'] ?? '').split(',').map((value) => value.trim()).filter(Boolean)) {
+    push(identifier);
+  }
+
+  for (const [identifier, state] of parseIssueStatePairs(fields?.['Native Subissue Project States'])) {
+    push(identifier, state);
+  }
+
+  return [...byId.values()];
+}
+
+function nativeSubissueArray(value: any) {
+  if (Array.isArray(value)) return value;
+  if (Array.isArray(value?.nodes)) return value.nodes;
+  return [];
+}
+
+function parseIssueStatePairs(value: any) {
+  if (typeof value !== 'string') return [];
+  return value.split(',').map((pair) => pair.trim().split('=')).filter((pair) => pair.length === 2 && pair[0] && pair[1]);
 }
 
 function isTerminalBlockerState(state: any) {

--- a/app/test/operator-view.test.mjs
+++ b/app/test/operator-view.test.mjs
@@ -2029,6 +2029,67 @@ test('blocked Todo project rows keep dependency readback but stay out of Main la
   assert.deepEqual(main.issues.map((issue) => issue.id), ['#441', '#438']);
 });
 
+test('native parent rows with incomplete subissues stay out of Main lane queue', () => {
+  const view = buildViewModel({
+    generatedAt: new Date().toISOString(),
+    workflowPath: 'workflows/shea-symphony.md',
+    commands: {
+      githubQueue: {
+        ok: true,
+        args: ['project', 'state', 'workflows/shea-symphony.md', '--json'],
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        durationMs: 12,
+        stderr: '',
+        stdoutPreview: '{}'
+      }
+    },
+    githubQueue: {
+      source: 'GitHub Project',
+      issues: [
+        {
+          identifier: '#447',
+          title: 'Incomplete native parent',
+          state: 'Todo',
+          projectFields: {
+            'GitHub Native Subissues': [
+              { identifier: '#450', project_state: 'Done' },
+              { identifier: '#451', project_state: 'Agent Review' }
+            ]
+          }
+        },
+        {
+          identifier: '#448',
+          title: 'Complete native parent',
+          state: 'Todo',
+          nativeSubissues: [
+            { identifier: '#452', projectState: 'Done' },
+            { identifier: '#453', projectState: 'Done' }
+          ]
+        },
+        {
+          identifier: '#449',
+          title: 'Missing native subissue Project status',
+          state: 'Rework',
+          projectFields: {
+            'Native Subissues': '#454'
+          }
+        }
+      ]
+    },
+    healthy: true
+  });
+
+  const board = buildLaneThroughputBoard({ queueIssues: view.queueIssues });
+  const main = board.find((lane) => lane.laneKey === 'main');
+
+  assert.deepEqual(view.queueIssues.map((issue) => issue.id), ['#448']);
+  assert.deepEqual(view.laneProjectIssues.main.map((issue) => issue.id), ['#448']);
+  assert.deepEqual(main.issues.map((issue) => issue.id), ['#448']);
+  assert.equal(main.queuedCount, 1);
+});
+
 test('fixture overview feeds first-screen human todo and lane board data', () => {
   const overview = buildFixtureOverview(true);
   const view = buildViewModel(overview);

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 
 use serde_json::{json, Value};
 use shea_symphony::config::RuntimeConfig;
-use shea_symphony::model::{native_subissue_gate_blocker, normalize_state, TrackerIssue};
+use shea_symphony::model::{
+    native_subissue_gate_blocker, native_subissue_statuses, normalize_state, TrackerIssue,
+};
 use shea_symphony::presentation::render_project_state_panel;
 use shea_symphony::progress::run_with_progress_heartbeat;
 use shea_symphony::review_status::{
@@ -628,6 +630,16 @@ fn render_queue_issue(issue: &TrackerIssue) -> Value {
     } else {
         Some("issue has tracker dependencies")
     };
+    let native_subissues = native_subissue_statuses(issue)
+        .into_iter()
+        .map(|subissue| {
+            json!({
+                "identifier": subissue.identifier,
+                "projectState": subissue.project_state,
+                "githubState": subissue.github_state,
+            })
+        })
+        .collect::<Vec<_>>();
 
     json!({
         "identifier": issue.identifier,
@@ -642,6 +654,7 @@ fn render_queue_issue(issue: &TrackerIssue) -> Value {
         "branchName": issue.branch_name,
         "blockedBy": blocked_by,
         "blockedReason": blocked_reason,
+        "nativeSubissues": native_subissues,
     })
 }
 
@@ -652,6 +665,11 @@ fn lane_for_issue(
     let normalized_state = issue.normalized_state();
     if matches!(normalized_state.as_str(), "todo" | "rework")
         && issue_has_unresolved_blockers(issue, terminal_states)
+    {
+        return None;
+    }
+    if matches!(normalized_state.as_str(), "todo" | "rework")
+        && native_subissue_gate_blocker(issue, terminal_states).is_some()
     {
         return None;
     }

--- a/src/main/tests.rs
+++ b/src/main/tests.rs
@@ -748,6 +748,41 @@ fn renders_project_state_json_dependency_readback_without_main_lane_projection()
 }
 
 #[test]
+fn renders_project_state_json_native_parent_gate_without_main_lane_projection() {
+    let mut incomplete = tracker_issue_with_ref("#447", "Incomplete native parent", "Todo");
+    incomplete.project_fields.insert(
+        "GitHub Native Subissues".into(),
+        serde_json::json!([
+            {"identifier": "#450", "project_state": "Done"},
+            {"identifier": "#451", "project_state": "Agent Review"}
+        ]),
+    );
+    let mut complete = tracker_issue_with_ref("#448", "Complete native parent", "Todo");
+    complete.project_fields.insert(
+        "GitHub Native Subissues".into(),
+        serde_json::json!([
+            {"identifier": "#452", "project_state": "Done"},
+            {"identifier": "#453", "project_state": "Done"}
+        ]),
+    );
+    let terminal_states = BTreeSet::from(["done".into()]);
+
+    let rendered =
+        render_project_state_json(&[incomplete, complete], &[], "queue", &terminal_states).unwrap();
+    let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+    assert_eq!(value["laneCounts"]["main"], 1);
+    assert_eq!(
+        value["issues"][0]["nativeSubissues"][1]["identifier"],
+        "#451"
+    );
+    assert_eq!(
+        value["issues"][0]["nativeSubissues"][1]["projectState"],
+        "Agent Review"
+    );
+}
+
+#[test]
 fn project_state_queue_scope_excludes_terminal_issues_by_default() {
     let workflow = WorkflowDefinition::parse(
         "/tmp/WORKFLOW.md",


### PR DESCRIPTION
## Summary
- Implements #458: Hide incomplete native parent issues from executable lane board.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #458
