### PR TITLE
#492: T2607-02: add LocalStateAdmin health and explicit migration boundary

### DIFF
--- a/docs/milestones/2607-hardening/APP-CLI-SPLIT.md
+++ b/docs/milestones/2607-hardening/APP-CLI-SPLIT.md
@@ -63,10 +63,16 @@ Human input / approve / request rework / human fix
   -> Workflow validates the request
   -> Activities update tracker/read model
 
-DB health / migration / rebuild
-  -> Tauri backend command
-  -> LocalStateAdmin
+DB health / explicit migration / later rebuild
+  -> T2607-07 Tauri backend command
+  -> T2607-02 LocalStateAdmin library
 ```
+
+T2607-02 owns only the internal `LocalStateAdmin` library boundary. It does
+not add a product CLI command, Tauri command, or Temporal Activity. T2607-07
+later owns the Tauri command/operator surface and must preserve the distinction
+between read-only health inspection and an explicit migration or recovery
+request.
 
 The App may expose buttons or links for human todo actions, but those controls
 should route to the appropriate Coding Agent/operator flow. They should not
@@ -88,6 +94,9 @@ projection.
 - provide thin admin/debug wrappers over Temporal start, query, signal, or
   update APIs.
 - provide debug-only wrappers for operator action submission if needed.
+
+Until T2607-07 provides an operator surface, LocalStateAdmin remains a library
+seam rather than a normal product CLI path.
 
 ## CLI Must Not
 

--- a/docs/milestones/2607-hardening/LOCAL-STATE-DB.md
+++ b/docs/milestones/2607-hardening/LOCAL-STATE-DB.md
@@ -115,6 +115,30 @@ The five v1 tables are:
 - `meta(key, value)`, initialized with RFC 3339 UTC `created_at` and
   `updated_at` rows.
 
+## Implemented Admin Boundary
+
+`LocalStateAdmin` now provides the narrow administrative library seam above
+the completed `LocalStateDatabase` lifecycle. It is not a CLI command, a Tauri
+command, or a Temporal Activity.
+
+`check_health` opens only an existing database with SQLite read-only flags. It
+reports typed readiness and diagnostics for missing/unavailable paths, supported
+but not-current versions, future versions, unversioned application schemas,
+incomplete current v1 evidence, malformed/corrupt files, and safe inspection
+failures. Health neither creates a parent directory nor a database file, and it
+does not alter connection PRAGMAs, journal mode, migrations, metadata, or file
+contents.
+
+`migrate` is explicit. It delegates to `LocalStateDatabase::initialize`, which
+remains the sole owner of path creation, connection policy, version inspection,
+transactions, forward migration, and compatibility/corruption semantics. This
+admin boundary does not implement rebuild, replace, recovery, compact, or
+checkpoint operations.
+
+T2607-07 will own a Tauri command or other operator-facing surface that calls
+this library. That later command must keep health inspection separate from an
+explicit migrate or recovery request.
+
 Primary keys are `workflow_index(workflow_id)`,
 `artifact_index(artifact_id)`,
 `tracker_cache(workspace_runtime_id, repo_id, issue_ref)`,
@@ -211,8 +235,9 @@ Recommended shape:
 
 - `LocalStateReader` for App/Tauri backend reads;
 - `LocalStateProjector` for Activity/backend result projection writes;
-- `LocalStateAdmin` for later health, explicit rebuild/recovery, and compact
-  operations. Startup migration remains owned by `LocalStateDatabase`.
+- `LocalStateAdmin` for read-only health and explicit migration; rebuild,
+  recovery, and compact remain deferred. Startup migration remains owned by
+  `LocalStateDatabase`.
 
 Recommended initial methods:
 
@@ -231,9 +256,9 @@ LocalStateProjector:
   mark_stale(scope, reason)
 
 LocalStateAdmin:
-  check_health()
-  rebuild(scope)
-  compact()
+  check_health() -> LocalStateHealth
+  migrate() -> LocalStateInitialization | LocalStateError
+  # rebuild/recovery/compact are deferred
 ```
 
 The lifecycle boundary uses bundled `rusqlite`, SeaQuery SQLite schema
@@ -333,6 +358,9 @@ Do not full-rebuild SQLite on every App or worker start. Startup should perform
 lightweight schema and health checks. Rebuild should happen when the DB is
 missing, corrupt, schema-incompatible, or explicitly requested by the operator
 or a recovery path.
