### PR TITLE
#475: T2607-01: add Temporal Rust SDK quickstart-conformant runtime skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +86,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.17",
+ "instant",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +162,43 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cassowary"
@@ -110,10 +216,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+ "serde",
+]
 
 [[package]]
 name = "clap"
@@ -156,10 +301,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compact_str"
@@ -176,6 +340,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +372,39 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -263,6 +485,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,16 +518,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -301,10 +639,167 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fragile"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-retry"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde5a672a61f96552aa5ed9fd9c81c3fbdae4be9b1e205d6eaf17c83705adc0f"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -317,16 +812,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -337,7 +889,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -345,12 +897,217 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "id-arena"
@@ -363,6 +1120,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -399,6 +1177,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +1231,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +1310,12 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -449,6 +1328,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -517,6 +1405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,10 +1435,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -559,10 +1487,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -575,6 +1581,92 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -604,6 +1696,28 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbjson"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8edd1efdd8ab23ba9cb9ace3d9987a72663d5d7c9f74fa00b51d6213645cf6c"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "prost",
+ "prost-types",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -655,10 +1769,121 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
+name = "pid"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c931ef9756cd5e3fa3d395bfe09df4dfa6f0612c6ca8f6b12927d17ca34e36"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -680,6 +1905,196 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "prost-wkt"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3de5e9c9e84fcb5efa204b8e283d23e615a8bc8c777bf1d6622bb01dc61445"
+dependencies = [
+ "chrono",
+ "inventory",
+ "prost",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "typetag",
+]
+
+[[package]]
+name = "prost-wkt-build"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe500dc80e757a75e1e8fb7290e448d62dfba3105ece1d058579cb00b58151cd"
+dependencies = [
+ "heck",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "quote",
+]
+
+[[package]]
+name = "prost-wkt-types"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13807eaa7e15833d06e899008371926201cdcd11d74b6d490f49130cdb3f415e"
+dependencies = [
+ "chrono",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "prost-wkt",
+ "prost-wkt-build",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,9 +2105,100 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ratatui"
@@ -707,7 +2213,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -722,6 +2228,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -754,6 +2271,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ringbuf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3ecbcab081b935fb9c618b07654924f27686b4aac8818e700580a83eedcb7f"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +2374,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,10 +2463,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -847,6 +2559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,8 +2587,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -876,6 +2606,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "crossterm",
+ "futures",
+ "futures-util",
  "liquid",
  "ratatui",
  "serde",
@@ -883,8 +2615,21 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "tempfile",
- "thiserror",
+ "temporalio-client",
+ "temporalio-common",
+ "temporalio-macros",
+ "temporalio-sdk",
+ "temporalio-sdk-core",
+ "temporalio-workflow",
+ "thiserror 1.0.69",
+ "tokio",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -918,10 +2663,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -958,6 +2762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,17 +2779,283 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "temporalio-client"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257e69cdc823bfd0707d4daac7470451d59d31aefe519c4eb60d4ceeb77c443e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backoff",
+ "base64",
+ "bon",
+ "bytes",
+ "derive_more",
+ "dyn-clone",
+ "futures-retry",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "parking_lot",
+ "rand 0.10.2",
+ "temporalio-common",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tonic",
+ "tower",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "temporalio-common"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6988555678e6177c08553aece24312643b714d35983ad9bf383c9f9eb77ea6ec"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bon",
+ "crc32fast",
+ "derive_more",
+ "dirs",
+ "erased-serde",
+ "futures",
+ "futures-channel",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "opentelemetry-otlp",
+ "parking_lot",
+ "prometheus",
+ "prost",
+ "prost-types",
+ "ringbuf",
+ "serde",
+ "serde_json",
+ "temporalio-common-wasm",
+ "temporalio-protos",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "temporalio-common-wasm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5dba313ccb58da518e23f85557e7cb9d5a1298fd7d8935328521ca641a4b11"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bon",
+ "crc32fast",
+ "derive_more",
+ "erased-serde",
+ "futures",
+ "parking_lot",
+ "prost",
+ "serde",
+ "serde_json",
+ "temporalio-protos",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "temporalio-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bd354f4226ade84d07266a21456553be402b2187ef72f263c334ec93a2109c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "temporalio-protos"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce29ee903d46edec16df756e78e5ab125e4d342957174d4ac8ee30290ef249a"
+dependencies = [
+ "anyhow",
+ "base64",
+ "derive_more",
+ "http",
+ "pbjson",
+ "pbjson-build",
+ "prost",
+ "prost-types",
+ "prost-wkt-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
+name = "temporalio-sdk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964d8c74815d169491e640e5688b7a37525641c59c683ea775a7bc9138c38b5c"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bon",
+ "derive_more",
+ "futures-util",
+ "gethostname",
+ "parking_lot",
+ "prost",
+ "prost-wkt-types",
+ "serde",
+ "temporalio-client",
+ "temporalio-common",
+ "temporalio-macros",
+ "temporalio-sdk-core",
+ "temporalio-workflow",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "temporalio-sdk-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8498ec9d16b1ca9a85aaf622d7542f2bdefe82972e221f8026d1ddd18686591"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backoff",
+ "bon",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "derive_more",
+ "enum-iterator",
+ "enum_dispatch",
+ "futures",
+ "futures-util",
+ "gethostname",
+ "itertools 0.14.0",
+ "lru 0.18.1",
+ "mockall",
+ "opentelemetry-otlp",
+ "parking_lot",
+ "pid",
+ "pin-project",
+ "prost",
+ "prost-wkt-types",
+ "rand 0.10.2",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "slotmap",
+ "sysinfo",
+ "temporalio-client",
+ "temporalio-common",
+ "temporalio-macros",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "temporalio-workflow"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d49f689bc594fbc81da9bf7989858b0e358b6aa28d47400ae822d3e0b559b"
+dependencies = [
+ "anyhow",
+ "bon",
+ "derive_more",
+ "futures-channel",
+ "futures-util",
+ "prost",
+ "prost-wkt-types",
+ "serde",
+ "temporalio-common-wasm",
+ "temporalio-macros",
+ "thiserror 2.0.18",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -987,7 +3063,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -999,6 +3084,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1033,16 +3138,363 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "flate2",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "rustls-native-certs",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+ "tempfile",
+ "tonic-build",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project-lite",
+ "slab",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "parking_lot",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "typetag"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -1092,16 +3544,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.2",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1128,13 +3638,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
@@ -1145,8 +3720,20 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665fe59e56cc9b419ca6fcca56673e3421d1a5011e3b65caf6b726fd9e041d10"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.247.0",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]
@@ -1159,6 +3746,47 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1178,16 +3806,129 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1221,6 +3962,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1272,12 +4022,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "wit-bindgen-rust-macro",
+ "wit-bindgen-rust-macro 0.51.0",
 ]
 
 [[package]]
@@ -1285,6 +4041,10 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+dependencies = [
+ "bitflags",
+ "wit-bindgen-rust-macro 0.57.1",
+]
 
 [[package]]
 name = "wit-bindgen-core"
@@ -1294,7 +4054,18 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02dee27a2dc20d1008016c742ec9fc6ea498492994ba3750be7454cbc97ff04c"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.247.0",
 ]
 
 [[package]]
@@ -1308,9 +4079,25 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core 0.51.0",
+ "wit-component 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5007dae772945b7a5003d69d90a3a4a78929d41f19d004e980c4259a6af4484"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata 0.247.0",
+ "wit-bindgen-core 0.57.1",
+ "wit-component 0.247.0",
 ]
 
 [[package]]
@@ -1324,8 +4111,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
+ "wit-bindgen-core 0.51.0",
+ "wit-bindgen-rust 0.51.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9237d678e3513ad24e96fe98beacdc0db6405284ba2a2400418cf0d42caa89"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core 0.57.1",
+ "wit-bindgen-rust 0.57.1",
 ]
 
 [[package]]
@@ -1341,10 +4143,29 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata 0.244.0",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d567162a6b9843080e5e0053f696623ff694bae8ae017c9ec536d1873bbe3d8"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.247.0",
+ "wasm-metadata 0.247.0",
+ "wasmparser 0.247.0",
+ "wit-parser 0.247.0",
 ]
 
 [[package]]