+
+The health portion of startup is inspection-only: it must not turn a missing or
+unhealthy database into a migrated, repaired, or rebuilt one.
 
 ## Memory Cache
 

--- a/docs/milestones/2607-hardening/implementation/T2607-02-local-state-db.md
+++ b/docs/milestones/2607-hardening/implementation/T2607-02-local-state-db.md
@@ -1,7 +1,7 @@
 # T2607-02 Local State DB
 
-Status: Migration v1 implemented; projection, query, admin, and integration
-slices deferred
+Status: Migration v1 and the LocalStateAdmin health/explicit-migration boundary
+implemented; projection, query, recovery, and integration slices deferred
 
 ## Purpose
 
@@ -31,6 +31,25 @@ PR linkage, merging, or terminal writes.
   `activity_progress`, and `meta` atomically.
 - `meta` begins with RFC 3339 UTC `created_at` and `updated_at`; it never stores
   a duplicate schema version.
+
+## Implemented Admin Slice
+
+- `LocalStateAdmin` is a crate-internal library seam above
+  `LocalStateDatabase`, not a product CLI command, Tauri command, or Temporal
+  Activity.
+- `check_health` opens only an existing database in SQLite read-only mode. It
+  never creates a path, configures a connection, changes journal mode, runs a
+  migration, repairs state, or replaces a file.
+- Health returns typed current, migration-required, incompatible,
+  unversioned-conflict, incomplete-schema, corruption, and unavailable-path
+  outcomes. Current v1 readiness verifies the required table set and migration
+  metadata without becoming a database-wide schema audit.
+- `migrate` is explicit and delegates unchanged to
+  `LocalStateDatabase::initialize`; it is the only Admin operation that may
+  create a database or parent directory and apply supported forward migrations.
+- T2607-07 owns any future Tauri command or operator-facing surface over this
+  library. It must keep health read-only unless the caller explicitly requests
+  migration or a later recovery operation.
 
 ## Scope And Identity
 
@@ -94,8 +113,8 @@ require table reconstruction.
 - `projection`: typed upserts, freshness writes, and active-guard conflict
   mapping;
 - `query`: workspace-scoped readers and dashboard snapshots;
-- `admin`: health, explicit rebuild/replace, compact, recovery, and manual
-  checkpoint operations;
+- `admin`: explicit rebuild/replace, compact, recovery, and manual checkpoint
+  operations beyond the implemented health/explicit-migration boundary;
 - `test/hardening`: measured contention, internal pooling decisions,
   corruption/rebuild, and performance work after real callers exist;
 - `integration`: layered config resolves the final path and passes it to this
@@ -113,6 +132,7 @@ threads when later integrations call it.
 Temporary-file tests cover initialization/no-op reinitialization, concurrent
 initializers, exact columns/nullability/keys/indexes, connection PRAGMAs,
 machine-wide active uniqueness, workspace-scoped tracker cache keys, future
-versions, unversioned drift, malformed files, bounded contention, and atomic
-rollback. Tests inject all paths and do not touch the operator database or the
-canonical worktree.
+versions, unversioned drift, malformed files, bounded contention, atomic
+rollback, read-only health diagnostics, and explicit admin migration re-entry.
+Tests inject all paths and do not touch the operator database or the canonical
+worktree.

--- a/docs/milestones/2607-hardening/implementation/T2607-07-app-integration.md
+++ b/docs/milestones/2607-hardening/implementation/T2607-07-app-integration.md
@@ -78,6 +78,11 @@ has better local conventions.
 
 Expose a small command allowlist.
 