@@ -1362,7 +4183,135 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffe4064318cdf3c08cb99343b44c039fcefe61ccdf58aa9975285f13d74d1fc"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ temporalio-common = "0.5.0"
 temporalio-macros = "0.5.0"
 temporalio-sdk = "0.5.0"
 temporalio-sdk-core = "0.5.0"
+temporalio-workflow = "0.5.0"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,21 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.28"
+futures = "0.3.32"
+futures-util = "0.3.32"
 liquid = "0.26.11"
 ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 signal-hook = "0.3"
+temporalio-client = "0.5.0"
+temporalio-common = "0.5.0"
+temporalio-macros = "0.5.0"
+temporalio-sdk = "0.5.0"
+temporalio-sdk-core = "0.5.0"
 thiserror = "1"
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/milestones/2607-hardening/implementation/T2607-01-temporal-runtime-skeleton.md
+++ b/docs/milestones/2607-hardening/implementation/T2607-01-temporal-runtime-skeleton.md
@@ -217,6 +217,23 @@ Defaults should match the 2607 docs:
 - agent concurrency: 3;
 - local concurrency: 8.
 
+## SDK Version Choice
+
+As of the T2607-01 implementation pass on 2026-07-09, the official Temporal
+Rust SDK quickstart documents the compatible crate family as:
+
+```text
+temporalio-client = "0.5.0"
+temporalio-common = "0.5.0"
+temporalio-macros = "0.5.0"
+temporalio-sdk = "0.5.0"
+temporalio-sdk-core = "0.5.0"
+```
+
+The skeleton pins that crate family together and keeps SDK-facing types inside
+the `symphony` runtime module so later 2607 slices can absorb SDK API drift at
+one boundary.
+
 Use the existing workspace config precedence:
 
 1. workspace-local config;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1064,7 +1064,7 @@ mod tests {
     fn parses_temporal_runtime_config() {
         let workflow = WorkflowDefinition::parse(
             "/tmp/WORKFLOW.md",
-            "---\ntemporal:\n  address: 127.0.0.1:7233\n  namespace: shea-dev\n  task_queues:\n    core: shea-core\n    agent: shea-agent\n    local: shea-local\n  worker:\n    core_concurrency: 2\n    agent_concurrency: 1\n    local_concurrency: 4\n---\nPrompt",
+            "---\ntracker:\n  kind: memory\ntemporal:\n  address: 127.0.0.1:7233\n  namespace: shea-dev\n  task_queues:\n    core: shea-core\n    agent: shea-agent\n    local: shea-local\n  worker:\n    core_concurrency: 2\n    agent_concurrency: 1\n    local_concurrency: 4\n---\nPrompt",
         )
         .unwrap();
         let config =

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub const DEFAULT_GIT_BASE_BRANCH: &str = "main";
 pub struct RuntimeConfig {
     pub tracker: TrackerConfig,
     pub git: GitConfig,
+    pub temporal: TemporalConfig,
     pub polling: PollingConfig,
     pub workspace: WorkspaceConfig,
     pub worker: WorkerConfig,
@@ -85,6 +86,28 @@ pub struct WorkpadConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GitConfig {
     pub base_branch: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemporalConfig {
+    pub address: String,
+    pub namespace: String,
+    pub task_queues: TemporalTaskQueuesConfig,
+    pub worker: TemporalWorkerConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemporalTaskQueuesConfig {
+    pub core: String,
+    pub agent: String,
+    pub local: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TemporalWorkerConfig {
+    pub core_concurrency: usize,
+    pub agent_concurrency: usize,
+    pub local_concurrency: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -296,6 +319,7 @@ impl RuntimeConfig {
 
         let tracker = parse_tracker(root.get("tracker"), workflow_dir);
         let git = parse_git(root.get("git"));
+        let temporal = parse_temporal(root.get("temporal"));
         let polling = PollingConfig {
             interval_ms: get_u64(root.get("polling"), "interval_ms").unwrap_or(30_000),
         };
@@ -433,6 +457,7 @@ impl RuntimeConfig {
         Ok(Self {
             tracker,
             git,
+            temporal,
             polling,
             workspace,
             worker,
@@ -496,6 +521,32 @@ impl RuntimeConfig {
 
         require_positive("polling.interval_ms", self.polling.interval_ms)?;
         require_present("git.base_branch", Some(self.git.base_branch.as_str()))?;
+        require_present("temporal.address", Some(self.temporal.address.as_str()))?;
+        require_present("temporal.namespace", Some(self.temporal.namespace.as_str()))?;
+        require_present(
+            "temporal.task_queues.core",
+            Some(self.temporal.task_queues.core.as_str()),
+        )?;
+        require_present(
+            "temporal.task_queues.agent",
+            Some(self.temporal.task_queues.agent.as_str()),
+        )?;
+        require_present(
+            "temporal.task_queues.local",
+            Some(self.temporal.task_queues.local.as_str()),
+        )?;
+        require_positive(
+            "temporal.worker.core_concurrency",
+            self.temporal.worker.core_concurrency as u64,
+        )?;
+        require_positive(
+            "temporal.worker.agent_concurrency",
+            self.temporal.worker.agent_concurrency as u64,
+        )?;
+        require_positive(
+            "temporal.worker.local_concurrency",
+            self.temporal.worker.local_concurrency as u64,
+        )?;
         require_positive("hooks.timeout_ms", self.hooks.timeout_ms)?;
         if let Some(limit) = self.worker.max_concurrent_agents_per_host {
             if limit <= 0 {
@@ -587,6 +638,26 @@ fn parse_git(value: Option<&Value>) -> GitConfig {
         .filter(|branch| !branch.is_empty())
         .unwrap_or_else(|| DEFAULT_GIT_BASE_BRANCH.to_string());
     GitConfig { base_branch }
+}
+
+fn parse_temporal(value: Option<&Value>) -> TemporalConfig {
+    let task_queues = get_value(value, "task_queues");
+    let worker = get_value(value, "worker");
+
+    TemporalConfig {
+        address: get_string(value, "address").unwrap_or_else(|| "localhost:7233".to_string()),
+        namespace: get_string(value, "namespace").unwrap_or_else(|| "default".to_string()),
+        task_queues: TemporalTaskQueuesConfig {
+            core: get_string(task_queues, "core").unwrap_or_else(|| "symphony-core".to_string()),
+            agent: get_string(task_queues, "agent").unwrap_or_else(|| "symphony-agent".to_string()),
+            local: get_string(task_queues, "local").unwrap_or_else(|| "symphony-local".to_string()),
+        },
+        worker: TemporalWorkerConfig {
+            core_concurrency: get_u64(worker, "core_concurrency").unwrap_or(3) as usize,
+            agent_concurrency: get_u64(worker, "agent_concurrency").unwrap_or(3) as usize,
+            local_concurrency: get_u64(worker, "local_concurrency").unwrap_or(8) as usize,
+        },
+    }
 }
 
 fn parse_tracker(value: Option<&Value>, workflow_dir: &Path) -> TrackerConfig {
@@ -978,6 +1049,35 @@ mod tests {
         );
         assert_eq!(config.git.base_branch, DEFAULT_GIT_BASE_BRANCH);
         assert_eq!(config.tracker.project_owner_type, None);
+        assert_eq!(config.temporal.address, "localhost:7233");
+        assert_eq!(config.temporal.namespace, "default");
+        assert_eq!(config.temporal.task_queues.core, "symphony-core");
+        assert_eq!(config.temporal.task_queues.agent, "symphony-agent");
+        assert_eq!(config.temporal.task_queues.local, "symphony-local");
+        assert_eq!(config.temporal.worker.core_concurrency, 3);
+        assert_eq!(config.temporal.worker.agent_concurrency, 3);
+        assert_eq!(config.temporal.worker.local_concurrency, 8);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn parses_temporal_runtime_config() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntemporal:\n  address: 127.0.0.1:7233\n  namespace: shea-dev\n  task_queues:\n    core: shea-core\n    agent: shea-agent\n    local: shea-local\n  worker:\n    core_concurrency: 2\n    agent_concurrency: 1\n    local_concurrency: 4\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert_eq!(config.temporal.address, "127.0.0.1:7233");
+        assert_eq!(config.temporal.namespace, "shea-dev");
+        assert_eq!(config.temporal.task_queues.core, "shea-core");
+        assert_eq!(config.temporal.task_queues.agent, "shea-agent");
+        assert_eq!(config.temporal.task_queues.local, "shea-local");
+        assert_eq!(config.temporal.worker.core_concurrency, 2);
+        assert_eq!(config.temporal.worker.agent_concurrency, 1);
+        assert_eq!(config.temporal.worker.local_concurrency, 4);
         assert!(config.validate().is_ok());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod runtime_state;
 pub mod session_registry;
 pub mod skill_status;
 pub mod status_surface;
+pub mod symphony;
 pub mod target_runtime;
 pub mod tracker;
 pub mod workflow;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,348 +1,54 @@
-use cli::Command;
+use std::path::PathBuf;
 
-mod cli;
-mod commands;
-mod lanes;
-mod orchestration;
+use shea_symphony::{symphony::run_symphony_workers, RuntimeConfig, WorkflowStore};
 
-use commands::autopilot::{autopilot_loop, autopilot_plan};
-use commands::clean::{clean_audit_command, cleanup_plan_command};
-use commands::debug::debug_report;
-use commands::doctor::{doctor, doctor_repair_human_review};
-use commands::follow_up::create_follow_up;
-use commands::forge::{
-    forge_create, forge_promote, forge_rework, forge_validate, ForgeCreateOptions,
-};
-use commands::gate::quality_gate;
-use commands::profiles::list_profiles;
-use commands::project::{
-    add_to_project, append_timeline_comment, link_pr, project_inspect, project_issue,
-    project_relationship_add_blocked_by, project_relationship_add_subissue,
-    project_relationship_list, project_relationship_verify, project_state, set_state,
-    upsert_workpad,
-};
-use commands::session::{
-    agent_session_attach, agent_session_list, agent_session_start, lane_claim_command,
-    legacy_agent_session_start, AgentSessionLaneArg,
-};
-use commands::skills::skills_status;
-use commands::status::{plan, status_api};
-use commands::target_runtime::{target_runtime_init, target_runtime_status};
-use commands::workflow::{inspect, validate};
-use commands::workspace::{
-    cleanup_workspaces, workspace_adopt, workspace_ensure, workspace_list, workspace_show,
-};
-use lanes::main_loop::{run_loop, run_once};
-use lanes::merge::{merge_loop, merge_once};
-use lanes::review::{
-    review_claim, review_clear_claim, review_fake, review_freshness, review_loop,
-    review_manual_pass, review_manual_reject, review_once, review_status,
-};
+const DEFAULT_WORKFLOW_PATH: &str = "workflows/shea-symphony.md";
+const WORKFLOW_PATH_ENV: &str = "SHEA_WORKFLOW_PATH";
 
-fn main() {
-    if let Err(error) = run() {
-        eprintln!("{error}");
-        std::process::exit(1);
-    }
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let workflow_path = workflow_path();
+    let workflow_store = WorkflowStore::load(&workflow_path)?;
+    let config = RuntimeConfig::from_workflow(workflow_store.active(), &workflow_path)?;
+
+    println!(
+        "Starting Shea Symphony Temporal workers from {}",
+        workflow_path.display()
+    );
+    run_symphony_workers(config).await?;
+
+    Ok(())
 }
 
-fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    let command = Command::parse(args)?;
-
-    match command {
-        Command::Plan {
-            workflow_path,
-            json,
-        } => plan(workflow_path, json),
-        Command::AutopilotPlan {
-            workflow_path,
-            json,
-        } => autopilot_plan(workflow_path, json),
-        Command::AutopilotLoop { options } => autopilot_loop(options),
-        Command::StatusApi {
-            workflow_path,
-            bind,
-            once,
-        } => status_api(workflow_path, bind, once),
-        Command::Validate { workflow_path } => validate(workflow_path),
-        Command::Inspect {
-            workflow_path,
-            states,
-        } => inspect(workflow_path, states),
-        Command::ProjectState { options } => project_state(options),
-        Command::ProjectIssue {
-            workflow_path,
-            issue_ref,
-            json,
-        } => project_issue(workflow_path, issue_ref, json),
-        Command::ProjectInspect {
-            workflow_path,
-            issue_ref,
-            lane,
-        } => project_inspect(workflow_path, issue_ref, lane),
-        Command::ProjectRelationshipList {
-            workflow_path,
-            issue_ref,
-        } => project_relationship_list(workflow_path, issue_ref),
-        Command::ProjectRelationshipVerify {
-            workflow_path,
-            issue_ref,
-            blocked_by,
-            subissue,
-        } => project_relationship_verify(workflow_path, issue_ref, blocked_by, subissue),
-        Command::ProjectRelationshipAddBlockedBy {
-            workflow_path,
-            issue_ref,
-            blocker_ref,
-            write,
-            dry_run,
-        } => project_relationship_add_blocked_by(
-            workflow_path,
-            issue_ref,
-            blocker_ref,
-            write,
-            dry_run,
-        ),
-        Command::ProjectRelationshipAddSubissue {
-            workflow_path,
-            parent_ref,
-            subissue_ref,
-            write,
-            dry_run,
-        } => project_relationship_add_subissue(
-            workflow_path,
-            parent_ref,
-            subissue_ref,
-            write,
-            dry_run,
-        ),
-        Command::Doctor { options } => doctor(options),
-        Command::DoctorRepairHumanReview {
-            workflow_path,
-            write,
-        } => doctor_repair_human_review(workflow_path, write),
-        Command::SkillsStatus { input, json } => skills_status(input, json),
-        Command::Profiles { workflow_path } => list_profiles(workflow_path),
-        Command::Debug { workflow_path } => debug_report(workflow_path),
-        Command::TargetRuntimeStatus { path } => target_runtime_status(path),
-        Command::TargetRuntimeInit { path } => target_runtime_init(path),
-        Command::CleanupPlan { workflow_path } => cleanup_plan_command(workflow_path),
-        Command::CleanPlan { workflow_path } => cleanup_plan_command(workflow_path),
-        Command::CleanAudit { workflow_path } => clean_audit_command(workflow_path),
-        Command::RunOnce { workflow_path } => run_once(workflow_path),
-        Command::RunLoop { options } => run_loop(options),
-        Command::CleanupWorkspaces {
-            workflow_path,
-            write,
-        } => cleanup_workspaces(workflow_path, write),
-        Command::WorkspaceList { workflow_path } => workspace_list(workflow_path),
-        Command::WorkspaceShow {
-            workflow_path,
-            issue_ref,
-        } => workspace_show(workflow_path, issue_ref),
-        Command::WorkspaceAdopt {
-            workflow_path,
-            issue_ref,
-            path,
-            write,
-        } => workspace_adopt(workflow_path, issue_ref, path, write),
-        Command::WorkspaceEnsure {
-            workflow_path,
-            issue_ref,
-            pr_ref,
-            branch,
-            write,
-        } => workspace_ensure(workflow_path, issue_ref, pr_ref, branch, write),
-        Command::MergeOnce {
-            workflow_path,
-            write,
-        } => merge_once(workflow_path, write),
-        Command::MergeLoop { options } => merge_loop(options),
-        Command::SetState {
-            workflow_path,
-            issue_ref,
-            state,
-            write,
-        } => set_state(workflow_path, issue_ref, state, write),
-        Command::Workpad {
-            workflow_path,
-            issue_ref,
-            markdown_path,
-            write,
-        } => upsert_workpad(workflow_path, issue_ref, markdown_path, write),
-        Command::TimelineComment {
-            workflow_path,
-            issue_ref,
-            markdown_path,
-            write,
-        } => append_timeline_comment(workflow_path, issue_ref, markdown_path, write),
-        Command::LinkPr {
-            workflow_path,
-            issue_ref,
-            pr_ref,
-            write,
-        } => link_pr(workflow_path, issue_ref, pr_ref, write),
-        Command::CreateFollowUp {
-            workflow_path,
-            title,
-            body_path,
-            write,
-        } => create_follow_up(workflow_path, title, body_path, write),
-        Command::AddToProject {
-            workflow_path,
-            issue_id,
-            write,
-        } => add_to_project(workflow_path, issue_id, write),
-        Command::ReviewFake {
-            workflow_path,
-            issue_ref,
-            outcome,
-            write,
-        } => review_fake(workflow_path, issue_ref, outcome, write),
-        Command::ReviewOnce {
-            workflow_path,
-            issue_ref,
-            write,
-        } => review_once(workflow_path, issue_ref, write),
-        Command::ReviewClaim {
-            workflow_path,
-            issue_ref,
-            worker,
-            write,
-        } => review_claim(workflow_path, issue_ref, worker, write),
-        Command::LaneClaim {
-            workflow_path,
-            issue_ref,
-            lane,
-            worker,
-            source,
-            write,
-        } => lane_claim_command(workflow_path, issue_ref, lane, worker, source, write),
-        Command::ReviewClearClaim {
-            workflow_path,
-            issue_ref,
-            write,
-        } => review_clear_claim(workflow_path, issue_ref, write),
-        Command::ReviewPass {
-            workflow_path,
-            issue_ref,
-            evidence,
-            write,
-        } => review_manual_pass(workflow_path, issue_ref, evidence, write),
-        Command::ReviewReject {
-            workflow_path,
-            issue_ref,
-            evidence,
-            target_state,
-            write,
-        } => review_manual_reject(workflow_path, issue_ref, evidence, target_state, write),
-        Command::ReviewSession {
-            workflow_path,
-            issue_ref,
-            write,
-        } => {
-            legacy_agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Review, write)
-        }
-        Command::ReviewFreshness { input } => review_freshness(input),
-        Command::ReviewLoop { options } => review_loop(options),
-        Command::ReviewStatus { options } => review_status(options),
-        Command::MergeSession {
-            workflow_path,
-            issue_ref,
-            write,
-        } => {
-            legacy_agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Merge, write)
-        }
-        Command::AgentSessionStart {
-            workflow_path,
-            issue_ref,
-            lane,
-            run_id,
-            write,
-        } => agent_session_start(workflow_path, issue_ref, lane, run_id, write),
-        Command::SessionStart {
-            workflow_path,
-            issue_ref,
-            lane,
-            run_id,
-            write,
-        } => agent_session_start(workflow_path, issue_ref, lane, Some(run_id), write),
-        Command::SessionList { workflow_path } => agent_session_list(workflow_path),
-        Command::SessionAttach {
-            workflow_path,
-            session,
-            exec,
-        } => agent_session_attach(workflow_path, session, exec),
-        Command::AgentSessionList { workflow_path } => agent_session_list(workflow_path),
-        Command::AgentSessionAttach {
-            workflow_path,
-            session,
-            exec,
-        } => agent_session_attach(workflow_path, session, exec),
-        Command::Gate {
-            workflow_path,
-            issue_ref,
-            apply,
-            write,
-        } => quality_gate(workflow_path, issue_ref, apply, write),
-        Command::ForgeValidate {
-            workflow_path,
-            status,
-            title,
-            markdown,
-            issue_ref,
-        } => forge_validate(workflow_path, status, title, markdown, issue_ref),
-        Command::ForgeCreate {
-            workflow_path,
-            title,
-            markdown,
-            status,
-            project,
-            project_fields,
-            assignees,
-            relationships,
-            write,
-            dry_run,
-        } => forge_create(ForgeCreateOptions {
-            workflow_path,
-            title,
-            markdown,
-            status,
-            project,
-            project_fields,
-            assignees,
-            relationships,
-            write,
-            dry_run,
-        }),
-        Command::ForgePromote {
-            workflow_path,
-            issue_ref,
-            title,
-            markdown,
-            promotion_note,
-            relationships,
-            write,
-            dry_run,
-        } => forge_promote(crate::commands::forge::ForgePromoteInput {
-            workflow_path,
-            issue_ref,
-            title,
-            markdown,
-            promotion_note,
-            relationships,
-            write,
-            dry_run,
-        }),
-        Command::ForgeRework { options } => forge_rework(options),
-        Command::Help(text) => {
-            print!("{text}");
-            Ok(())
-        }
-    }
+fn workflow_path() -> PathBuf {
+    std::env::var_os(WORKFLOW_PATH_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_WORKFLOW_PATH))
 }
 
 #[cfg(test)]
-#[path = "main/tests.rs"]
-mod tests;
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_path_defaults_to_repo_workflow() {
+        unsafe {
+            std::env::remove_var(WORKFLOW_PATH_ENV);
+        }
+
+        assert_eq!(workflow_path(), PathBuf::from(DEFAULT_WORKFLOW_PATH));
+    }
+
+    #[test]
+    fn workflow_path_can_be_overridden_for_local_profiles() {
+        unsafe {
+            std::env::set_var(WORKFLOW_PATH_ENV, "/tmp/local-workflow.md");
+        }
+
+        assert_eq!(workflow_path(), PathBuf::from("/tmp/local-workflow.md"));
+
+        unsafe {
+            std::env::remove_var(WORKFLOW_PATH_ENV);
+        }
+    }
+}

--- a/src/symphony/activities.rs
+++ b/src/symphony/activities.rs
@@ -1,0 +1,107 @@
+use temporalio_macros::activities;
+use temporalio_sdk::activities::{ActivityContext, ActivityError};
+
+use crate::symphony::dto::{NoopActivityRequest, NoopActivityResult};
+
+pub const CORE_ACTIVITY_TYPES: &[&str] = &["NoopCoreActivity", "TrackerTransitionActivity"];
+pub const AGENT_ACTIVITY_TYPES: &[&str] = &[
+    "MainAgentActivity",
+    "ReworkActivity",
+    "AgentReviewActivity",
+    "MergeActivity",
+];
+pub const LOCAL_ACTIVITY_TYPES: &[&str] = &[
+    "LocalStateProjectionActivity",
+    "ArtifactIndexActivity",
+    "LocalHealthActivity",
+];
+
+#[derive(Debug, Default, Clone)]
+pub struct CoreActivities;
+
+#[activities]
+impl CoreActivities {
+    #[activity(name = "NoopCoreActivity")]
+    pub async fn noop_core_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::success(&request))
+    }
+
+    #[activity(name = "TrackerTransitionActivity")]
+    pub async fn tracker_transition_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::not_implemented(&request))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct AgentActivities;
+
+#[activities]
+impl AgentActivities {
+    #[activity(name = "MainAgentActivity")]
+    pub async fn main_agent_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::not_implemented(&request))
+    }
+
+    #[activity(name = "ReworkActivity")]
+    pub async fn rework_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::not_implemented(&request))
+    }
+
+    #[activity(name = "AgentReviewActivity")]
+    pub async fn agent_review_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::not_implemented(&request))
+    }
+
+    #[activity(name = "MergeActivity")]
+    pub async fn merge_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::not_implemented(&request))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct LocalActivities;
+
+#[activities]
+impl LocalActivities {
+    #[activity(name = "LocalStateProjectionActivity")]
+    pub async fn local_state_projection_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::not_implemented(&request))
+    }
+
+    #[activity(name = "ArtifactIndexActivity")]
+    pub async fn artifact_index_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::not_implemented(&request))
+    }
+
+    #[activity(name = "LocalHealthActivity")]
+    pub async fn local_health_activity(
+        _ctx: ActivityContext,
+        request: NoopActivityRequest,
+    ) -> Result<NoopActivityResult, ActivityError> {
+        Ok(NoopActivityResult::success(&request))
+    }
+}

--- a/src/symphony/client.rs
+++ b/src/symphony/client.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
 use temporalio_client::{
-    Client, ClientOptions, Connection, ConnectionOptions, GetWorkflowResultOptions, QueryOptions,
-    WorkflowStartOptions,
+    Client, ClientOptions, Connection, ConnectionOptions, WorkflowGetResultOptions,
+    WorkflowQueryOptions, WorkflowStartOptions,
 };
 use temporalio_sdk_core::Url;
 use thiserror::Error;
@@ -26,16 +26,24 @@ pub struct StartedIssueWorkflow {
 pub enum TemporalRuntimeError {
     #[error("invalid Temporal configuration: {0}")]
     InvalidConfig(String),
-    #[error("Temporal service is unavailable at {address} for namespace {namespace}: {source}")]
+    #[error(
+        "Temporal service is unavailable at {address} for namespace {namespace}: {source_error}"
+    )]
     Unavailable {
         address: String,
         namespace: String,
-        source: String,
+        source_error: String,
     },
-    #[error("failed to register Temporal worker for {task_queue}: {source}")]
-    WorkerRegistration { task_queue: String, source: String },
-    #[error("Temporal workflow operation failed for {workflow_id}: {source}")]
-    WorkflowOperation { workflow_id: String, source: String },
+    #[error("failed to register Temporal worker for {task_queue}: {source_error}")]
+    WorkerRegistration {
+        task_queue: String,
+        source_error: String,
+    },
+    #[error("Temporal workflow operation failed for {workflow_id}: {source_error}")]
+    WorkflowOperation {
+        workflow_id: String,
+        source_error: String,
+    },
 }
 
 impl SymphonyTemporalClient {
@@ -55,7 +63,7 @@ impl SymphonyTemporalClient {
             .map_err(|error| TemporalRuntimeError::Unavailable {
                 address: self.config.address.clone(),
                 namespace: self.config.namespace.clone(),
-                source: error.to_string(),
+                source_error: error.to_string(),
             })?;
 
         Client::new(
@@ -65,7 +73,7 @@ impl SymphonyTemporalClient {
         .map_err(|error| TemporalRuntimeError::Unavailable {
             address: self.config.address.clone(),
             namespace: self.config.namespace.clone(),
-            source: error.to_string(),
+            source_error: error.to_string(),
         })
     }
 
@@ -88,7 +96,7 @@ impl SymphonyTemporalClient {
             .await
             .map_err(|error| TemporalRuntimeError::WorkflowOperation {
                 workflow_id: workflow_id.clone(),
-                source: error.to_string(),
+                source_error: error.to_string(),
             })?;
 
         Ok(StartedIssueWorkflow {
@@ -104,11 +112,15 @@ impl SymphonyTemporalClient {
         let client = self.connect().await?;
         let handle = client.get_workflow_handle::<IssueWorkflow>(workflow_id);
         handle
-            .query(IssueWorkflow::current_state, (), QueryOptions::default())
+            .query(
+                IssueWorkflow::current_state,
+                (),
+                WorkflowQueryOptions::default(),
+            )
             .await
             .map_err(|error| TemporalRuntimeError::WorkflowOperation {
                 workflow_id: workflow_id.to_string(),
-                source: error.to_string(),
+                source_error: error.to_string(),
             })
     }
 
@@ -119,11 +131,11 @@ impl SymphonyTemporalClient {
         let client = self.connect().await?;
         let handle = client.get_workflow_handle::<IssueWorkflow>(workflow_id);
         handle
-            .get_result(GetWorkflowResultOptions::default())
+            .get_result(WorkflowGetResultOptions::default())
             .await
             .map_err(|error| TemporalRuntimeError::WorkflowOperation {
                 workflow_id: workflow_id.to_string(),
-                source: error.to_string(),
+                source_error: error.to_string(),
             })
     }
 }
@@ -172,8 +184,10 @@ mod tests {
     #[tokio::test]
     async fn missing_local_temporal_maps_to_unavailable_error() {
         let client = SymphonyTemporalClient::new(config("127.0.0.1:1"));
-        let error = client.connect().await.unwrap_err();
+        let result = client.connect().await;
 
+        assert!(result.is_err());
+        let error = result.err().unwrap();
         assert!(matches!(error, TemporalRuntimeError::Unavailable { .. }));
     }
 }

--- a/src/symphony/client.rs
+++ b/src/symphony/client.rs
@@ -39,6 +39,10 @@ pub enum TemporalRuntimeError {
         task_queue: String,
         source_error: String,
     },
+    #[error("failed to initialize Temporal runtime: {0}")]
+    RuntimeInitialization(String),
+    #[error("Temporal worker runtime failed: {0}")]
+    WorkerRuntime(String),
     #[error("Temporal workflow operation failed for {workflow_id}: {source_error}")]
     WorkflowOperation {
         workflow_id: String,

--- a/src/symphony/client.rs
+++ b/src/symphony/client.rs
@@ -1,0 +1,179 @@
+use std::str::FromStr;
+
+use temporalio_client::{
+    Client, ClientOptions, Connection, ConnectionOptions, GetWorkflowResultOptions, QueryOptions,
+    WorkflowStartOptions,
+};
+use temporalio_sdk_core::Url;
+use thiserror::Error;
+
+use crate::config::TemporalConfig;
+use crate::symphony::dto::{IssueWorkflowInput, IssueWorkflowQueryResult, IssueWorkflowState};
+use crate::symphony::workflows::IssueWorkflow;
+
+#[derive(Debug, Clone)]
+pub struct SymphonyTemporalClient {
+    config: TemporalConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StartedIssueWorkflow {
+    pub workflow_id: String,
+    pub run_id: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum TemporalRuntimeError {
+    #[error("invalid Temporal configuration: {0}")]
+    InvalidConfig(String),
+    #[error("Temporal service is unavailable at {address} for namespace {namespace}: {source}")]
+    Unavailable {
+        address: String,
+        namespace: String,
+        source: String,
+    },
+    #[error("failed to register Temporal worker for {task_queue}: {source}")]
+    WorkerRegistration { task_queue: String, source: String },
+    #[error("Temporal workflow operation failed for {workflow_id}: {source}")]
+    WorkflowOperation { workflow_id: String, source: String },
+}
+
+impl SymphonyTemporalClient {
+    pub fn new(config: TemporalConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn config(&self) -> &TemporalConfig {
+        &self.config
+    }
+
+    pub async fn connect(&self) -> Result<Client, TemporalRuntimeError> {
+        let address = endpoint_url(&self.config.address)?;
+        let connection_options = ConnectionOptions::new(address).build();
+        let connection = Connection::connect(connection_options)
+            .await
+            .map_err(|error| TemporalRuntimeError::Unavailable {
+                address: self.config.address.clone(),
+                namespace: self.config.namespace.clone(),
+                source: error.to_string(),
+            })?;
+
+        Client::new(
+            connection,
+            ClientOptions::new(self.config.namespace.as_str()).build(),
+        )
+        .map_err(|error| TemporalRuntimeError::Unavailable {
+            address: self.config.address.clone(),
+            namespace: self.config.namespace.clone(),
+            source: error.to_string(),
+        })
+    }
+
+    pub async fn start_noop_issue_workflow(
+        &self,
+        input: IssueWorkflowInput,
+    ) -> Result<StartedIssueWorkflow, TemporalRuntimeError> {
+        let client = self.connect().await?;
+        let workflow_id = input.workflow_id.clone();
+        client
+            .start_workflow(
+                IssueWorkflow::run,
+                input,
+                WorkflowStartOptions::new(
+                    self.config.task_queues.core.as_str(),
+                    workflow_id.as_str(),
+                )
+                .build(),
+            )
+            .await
+            .map_err(|error| TemporalRuntimeError::WorkflowOperation {
+                workflow_id: workflow_id.clone(),
+                source: error.to_string(),
+            })?;
+
+        Ok(StartedIssueWorkflow {
+            workflow_id,
+            run_id: None,
+        })
+    }
+
+    pub async fn query_issue_workflow(
+        &self,
+        workflow_id: &str,
+    ) -> Result<IssueWorkflowQueryResult, TemporalRuntimeError> {
+        let client = self.connect().await?;
+        let handle = client.get_workflow_handle::<IssueWorkflow>(workflow_id);
+        handle
+            .query(IssueWorkflow::current_state, (), QueryOptions::default())
+            .await
+            .map_err(|error| TemporalRuntimeError::WorkflowOperation {
+                workflow_id: workflow_id.to_string(),
+                source: error.to_string(),
+            })
+    }
+
+    pub async fn get_issue_workflow_result(
+        &self,
+        workflow_id: &str,
+    ) -> Result<IssueWorkflowState, TemporalRuntimeError> {
+        let client = self.connect().await?;
+        let handle = client.get_workflow_handle::<IssueWorkflow>(workflow_id);
+        handle
+            .get_result(GetWorkflowResultOptions::default())
+            .await
+            .map_err(|error| TemporalRuntimeError::WorkflowOperation {
+                workflow_id: workflow_id.to_string(),
+                source: error.to_string(),
+            })
+    }
+}
+
+fn endpoint_url(address: &str) -> Result<Url, TemporalRuntimeError> {
+    let normalized = if address.contains("://") {
+        address.to_string()
+    } else {
+        format!("http://{address}")
+    };
+
+    Url::from_str(&normalized)
+        .map_err(|error| TemporalRuntimeError::InvalidConfig(error.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{TemporalTaskQueuesConfig, TemporalWorkerConfig};
+    use crate::symphony::task_queues::{AGENT_TASK_QUEUE, CORE_TASK_QUEUE, LOCAL_TASK_QUEUE};
+
+    fn config(address: &str) -> TemporalConfig {
+        TemporalConfig {
+            address: address.to_string(),
+            namespace: "default".to_string(),
+            task_queues: TemporalTaskQueuesConfig {
+                core: CORE_TASK_QUEUE.to_string(),
+                agent: AGENT_TASK_QUEUE.to_string(),
+                local: LOCAL_TASK_QUEUE.to_string(),
+            },
+            worker: TemporalWorkerConfig {
+                core_concurrency: 3,
+                agent_concurrency: 3,
+                local_concurrency: 8,
+            },
+        }
+    }
+
+    #[test]
+    fn endpoint_url_defaults_to_local_http_scheme() {
+        let url = endpoint_url("localhost:7233").unwrap();
+
+        assert_eq!(url.as_str(), "http://localhost:7233/");
+    }
+
+    #[tokio::test]
+    async fn missing_local_temporal_maps_to_unavailable_error() {
+        let client = SymphonyTemporalClient::new(config("127.0.0.1:1"));
+        let error = client.connect().await.unwrap_err();
+
+        assert!(matches!(error, TemporalRuntimeError::Unavailable { .. }));
+    }
+}

--- a/src/symphony/dto.rs
+++ b/src/symphony/dto.rs
@@ -1,0 +1,178 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueWorkflowInput {
+    pub workflow_id: String,
+    pub repo_id: String,
+    pub issue_ref: String,
+    pub from_tracker_state: String,
+    pub target_kind: String,
+    pub source_ref: String,
+    pub source_tracker_revision: String,
+    pub started_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operator_action_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capacity_policy_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueWorkflowState {
+    pub workflow_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub repo_id: String,
+    pub issue_ref: String,
+    pub current_tracker_state: String,
+    pub active_step: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_outcome: Option<String>,
+    #[serde(default)]
+    pub artifact_refs: Vec<String>,
+    pub runtime_health_summary: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueWorkflowQueryResult {
+    pub workflow_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    pub issue_ref: String,
+    pub current_tracker_state: String,
+    pub active_step: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_outcome: Option<String>,
+    pub runtime_health_summary: String,
+    #[serde(default)]
+    pub artifact_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoopActivityRequest {
+    pub workflow_id: String,
+    pub activity_kind: String,
+    pub issue_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NoopActivityResult {
+    pub outcome: String,
+    pub summary: String,
+    #[serde(default)]
+    pub artifact_refs: Vec<String>,
+}
+
+impl IssueWorkflowState {
+    pub fn from_input(input: IssueWorkflowInput, run_id: Option<String>) -> Self {
+        Self {
+            workflow_id: input.workflow_id,
+            run_id,
+            repo_id: input.repo_id,
+            issue_ref: input.issue_ref,
+            current_tracker_state: input.from_tracker_state,
+            active_step: format!("noop:{}", input.target_kind),
+            terminal_outcome: None,
+            artifact_refs: Vec::new(),
+            runtime_health_summary: "initialized".to_string(),
+        }
+    }
+
+    pub fn query_result(&self) -> IssueWorkflowQueryResult {
+        IssueWorkflowQueryResult {
+            workflow_id: self.workflow_id.clone(),
+            run_id: self.run_id.clone(),
+            issue_ref: self.issue_ref.clone(),
+            current_tracker_state: self.current_tracker_state.clone(),
+            active_step: self.active_step.clone(),
+            terminal_outcome: self.terminal_outcome.clone(),
+            runtime_health_summary: self.runtime_health_summary.clone(),
+            artifact_refs: self.artifact_refs.clone(),
+        }
+    }
+}
+
+impl NoopActivityResult {
+    pub fn success(request: &NoopActivityRequest) -> Self {
+        Self {
+            outcome: "noop_success".to_string(),
+            summary: format!(
+                "{} completed without side effects for {}",
+                request.activity_kind, request.issue_ref
+            ),
+            artifact_refs: Vec::new(),
+        }
+    }
+
+    pub fn not_implemented(request: &NoopActivityRequest) -> Self {
+        Self {
+            outcome: "not_implemented".to_string(),
+            summary: format!(
+                "{} is registered but intentionally inert for {}",
+                request.activity_kind, request.issue_ref
+            ),
+            artifact_refs: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input() -> IssueWorkflowInput {
+        IssueWorkflowInput {
+            workflow_id: "issue:shea-symphony:475:pulse:todo-to-work:20260709-175700Z:project"
+                .to_string(),
+            repo_id: "Alive24/shea-symphony".to_string(),
+            issue_ref: "#475".to_string(),
+            from_tracker_state: "Todo".to_string(),
+            target_kind: "work".to_string(),
+            source_ref: "project-v2".to_string(),
+            source_tracker_revision: "rev-1".to_string(),
+            started_at: "2026-07-09T17:57:00Z".to_string(),
+            operator_action_ref: None,
+            capacity_policy_ref: Some("default-local".to_string()),
+        }
+    }
+
+    #[test]
+    fn issue_workflow_state_is_small_serializable_dto() {
+        let state = IssueWorkflowState::from_input(input(), Some("temporal-run-id".to_string()));
+        let value = serde_json::to_value(&state).unwrap();
+
+        assert_eq!(value["issue_ref"], "#475");
+        assert_eq!(value["artifact_refs"].as_array().unwrap().len(), 0);
+        assert!(value.get("transcript").is_none());
+        assert!(value.get("diff").is_none());
+        assert!(value.get("tracker_payload").is_none());
+    }
+
+    #[test]
+    fn query_result_exposes_state_without_repo_payload() {
+        let state = IssueWorkflowState::from_input(input(), None);
+        let query = state.query_result();
+
+        assert_eq!(query.workflow_id, state.workflow_id);
+        assert_eq!(query.issue_ref, "#475");
+        assert!(!serde_json::to_value(query)
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .contains_key("repo_id"));
+    }
+
+    #[test]
+    fn noop_activity_results_carry_summaries_not_artifacts() {
+        let request = NoopActivityRequest {
+            workflow_id: "workflow-id".to_string(),
+            activity_kind: "NoopCoreActivity".to_string(),
+            issue_ref: "#475".to_string(),
+        };
+
+        let result = NoopActivityResult::success(&request);
+
+        assert_eq!(result.outcome, "noop_success");
+        assert!(result.summary.contains("NoopCoreActivity"));
+        assert!(result.artifact_refs.is_empty());
+    }
+}

--- a/src/symphony/mod.rs
+++ b/src/symphony/mod.rs
@@ -1,0 +1,14 @@
+pub mod activities;
+pub mod client;
+pub mod dto;
+pub mod task_queues;
+pub mod workers;
+pub mod workflows;
+
+pub use client::{StartedIssueWorkflow, SymphonyTemporalClient, TemporalRuntimeError};
+pub use dto::{
+    IssueWorkflowInput, IssueWorkflowQueryResult, IssueWorkflowState, NoopActivityRequest,
+    NoopActivityResult,
+};
+pub use task_queues::{AGENT_TASK_QUEUE, CORE_TASK_QUEUE, LOCAL_TASK_QUEUE, TASK_QUEUE_COUNT};
+pub use workers::{task_queue_registrations, TaskQueueRegistration};

--- a/src/symphony/mod.rs
+++ b/src/symphony/mod.rs
@@ -2,6 +2,7 @@ pub mod activities;
 pub mod client;
 pub mod dto;
 pub mod task_queues;
+pub mod worker_runtime;
 pub mod workers;
 pub mod workflows;
 
@@ -11,4 +12,5 @@ pub use dto::{
     NoopActivityResult,
 };
 pub use task_queues::{AGENT_TASK_QUEUE, CORE_TASK_QUEUE, LOCAL_TASK_QUEUE, TASK_QUEUE_COUNT};
+pub use worker_runtime::run_symphony_workers;
 pub use workers::{task_queue_registrations, TaskQueueRegistration};

--- a/src/symphony/task_queues.rs
+++ b/src/symphony/task_queues.rs
@@ -1,0 +1,36 @@
+use crate::config::{TemporalConfig, TemporalTaskQueuesConfig};
+
+pub const CORE_TASK_QUEUE: &str = "symphony-core";
+pub const AGENT_TASK_QUEUE: &str = "symphony-agent";
+pub const LOCAL_TASK_QUEUE: &str = "symphony-local";
+pub const TASK_QUEUE_COUNT: usize = 3;
+
+pub fn default_task_queues() -> TemporalTaskQueuesConfig {
+    TemporalTaskQueuesConfig {
+        core: CORE_TASK_QUEUE.to_string(),
+        agent: AGENT_TASK_QUEUE.to_string(),
+        local: LOCAL_TASK_QUEUE.to_string(),
+    }
+}
+
+pub fn configured_task_queues(config: &TemporalConfig) -> [&str; TASK_QUEUE_COUNT] {
+    [
+        config.task_queues.core.as_str(),
+        config.task_queues.agent.as_str(),
+        config.task_queues.local.as_str(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_task_queues_match_2607_contract() {
+        let queues = default_task_queues();
+
+        assert_eq!(queues.core, CORE_TASK_QUEUE);
+        assert_eq!(queues.agent, AGENT_TASK_QUEUE);
+        assert_eq!(queues.local, LOCAL_TASK_QUEUE);
+    }
+}

--- a/src/symphony/worker_runtime.rs
+++ b/src/symphony/worker_runtime.rs
@@ -1,0 +1,64 @@
+use futures_util::try_join;
+use temporalio_client::Client;
+use temporalio_common::telemetry::TelemetryOptions;
+use temporalio_sdk::Worker;
+use temporalio_sdk_core::{CoreRuntime, RuntimeOptions};
+
+use crate::config::RuntimeConfig;
+use crate::symphony::client::{SymphonyTemporalClient, TemporalRuntimeError};
+use crate::symphony::workers::{agent_worker_options, core_worker_options, local_worker_options};
+
+pub async fn run_symphony_workers(config: RuntimeConfig) -> Result<(), TemporalRuntimeError> {
+    let runtime = core_runtime()?;
+    let temporal_client = SymphonyTemporalClient::new(config.temporal.clone());
+    let client = temporal_client.connect().await?;
+
+    let mut core_worker = worker(
+        &runtime,
+        client.clone(),
+        &config.temporal.task_queues.core,
+        core_worker_options(&config.temporal)?,
+    )?;
+    let mut agent_worker = worker(
+        &runtime,
+        client.clone(),
+        &config.temporal.task_queues.agent,
+        agent_worker_options(&config.temporal),
+    )?;
+    let mut local_worker = worker(
+        &runtime,
+        client,
+        &config.temporal.task_queues.local,
+        local_worker_options(&config.temporal),
+    )?;
+
+    try_join!(core_worker.run(), agent_worker.run(), local_worker.run())
+        .map_err(|error| TemporalRuntimeError::WorkerRuntime(error.to_string()))?;
+
+    Ok(())
+}
+
+fn core_runtime() -> Result<CoreRuntime, TemporalRuntimeError> {
+    let telemetry_options = TelemetryOptions::builder().build();
+    let runtime_options = RuntimeOptions::builder()
+        .telemetry_options(telemetry_options)
+        .build()
+        .map_err(|error| TemporalRuntimeError::RuntimeInitialization(error.to_string()))?;
+
+    CoreRuntime::new_assume_tokio(runtime_options)
+        .map_err(|error| TemporalRuntimeError::RuntimeInitialization(error.to_string()))
+}
+
+fn worker(
+    runtime: &CoreRuntime,
+    client: Client,
+    task_queue: &str,
+    options: temporalio_sdk::WorkerOptions,
+) -> Result<Worker, TemporalRuntimeError> {
+    Worker::new(runtime, client, options).map_err(|error| {
+        TemporalRuntimeError::WorkerRegistration {
+            task_queue: task_queue.to_string(),
+            source_error: error.to_string(),
+        }
+    })
+}

--- a/src/symphony/workers.rs
+++ b/src/symphony/workers.rs
@@ -1,0 +1,141 @@
+use temporalio_sdk::WorkerOptions;
+
+use crate::config::TemporalConfig;
+use crate::symphony::activities::{
+    AgentActivities, CoreActivities, LocalActivities, AGENT_ACTIVITY_TYPES, CORE_ACTIVITY_TYPES,
+    LOCAL_ACTIVITY_TYPES,
+};
+use crate::symphony::client::TemporalRuntimeError;
+use crate::symphony::workflows::{IssueWorkflow, ISSUE_WORKFLOW_TYPE};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskQueueRegistration {
+    pub task_queue: String,
+    pub workflows: Vec<String>,
+    pub activities: Vec<String>,
+    pub max_concurrent_activities: usize,
+}
+
+pub fn task_queue_registrations(config: &TemporalConfig) -> Vec<TaskQueueRegistration> {
+    vec![
+        TaskQueueRegistration {
+            task_queue: config.task_queues.core.clone(),
+            workflows: vec![ISSUE_WORKFLOW_TYPE.to_string()],
+            activities: CORE_ACTIVITY_TYPES
+                .iter()
+                .map(|activity| (*activity).to_string())
+                .collect(),
+            max_concurrent_activities: config.worker.core_concurrency,
+        },
+        TaskQueueRegistration {
+            task_queue: config.task_queues.agent.clone(),
+            workflows: Vec::new(),
+            activities: AGENT_ACTIVITY_TYPES
+                .iter()
+                .map(|activity| (*activity).to_string())
+                .collect(),
+            max_concurrent_activities: config.worker.agent_concurrency,
+        },
+        TaskQueueRegistration {
+            task_queue: config.task_queues.local.clone(),
+            workflows: Vec::new(),
+            activities: LOCAL_ACTIVITY_TYPES
+                .iter()
+                .map(|activity| (*activity).to_string())
+                .collect(),
+            max_concurrent_activities: config.worker.local_concurrency,
+        },
+    ]
+}
+
+pub fn core_worker_options(config: &TemporalConfig) -> Result<WorkerOptions, TemporalRuntimeError> {
+    Ok(WorkerOptions::new(config.task_queues.core.as_str())
+        .register_activities(CoreActivities)
+        .register_workflow::<IssueWorkflow>()
+        .build())
+}
+
+pub fn agent_worker_options(config: &TemporalConfig) -> WorkerOptions {
+    WorkerOptions::new(config.task_queues.agent.as_str())
+        .register_activities(AgentActivities)
+        .build()
+}
+
+pub fn local_worker_options(config: &TemporalConfig) -> WorkerOptions {
+    WorkerOptions::new(config.task_queues.local.as_str())
+        .register_activities(LocalActivities)
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{TemporalTaskQueuesConfig, TemporalWorkerConfig};
+    use crate::symphony::task_queues::{AGENT_TASK_QUEUE, CORE_TASK_QUEUE, LOCAL_TASK_QUEUE};
+
+    fn config() -> TemporalConfig {
+        TemporalConfig {
+            address: "localhost:7233".to_string(),
+            namespace: "default".to_string(),
+            task_queues: TemporalTaskQueuesConfig {
+                core: CORE_TASK_QUEUE.to_string(),
+                agent: AGENT_TASK_QUEUE.to_string(),
+                local: LOCAL_TASK_QUEUE.to_string(),
+            },
+            worker: TemporalWorkerConfig {
+                core_concurrency: 3,
+                agent_concurrency: 3,
+                local_concurrency: 8,
+            },
+        }
+    }
+
+    #[test]
+    fn registrations_cover_all_starting_queues() {
+        let registrations = task_queue_registrations(&config());
+
+        assert_eq!(registrations.len(), 3);
+        assert_eq!(registrations[0].task_queue, CORE_TASK_QUEUE);
+        assert_eq!(registrations[1].task_queue, AGENT_TASK_QUEUE);
+        assert_eq!(registrations[2].task_queue, LOCAL_TASK_QUEUE);
+    }
+
+    #[test]
+    fn core_registration_owns_issue_workflow_and_core_placeholders() {
+        let registrations = task_queue_registrations(&config());
+        let core = &registrations[0];
+
+        assert_eq!(core.workflows, vec![ISSUE_WORKFLOW_TYPE]);
+        assert_eq!(
+            core.activities,
+            vec!["NoopCoreActivity", "TrackerTransitionActivity"]
+        );
+        assert_eq!(core.max_concurrent_activities, 3);
+    }
+
+    #[test]
+    fn agent_and_local_registrations_are_activity_only() {
+        let registrations = task_queue_registrations(&config());
+
+        assert!(registrations[1].workflows.is_empty());
+        assert_eq!(
+            registrations[1].activities,
+            vec![
+                "MainAgentActivity",
+                "ReworkActivity",
+                "AgentReviewActivity",
+                "MergeActivity"
+            ]
+        );
+        assert!(registrations[2].workflows.is_empty());
+        assert_eq!(
+            registrations[2].activities,
+            vec![
+                "LocalStateProjectionActivity",
+                "ArtifactIndexActivity",
+                "LocalHealthActivity"
+            ]
+        );
+        assert_eq!(registrations[2].max_concurrent_activities, 8);
+    }
+}

--- a/src/symphony/workers.rs
+++ b/src/symphony/workers.rs
@@ -49,10 +49,16 @@ pub fn task_queue_registrations(config: &TemporalConfig) -> Vec<TaskQueueRegistr
 }
 
 pub fn core_worker_options(config: &TemporalConfig) -> Result<WorkerOptions, TemporalRuntimeError> {
-    Ok(WorkerOptions::new(config.task_queues.core.as_str())
+    let worker_options = WorkerOptions::new(config.task_queues.core.as_str())
         .register_activities(CoreActivities)
         .register_workflow::<IssueWorkflow>()
-        .build())
+        .map_err(|error| TemporalRuntimeError::WorkerRegistration {
+            task_queue: config.task_queues.core.clone(),
+            source_error: error.to_string(),
+        })?
+        .build();
+
+    Ok(worker_options)
 }
 
 pub fn agent_worker_options(config: &TemporalConfig) -> WorkerOptions {

--- a/src/symphony/workers.rs
+++ b/src/symphony/workers.rs
@@ -1,3 +1,4 @@
+use temporalio_common::worker::WorkerTaskTypes;
 use temporalio_sdk::WorkerOptions;
 
 use crate::config::TemporalConfig;
@@ -63,12 +64,14 @@ pub fn core_worker_options(config: &TemporalConfig) -> Result<WorkerOptions, Tem
 
 pub fn agent_worker_options(config: &TemporalConfig) -> WorkerOptions {
     WorkerOptions::new(config.task_queues.agent.as_str())
+        .task_types(WorkerTaskTypes::activity_only())
         .register_activities(AgentActivities)
         .build()
 }
 
 pub fn local_worker_options(config: &TemporalConfig) -> WorkerOptions {
     WorkerOptions::new(config.task_queues.local.as_str())
+        .task_types(WorkerTaskTypes::activity_only())
         .register_activities(LocalActivities)
         .build()
 }

--- a/src/symphony/workflows.rs
+++ b/src/symphony/workflows.rs
@@ -30,10 +30,10 @@ impl IssueWorkflow {
         ctx: &mut WorkflowContext<Self>,
         _input: IssueWorkflowInput,
     ) -> WorkflowResult<IssueWorkflowState> {
-        let request = ctx.state(|state| NoopActivityRequest {
-            workflow_id: state.workflow_id.clone(),
+        let request = ctx.state(|workflow| NoopActivityRequest {
+            workflow_id: workflow.state.workflow_id.clone(),
             activity_kind: "NoopCoreActivity".to_string(),
-            issue_ref: state.issue_ref.clone(),
+            issue_ref: workflow.state.issue_ref.clone(),
         });
 
         let _noop = ctx
@@ -44,13 +44,14 @@ impl IssueWorkflow {
             )
             .await?;
 
-        ctx.state_mut(|state| {
-            state.active_step = "noop_completed".to_string();
-            state.terminal_outcome = Some("completed_noop".to_string());
-            state.runtime_health_summary = "completed no-op IssueWorkflow path".to_string();
+        ctx.state_mut(|workflow| {
+            workflow.state.active_step = "noop_completed".to_string();
+            workflow.state.terminal_outcome = Some("completed_noop".to_string());
+            workflow.state.runtime_health_summary =
+                "completed no-op IssueWorkflow path".to_string();
         });
 
-        Ok(ctx.state(|state| state.clone()))
+        Ok(ctx.state(|workflow| workflow.state.clone()))
     }
 
     #[query(name = "current_state")]

--- a/src/symphony/workflows.rs
+++ b/src/symphony/workflows.rs
@@ -1,0 +1,60 @@
+use std::time::Duration;
+
+use temporalio_macros::{workflow, workflow_methods};
+use temporalio_sdk::{ActivityOptions, WorkflowContext, WorkflowContextView, WorkflowResult};
+
+use crate::symphony::activities::CoreActivities;
+use crate::symphony::dto::{
+    IssueWorkflowInput, IssueWorkflowQueryResult, IssueWorkflowState, NoopActivityRequest,
+};
+
+pub const ISSUE_WORKFLOW_TYPE: &str = "IssueWorkflow";
+pub const ISSUE_WORKFLOW_QUERY_CURRENT_STATE: &str = "current_state";
+
+#[workflow(name = "IssueWorkflow")]
+pub struct IssueWorkflow {
+    state: IssueWorkflowState,
+}
+
+#[workflow_methods]
+impl IssueWorkflow {
+    #[init]
+    fn new(_ctx: &WorkflowContextView, input: IssueWorkflowInput) -> Self {
+        Self {
+            state: IssueWorkflowState::from_input(input, None),
+        }
+    }
+
+    #[run]
+    pub async fn run(
+        ctx: &mut WorkflowContext<Self>,
+        _input: IssueWorkflowInput,
+    ) -> WorkflowResult<IssueWorkflowState> {
+        let request = ctx.state(|state| NoopActivityRequest {
+            workflow_id: state.workflow_id.clone(),
+            activity_kind: "NoopCoreActivity".to_string(),
+            issue_ref: state.issue_ref.clone(),
+        });
+
+        let _noop = ctx
+            .start_activity(
+                CoreActivities::noop_core_activity,
+                request,
+                ActivityOptions::start_to_close_timeout(Duration::from_secs(30)),
+            )
+            .await?;
+
+        ctx.state_mut(|state| {
+            state.active_step = "noop_completed".to_string();
+            state.terminal_outcome = Some("completed_noop".to_string());
+            state.runtime_health_summary = "completed no-op IssueWorkflow path".to_string();
+        });
+
+        Ok(ctx.state(|state| state.clone()))
+    }
+
+    #[query(name = "current_state")]
+    pub fn current_state(&self, _ctx: &WorkflowContextView) -> IssueWorkflowQueryResult {
+        self.state.query_result()
+    }
+}

--- a/src/tracker/state.rs
+++ b/src/tracker/state.rs
@@ -47,7 +47,7 @@ pub(in crate::tracker) fn issue_matches_assignee_filter(
     let allowed: Vec<String> = current_login
         .into_iter()
         .chain(filter.additional_assignees.iter().map(String::as_str))
-        .map(|assignee| normalize_state(assignee))
+        .map(normalize_state)
         .collect();
 
     issue

--- a/workflows/shea-symphony.md
+++ b/workflows/shea-symphony.md
@@ -35,6 +35,17 @@ tracker:
     marker: "<!-- shea-symphony-workpad -->"
 git:
   base_branch: main
+temporal:
+  address: localhost:7233
+  namespace: default
+  task_queues:
+    core: symphony-core
+    agent: symphony-agent
+    local: symphony-local
+  worker:
+    core_concurrency: 3
+    agent_concurrency: 3
+    local_concurrency: 8
 prompts:
   main_agent: prompts/main-agent.md
   review_agent: prompts/review-agent.md


### PR DESCRIPTION
## Summary
- Implements #475: T2607-01: add Temporal Rust SDK quickstart-conformant runtime skeleton.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #475