+T2607-02 provides the internal `LocalStateAdmin` library seam only. This
+T2607-07 slice owns any eventual Tauri command or operator-facing control over
+that seam, and must keep a read-only health check distinct from explicit
+migration or later recovery commands.
+
 Recommended commands:
 
 ```text

--- a/src/symphony/local_state/admin.rs
+++ b/src/symphony/local_state/admin.rs
@@ -1,0 +1,668 @@
+//! Read-only local-state diagnosis and explicit migration administration.
+//!
+//! Health inspection intentionally uses SQLite's read-only open mode and only
+//! reads version/schema evidence. Mutation remains an explicit caller action
+//! delegated to [`LocalStateDatabase::initialize`].
+
+// T2607-07 is the first runtime consumer of this crate-internal library seam.
+// Keep its visibility narrow without treating the pending integration as an
+// error in the standalone library build.
+#![allow(dead_code)]
+
+use std::{
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
+
+use rusqlite::{Connection, ErrorCode, OpenFlags};
+
+use super::{
+    database::{
+        has_application_schema, is_busy, is_corrupt, read_user_version, CURRENT_SCHEMA_VERSION,
+    },
+    LocalStateDatabase, LocalStateError, LocalStateInitialization,
+};
+
+const REQUIRED_V1_TABLES: &[&str] = &[
+    "workflow_index",
+    "artifact_index",
+    "tracker_cache",
+    "activity_progress",
+    "meta",
+];
+const REQUIRED_V1_METADATA_KEYS: &[&str] = &["created_at", "updated_at"];
+
+/// Internal boundary for local-state health inspection and explicit migration.
+///
+/// This is intentionally crate-visible: a later Tauri command can use the
+/// typed boundary without exposing SQLite connections or SQL outside the
+/// Symphony runtime.
+#[derive(Debug, Clone)]
+pub(crate) struct LocalStateAdmin {
+    database: LocalStateDatabase,
+}
+
+impl LocalStateAdmin {
+    /// Builds an administrative boundary over one resolved local-state path.
+    pub(crate) fn new(database: LocalStateDatabase) -> Self {
+        Self { database }
+    }
+
+    /// Inspects local-state readiness without creating or changing anything.
+    ///
+    /// The returned diagnostic tells a caller whether an explicit migration,
+    /// operator inspection, or later recovery path is appropriate. It never
+    /// uses the initialization connection policy as a probe.
+    pub(crate) fn check_health(&self) -> LocalStateHealth {
+        let path = self.database.path();
+        if let Some(diagnostic) = inspect_path(path) {
+            return LocalStateHealth::NotReady(diagnostic);
+        }
+
+        // SQLite's ordinary open can create a missing file. Health instead
+        // uses read-only mode and performs only snapshot reads below; it does
+        // not set connection PRAGMAs, negotiate journal mode, or migrate.
+        let mut connection =
+            match Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+                Ok(connection) => connection,
+                Err(error) => {
+                    return LocalStateHealth::NotReady(classify_inspection_error(
+                        path,
+                        LocalStateInspectionPhase::Open,
+                        error,
+                    ));
+                }
+            };
+        let transaction = match connection.transaction() {
+            Ok(transaction) => transaction,
+            Err(error) => {
+                return LocalStateHealth::NotReady(classify_inspection_error(
+                    path,
+                    LocalStateInspectionPhase::ReadOnlyInspection,
+                    error,
+                ));
+            }
+        };
+        let health = inspect_schema(&transaction, path);
+        if let Err(error) = transaction.commit() {
+            return LocalStateHealth::NotReady(classify_inspection_error(
+                path,
+                LocalStateInspectionPhase::ReadOnlyInspection,
+                error,
+            ));
+        }
+        health
+    }
+
+    /// Explicitly creates or forward-migrates the configured local-state DB.
+    ///
+    /// This is the only admin mutation entry point. The completed database
+    /// lifecycle remains the version and transaction authority, so callers
+    /// retain its future-version, conflict, corruption, contention, and
+    /// idempotency semantics unchanged.
+    pub(crate) fn migrate(&self) -> Result<LocalStateInitialization, LocalStateError> {
+        self.database.initialize()
+    }
+}
+
+/// Read-only assessment of the configured local-state database.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LocalStateHealth {
+    /// The current schema and its minimum v1 readiness evidence are readable.
+    Current(LocalStateReadiness),
+    /// A typed condition prevents the database from being used as current.
+    NotReady(LocalStateHealthDiagnostic),
+}
+
+/// Readiness details for a verified current local-state database.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocalStateReadiness {
+    /// Resolved local-state database path that was inspected.
+    pub path: PathBuf,
+    /// Schema version read from SQLite's `user_version` authority.
+    pub schema_version: u32,
+}
+
+/// Typed diagnostic returned when local state is not currently usable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LocalStateHealthDiagnostic {
+    /// No database exists at the configured path; explicit migration may create it.
+    MissingPath {
+        /// Resolved path that was absent.
+        path: PathBuf,
+    },
+    /// Filesystem inspection found a path that cannot be safely opened as a DB.
+    UnavailablePath {
+        /// Resolved path that could not be used for inspection.
+        path: PathBuf,
+        /// Typed reason no read-only SQLite connection was attempted or possible.
+        reason: LocalStatePathIssue,
+    },
+    /// A supported older schema needs an explicit forward migration.
+    MigrationRequired {
+        /// Resolved database path.
+        path: PathBuf,
+        /// Version read from SQLite's `user_version` authority.
+        observed_schema_version: u32,
+        /// Latest version supported by this binary.
+        supported_schema_version: u32,
+    },
+    /// A newer schema must not be changed by this binary.
+    UnsupportedSchemaVersion {
+        /// Resolved database path.
+        path: PathBuf,
+        /// Version read from SQLite's `user_version` authority.
+        observed_schema_version: u32,
+        /// Latest version supported by this binary.
+        supported_schema_version: u32,
+    },
+    /// Version zero contains application objects and cannot be adopted safely.
+    UnversionedSchemaConflict {
+        /// Resolved database path.
+        path: PathBuf,
+    },
+    /// `user_version` is current but minimum v1 readiness evidence is missing.
+    IncompleteCurrentSchema {
+        /// Resolved database path.
+        path: PathBuf,
+        /// Current version whose required evidence was incomplete.
+        schema_version: u32,
+        /// Required v1 table names absent from `sqlite_schema`.
+        missing_tables: Vec<String>,
+        /// Required v1 metadata keys absent from the `meta` table.
+        missing_metadata_keys: Vec<String>,
+    },
+    /// SQLite rejected the configured file as corrupt or malformed.
+    CorruptDatabase {
+        /// Resolved database path.
+        path: PathBuf,
+    },
+    /// A read-only open or inspection could not finish safely.
+    InspectionFailure {
+        /// Resolved database path.
+        path: PathBuf,
+        /// Operation that failed without changing database state.
+        phase: LocalStateInspectionPhase,
+        /// Classified SQLite failure; raw SQLite errors remain private.
+        failure: LocalStateInspectionFailure,
+    },
+}
+
+/// Filesystem condition that made a configured local-state path unavailable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalStatePathIssue {
+    /// The configured path exists but is not a regular file.
+    NotARegularFile,
+    /// Filesystem metadata could not be read because access was denied.
+    PermissionDenied,
+    /// Filesystem metadata could not be read for another safe-to-report reason.
+    Unavailable,
+}
+
+/// Read-only inspection operation that encountered a SQLite failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalStateInspectionPhase {
+    /// Opening the existing database with SQLite read-only flags.
+    Open,
+    /// Reading schema version or v1 readiness evidence in a deferred transaction.
+    ReadOnlyInspection,
+}
+
+/// Classified SQLite failure from a read-only health inspection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalStateInspectionFailure {
+    /// Another connection held a lock that prevented the read-only inspection.
+    Busy,
+    /// SQLite could not open the configured existing file.
+    CannotOpen,
+    /// SQLite denied the requested read-only access.
+    ReadOnly,
+    /// SQLite returned a safe but otherwise unclassified inspection failure.
+    Other,
+}
+
+fn inspect_path(path: &Path) -> Option<LocalStateHealthDiagnostic> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => None,
+        Ok(_) => Some(LocalStateHealthDiagnostic::UnavailablePath {
+            path: path.to_path_buf(),
+            reason: LocalStatePathIssue::NotARegularFile,
+        }),
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            Some(LocalStateHealthDiagnostic::MissingPath {
+                path: path.to_path_buf(),
+            })
+        }
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => {
+            Some(LocalStateHealthDiagnostic::UnavailablePath {
+                path: path.to_path_buf(),
+                reason: LocalStatePathIssue::PermissionDenied,
+            })
+        }
+        Err(_) => Some(LocalStateHealthDiagnostic::UnavailablePath {
+            path: path.to_path_buf(),
+            reason: LocalStatePathIssue::Unavailable,
+        }),
+    }
+}
+
+fn inspect_schema(connection: &Connection, path: &Path) -> LocalStateHealth {
+    let schema_version = match read_user_version(connection) {
+        Ok(schema_version) => schema_version,
+        Err(error) => {
+            return LocalStateHealth::NotReady(classify_inspection_error(
+                path,
+                LocalStateInspectionPhase::ReadOnlyInspection,
+                error,
+            ));
+        }
+    };
+    if schema_version > CURRENT_SCHEMA_VERSION {
+        return LocalStateHealth::NotReady(LocalStateHealthDiagnostic::UnsupportedSchemaVersion {
+            path: path.to_path_buf(),
+            observed_schema_version: schema_version,
+            supported_schema_version: CURRENT_SCHEMA_VERSION,
+        });
+    }
+    if schema_version == 0 {
+        return match has_application_schema(connection) {
+            Ok(true) => {
+                LocalStateHealth::NotReady(LocalStateHealthDiagnostic::UnversionedSchemaConflict {
+                    path: path.to_path_buf(),
+                })
+            }
+            Ok(false) => {
+                LocalStateHealth::NotReady(LocalStateHealthDiagnostic::MigrationRequired {
+                    path: path.to_path_buf(),
+                    observed_schema_version: schema_version,
+                    supported_schema_version: CURRENT_SCHEMA_VERSION,
+                })
+            }
+            Err(error) => LocalStateHealth::NotReady(classify_inspection_error(
+                path,
+                LocalStateInspectionPhase::ReadOnlyInspection,
+                error,
+            )),
+        };
+    }
+    if schema_version < CURRENT_SCHEMA_VERSION {
+        return LocalStateHealth::NotReady(LocalStateHealthDiagnostic::MigrationRequired {
+            path: path.to_path_buf(),
+            observed_schema_version: schema_version,
+            supported_schema_version: CURRENT_SCHEMA_VERSION,
+        });
+    }
+
+    match missing_v1_evidence(connection) {
+        Ok((missing_tables, missing_metadata_keys))
+            if missing_tables.is_empty() && missing_metadata_keys.is_empty() =>
+        {
+            LocalStateHealth::Current(LocalStateReadiness {
+                path: path.to_path_buf(),
+                schema_version,
+            })
+        }
+        Ok((missing_tables, missing_metadata_keys)) => {
+            LocalStateHealth::NotReady(LocalStateHealthDiagnostic::IncompleteCurrentSchema {
+                path: path.to_path_buf(),
+                schema_version,
+                missing_tables,
+                missing_metadata_keys,
+            })
+        }
+        Err(error) => LocalStateHealth::NotReady(classify_inspection_error(
+            path,
+            LocalStateInspectionPhase::ReadOnlyInspection,
+            error,
+        )),
+    }
+}
+
+fn missing_v1_evidence(connection: &Connection) -> rusqlite::Result<(Vec<String>, Vec<String>)> {
+    // This fixed schema inspection is intentionally smaller than a full audit:
+    // current v1 needs only its table set and migration metadata to be useful.
+    let mut table_statement = connection.prepare(
+        "SELECT name FROM sqlite_schema WHERE type = 'table' AND name IN \
+         ('workflow_index', 'artifact_index', 'tracker_cache', 'activity_progress', 'meta')",
+    )?;
+    let present_tables = table_statement
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let missing_tables = missing_entries(REQUIRED_V1_TABLES, &present_tables);
+    if missing_tables.iter().any(|name| name == "meta") {
+        return Ok((
+            missing_tables,
+            REQUIRED_V1_METADATA_KEYS
+                .iter()
+                .map(|name| (*name).to_owned())
+                .collect(),
+        ));
+    }
+
+    let mut metadata_statement =
+        connection.prepare("SELECT key FROM meta WHERE key IN ('created_at', 'updated_at')")?;
+    let present_metadata = metadata_statement
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok((
+        missing_tables,
+        missing_entries(REQUIRED_V1_METADATA_KEYS, &present_metadata),
+    ))
+}
+
+fn missing_entries(required: &[&str], present: &[String]) -> Vec<String> {
+    required
+        .iter()
+        .filter(|name| !present.iter().any(|present_name| present_name == **name))
+        .map(|name| (*name).to_owned())
+        .collect()
+}
+
+fn classify_inspection_error(
+    path: &Path,
+    phase: LocalStateInspectionPhase,
+    error: rusqlite::Error,
+) -> LocalStateHealthDiagnostic {
+    if is_corrupt(&error) {
+        return LocalStateHealthDiagnostic::CorruptDatabase {
+            path: path.to_path_buf(),
+        };
+    }
+    let failure = if is_busy(&error) {
+        LocalStateInspectionFailure::Busy
+    } else {
+        match error {
+            rusqlite::Error::SqliteFailure(inner, _) if inner.code == ErrorCode::CannotOpen => {
+                LocalStateInspectionFailure::CannotOpen
+            }
+            rusqlite::Error::SqliteFailure(inner, _) if inner.code == ErrorCode::ReadOnly => {
+                LocalStateInspectionFailure::ReadOnly
+            }
+            _ => LocalStateInspectionFailure::Other,
+        }
+    };
+    LocalStateHealthDiagnostic::InspectionFailure {
+        path: path.to_path_buf(),
+        phase,
+        failure,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn temporary_database() -> (TempDir, LocalStateDatabase) {
+        let temporary = tempfile::tempdir().unwrap();
+        let database =
+            LocalStateDatabase::at_resolved_path(temporary.path().join("nested/state/symphony.db"))
+                .unwrap();
+        (temporary, database)
+    }
+
+    fn schema_version(database: &LocalStateDatabase) -> u32 {
+        Connection::open(database.path())
+            .unwrap()
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap()
+    }
+
+    fn migration_metadata(database: &LocalStateDatabase) -> BTreeMap<String, String> {
+        let connection = Connection::open(database.path()).unwrap();
+        let mut statement = connection
+            .prepare("SELECT key, value FROM meta ORDER BY key")
+            .unwrap();
+        statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap()
+    }
+
+    fn directory_entries(database: &LocalStateDatabase) -> Vec<std::path::PathBuf> {
+        let mut entries = std::fs::read_dir(database.path().parent().unwrap())
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect::<Vec<_>>();
+        entries.sort();
+        entries
+    }
+
+    #[test]
+    fn missing_path_health_is_typed_and_creates_nothing() {
+        let (_temporary, database) = temporary_database();
+        let admin = LocalStateAdmin::new(database.clone());
+        let parent = database.path().parent().unwrap();
+
+        assert!(!parent.exists());
+        assert_eq!(
+            admin.check_health(),
+            LocalStateHealth::NotReady(LocalStateHealthDiagnostic::MissingPath {
+                path: database.path().to_path_buf(),
+            })
+        );
+        assert!(!database.path().exists());
+        assert!(!parent.exists());
+    }
+
+    #[test]
+    fn current_v1_health_verifies_readiness_without_changing_metadata() {
+        let (_temporary, database) = temporary_database();
+        let admin = LocalStateAdmin::new(database.clone());
+        admin.migrate().unwrap();
+        let before_version = schema_version(&database);
+        let before_metadata = migration_metadata(&database);
+        let before_entries = directory_entries(&database);
+
+        assert_eq!(
+            admin.check_health(),
+            LocalStateHealth::Current(LocalStateReadiness {
+                path: database.path().to_path_buf(),
+                schema_version: 1,
+            })
+        );
+        assert!(database.path().exists());
+        assert_eq!(schema_version(&database), before_version);
+        assert_eq!(migration_metadata(&database), before_metadata);
+        assert_eq!(directory_entries(&database), before_entries);
+    }
+
+    #[test]
+    fn empty_existing_database_requires_explicit_migration() {
+        let (_temporary, database) = temporary_database();
+        std::fs::create_dir_all(database.path().parent().unwrap()).unwrap();
+        let connection = Connection::open(database.path()).unwrap();
+        let initial_version: u32 = connection
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap();
+        drop(connection);
+        let admin = LocalStateAdmin::new(database.clone());
+
+        assert_eq!(
+            admin.check_health(),
+            LocalStateHealth::NotReady(LocalStateHealthDiagnostic::MigrationRequired {
+                path: database.path().to_path_buf(),
+                observed_schema_version: 0,
+                supported_schema_version: 1,
+            })
+        );
+        assert_eq!(initial_version, 0);
+        assert_eq!(schema_version(&database), 0);
+    }
+
+    #[test]
+    fn current_version_without_required_v1_evidence_is_not_healthy() {
+        let (_temporary, database) = temporary_database();
+        let admin = LocalStateAdmin::new(database.clone());
+        admin.migrate().unwrap();
+        Connection::open(database.path())
+            .unwrap()
+            .execute("DROP TABLE artifact_index", [])
+            .unwrap();
+
+        assert_eq!(
+            admin.check_health(),
+            LocalStateHealth::NotReady(LocalStateHealthDiagnostic::IncompleteCurrentSchema {
+                path: database.path().to_path_buf(),
+                schema_version: 1,
+                missing_tables: vec!["artifact_index".into()],
+                missing_metadata_keys: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_database_health_is_typed_and_never_replaces_the_file() {
+        let (_temporary, database) = temporary_database();
+        std::fs::create_dir_all(database.path().parent().unwrap()).unwrap();
+        let bytes = b"not a sqlite database";
+        std::fs::write(database.path(), bytes).unwrap();
+        let admin = LocalStateAdmin::new(database.clone());
+
+        assert_eq!(
+            admin.check_health(),
+            LocalStateHealth::NotReady(LocalStateHealthDiagnostic::CorruptDatabase {
+                path: database.path().to_path_buf(),
+            })
+        );
+        assert_eq!(std::fs::read(database.path()).unwrap(), bytes);
+    }
+
+    #[test]
+    fn future_schema_health_is_typed_and_non_mutating() {
+        let (_temporary, database) = temporary_database();
+        std::fs::create_dir_all(database.path().parent().unwrap()).unwrap();
+        let connection = Connection::open(database.path()).unwrap();
+        connection.pragma_update(None, "user_version", 2).unwrap();
+        drop(connection);
+        let admin = LocalStateAdmin::new(database.clone());
+
+        assert_eq!(
+            admin.check_health(),
+            LocalStateHealth::NotReady(LocalStateHealthDiagnostic::UnsupportedSchemaVersion {
+                path: database.path().to_path_buf(),
+                observed_schema_version: 2,
+                supported_schema_version: 1,
+            })
+        );
+        assert_eq!(schema_version(&database), 2);
+    }
+
+    #[test]
+    fn unversioned_application_schema_health_is_typed_and_non_mutating() {
+        let (_temporary, database) = temporary_database();
+        std::fs::create_dir_all(database.path().parent().unwrap()).unwrap();
+        let connection = Connection::open(database.path()).unwrap();
+        connection
+            .execute("CREATE TABLE foreign_schema (id INTEGER)", [])
+            .unwrap();
+        drop(connection);
+        let admin = LocalStateAdmin::new(database.clone());
+
+        assert_eq!(
+            admin.check_health(),
+            LocalStateHealth::NotReady(LocalStateHealthDiagnostic::UnversionedSchemaConflict {
+                path: database.path().to_path_buf(),
+            })
+        );
+        let connection = Connection::open(database.path()).unwrap();
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'workflow_index'",
+                    [],
+                    |row| row.get::<_, u32>(0)
+                )
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn explicit_migration_creates_once_and_reentry_is_a_no_op() {
+        let (_temporary, database) = temporary_database();
+        let admin = LocalStateAdmin::new(database.clone());
+
+        let first = admin.migrate().unwrap();
+        let second = admin.migrate().unwrap();
+
+        assert_eq!(first.path, database.path());
+        assert_eq!(first.observed_schema_version, 0);
+        assert_eq!(first.schema_version, 1);
+        assert!(first.migration_ran);
+        assert_eq!(second.observed_schema_version, 1);
+        assert_eq!(second.schema_version, 1);
+        assert!(!second.migration_ran);
+        assert!(matches!(admin.check_health(), LocalStateHealth::Current(_)));
+    }
+
+    #[test]
+    fn explicit_migration_preserves_nonrecoverable_inputs() {
+        let (_temporary, malformed) = temporary_database();
+        std::fs::create_dir_all(malformed.path().parent().unwrap()).unwrap();
+        let malformed_bytes = b"not a sqlite database";
+        std::fs::write(malformed.path(), malformed_bytes).unwrap();
+        let malformed_admin = LocalStateAdmin::new(malformed.clone());
+        assert!(matches!(
+            malformed_admin.migrate(),
+            Err(LocalStateError::CorruptDatabase { .. })
+        ));
+        assert_eq!(std::fs::read(malformed.path()).unwrap(), malformed_bytes);
+
+        let (_temporary, future) = temporary_database();
+        std::fs::create_dir_all(future.path().parent().unwrap()).unwrap();
+        let connection = Connection::open(future.path()).unwrap();
+        connection.pragma_update(None, "user_version", 2).unwrap();
+        drop(connection);
+        let future_admin = LocalStateAdmin::new(future.clone());
+        assert!(matches!(
+            future_admin.migrate(),
+            Err(LocalStateError::UnsupportedSchemaVersion { observed: 2, .. })
+        ));
+        assert_eq!(schema_version(&future), 2);
+
+        let (_temporary, conflict) = temporary_database();
+        std::fs::create_dir_all(conflict.path().parent().unwrap()).unwrap();
+        let connection = Connection::open(conflict.path()).unwrap();
+        connection
+            .execute("CREATE TABLE foreign_schema (id INTEGER)", [])
+            .unwrap();
+        drop(connection);
+        let conflict_admin = LocalStateAdmin::new(conflict.clone());
+        assert!(matches!(
+            conflict_admin.migrate(),
+            Err(LocalStateError::UnversionedSchemaConflict { .. })
+        ));
+        let connection = Connection::open(conflict.path()).unwrap();
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_schema WHERE name = 'workflow_index'",
+                    [],
+                    |row| row.get::<_, u32>(0)
+                )
+                .unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn non_file_path_is_a_typed_unavailable_diagnostic() {
+        let temporary = tempfile::tempdir().unwrap();
+        let database = LocalStateDatabase::at_resolved_path(temporary.path()).unwrap();
+        let admin = LocalStateAdmin::new(database.clone());
+
+        assert_eq!(
+            admin.check_health(),
+            LocalStateHealth::NotReady(LocalStateHealthDiagnostic::UnavailablePath {
+                path: database.path().to_path_buf(),
+                reason: LocalStatePathIssue::NotARegularFile,
+            })
+        );
+    }
+}

--- a/src/symphony/local_state/database.rs
+++ b/src/symphony/local_state/database.rs
@@ -11,7 +11,8 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use super::migration::{Migration, MIGRATIONS};
 
-const CURRENT_SCHEMA_VERSION: u32 = super::migration::CURRENT_SCHEMA_VERSION;
+/// Latest schema version understood by this binary.
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = super::migration::CURRENT_SCHEMA_VERSION;
 
 const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const DATABASE_RELATIVE_PATH: &str = "state/symphony.db";
@@ -423,7 +424,8 @@ fn configure_connection(connection: &Connection) -> rusqlite::Result<JournalMode
     configure_journal_mode(connection)
 }
 
-fn read_user_version(connection: &Connection) -> rusqlite::Result<u32> {
+/// Reads SQLite's sole schema-version authority without changing it.
+pub(super) fn read_user_version(connection: &Connection) -> rusqlite::Result<u32> {
     // PRAGMA user_version is SQLite's only migration-version authority and has
     // no SeaQuery representation.
     connection.pragma_query_value(None, "user_version", |row| row.get(0))
@@ -439,7 +441,8 @@ fn inspect_initial_schema(connection: &mut Connection) -> rusqlite::Result<(u32,
     Ok((version, conflict))
 }
 
-fn has_application_schema(connection: &Connection) -> rusqlite::Result<bool> {
+/// Detects application-owned schema objects while ignoring SQLite internals.
+pub(super) fn has_application_schema(connection: &Connection) -> rusqlite::Result<bool> {
     // sqlite_schema introspection has no SeaQuery representation. Internal
     // sqlite_* objects are ignored; any application object makes v0 ambiguous.
     connection.query_row(
@@ -449,7 +452,8 @@ fn has_application_schema(connection: &Connection) -> rusqlite::Result<bool> {
     )
 }
 
-fn is_busy(error: &rusqlite::Error) -> bool {
+/// Returns whether SQLite reported bounded lock contention.
+pub(super) fn is_busy(error: &rusqlite::Error) -> bool {
     matches!(
         error,
         rusqlite::Error::SqliteFailure(inner, _)
@@ -457,7 +461,8 @@ fn is_busy(error: &rusqlite::Error) -> bool {
     )
 }
 
-fn is_corrupt(error: &rusqlite::Error) -> bool {
+/// Returns whether SQLite rejected the file as corrupt or malformed.
+pub(super) fn is_corrupt(error: &rusqlite::Error) -> bool {
     matches!(
         error,
         rusqlite::Error::SqliteFailure(inner, _)

--- a/src/symphony/local_state/mod.rs
+++ b/src/symphony/local_state/mod.rs
@@ -7,6 +7,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 
+pub(crate) mod admin;
 mod database;
 mod identity;
 mod migration;

--- a/src/symphony/mod.rs
+++ b/src/symphony/mod.rs
@@ -18,7 +18,7 @@
 mod activities;
 mod client;
 mod dto;
-mod local_state;
+pub(crate) mod local_state;
 mod task_queues;
 mod worker_runtime;
 mod workers;


### PR DESCRIPTION
## Summary
- Implements #492: T2607-02: add LocalStateAdmin health and explicit migration boundary.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #492
