### PR TITLE
#493: T2607-02: read active workflow-index rows without lifecycle inference

### DIFF
--- a/docs/milestones/2607-hardening/LOCAL-STATE-DB.md
+++ b/docs/milestones/2607-hardening/LOCAL-STATE-DB.md
@@ -246,6 +246,18 @@ Recommended shape:
   recovery, and compact remain deferred. Startup migration remains owned by
   `LocalStateDatabase`.
 
+The implemented first reader slice is intentionally narrower than the eventual
+dashboard surface. It can find one active `workflow_index` row by fully
+qualified repository and issue identity, or list at most 100 active rows for a
+workspace runtime and repository in stored issue/workflow identity order. It
+reuses the Admin readiness distinction, returns only persisted `starting` or
+`running` rows, and never infers latest execution, lifecycle, freshness,
+tracker state, or Temporal state.
+
+`tracker_cache`, `activity_progress`, and `artifact_index` reads remain
+deferred alongside the full `DashboardSnapshot`; their ownership ledger is in
+`implementation/T2607-02-local-state-db.md`.
+
 Recommended initial methods:
 
 ```text

--- a/docs/milestones/2607-hardening/implementation/T2607-02-local-state-db.md
+++ b/docs/milestones/2607-hardening/implementation/T2607-02-local-state-db.md
@@ -1,8 +1,8 @@
 # T2607-02 Local State DB
 
-Status: Migration v1, Describe-backed lifecycle projection, and the
-LocalStateAdmin health/explicit-migration boundary implemented; query, recovery,
-and integration slices deferred
+Status: Migration v1, Describe-backed lifecycle projection, LocalStateAdmin
+health/explicit migration, and active-only workflow-index reads implemented;
+broader query, recovery, and integration slices deferred
 
 ## Purpose
 
@@ -136,9 +136,39 @@ require table reconstruction.
   supported close classification later arrives. Old-Run evidence and identity
   conflicts never overwrite a row.
 
+## Implemented Active Query Slice
+
+- `LocalStateReader` is a crate-internal, synchronous read boundary. It reuses
+  `LocalStateAdmin` readiness diagnostics and opens only an existing, current
+  database in SQLite read-only mode.
+- A fully qualified repository/issue lookup returns only the shared
+  `starting` or `running` status rows. A scoped list filters by
+  `workspace_runtime_id` and `repo_id`, orders by stored `issue_ref` then
+  `workflow_id` ascending, and returns at most 100 rows.
+- Successful absence is possible only after readiness is established. Missing,
+  uninitialized, corrupt, incomplete, unversioned-conflict, or incompatible
+  state remains a typed unavailable/not-ready result.
+- Reads do not infer lifecycle, freshness, latest Run, tracker state, or
+  Temporal state, and they do not initialize, migrate, repair, project, write,
+  or make network calls.
+
+## Deferred Read-Model Ledger
+
+Only active `workflow_index` reads are implemented in this slice. Absence from
+an unimplemented surface is not evidence that the underlying work is fresh,
+successful, or complete.
+
+| Deferred surface | Known downstream owner |
+| --- | --- |
+| `tracker_cache` reads/projection completion | T2607-04 Tracker Transition Activity |
+| `activity_progress` reads/projection completion | T2607-05 Agent Activity Boundary |
+| `artifact_index` reads/projection completion | T2607-05 Agent Activity Boundary |
+| Full `DashboardSnapshot` assembly and App exposure | T2607-07 App Integration |
+
 ## Deferred Slices
 
-- `query`: workspace-scoped readers and dashboard snapshots;
+- `query`: tracker cache, activity progress, artifact index, and complete
+  dashboard snapshots beyond the implemented active workflow index;
 - `admin`: explicit rebuild/replace, compact, recovery, and manual checkpoint
   operations beyond the implemented health/explicit-migration boundary;
 - `test/hardening`: measured contention, internal pooling decisions,

--- a/src/symphony/local_state/mod.rs
+++ b/src/symphony/local_state/mod.rs
@@ -12,9 +12,12 @@ mod database;
 mod identity;
 mod migration;
 pub(crate) mod projector;
+pub(crate) mod reader;
+mod workflow_index;
 
 pub use database::{JournalMode, LocalStateDatabase, LocalStateError, LocalStateInitialization};
 pub use identity::{
     Freshness, IssueRef, RepoId, TrackerBackend, WorkflowId, WorkflowIndexStatus,
     WorkspaceRuntimeId, ACTIVE_WORKFLOW_STATUSES,
 };
+pub(crate) use workflow_index::{WorkflowIndexRow, WorkflowTerminalOutcome};

--- a/src/symphony/local_state/projector.rs
+++ b/src/symphony/local_state/projector.rs
@@ -8,18 +8,15 @@
 // tracked Coordinator integration slice. Its focused tests exercise behavior.
 #![allow(dead_code)]
 
-use std::io;
-
-use rusqlite::{
-    params_from_iter, types::Type, Connection, ErrorCode, OptionalExtension, Transaction,
-};
+use rusqlite::{params_from_iter, Connection, ErrorCode, OptionalExtension, Transaction};
 use sea_query::{Expr, ExprTrait, Query, SqliteQueryBuilder};
 use sea_query_rusqlite::RusqliteBinder;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime, UtcOffset};
 
 use super::{
-    Freshness, IssueRef, LocalStateDatabase, LocalStateError, RepoId, WorkflowId,
-    WorkflowIndexStatus, WorkspaceRuntimeId,
+    workflow_index::{unsupported_storage_value, workflow_index_columns, workflow_index_row},
+    Freshness, IssueRef, LocalStateDatabase, LocalStateError, RepoId, WorkflowId, WorkflowIndexRow,
+    WorkflowIndexStatus, WorkflowTerminalOutcome, WorkspaceRuntimeId,
 };
 
 const WORKFLOW_EXECUTION_STEP: &str = "workflow_execution";
@@ -39,48 +36,6 @@ pub(crate) enum WorkflowCloseStatus {
     Terminated,
     /// The execution timed out.
     TimedOut,
-}
-
-/// A bounded terminal classification persisted in `workflow_index.terminal_outcome`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum WorkflowTerminalOutcome {
-    /// The execution completed successfully.
-    Completed,
-    /// The execution failed.
-    Failed,
-    /// The execution was cancelled before normal completion.
-    Cancelled,
-    /// The execution was terminated by an operator or policy.
-    Terminated,
-    /// The execution timed out.
-    TimedOut,
-    /// A Describe-backed close was observed without a supported classification.
-    ClosedUnknown,
-}
-
-impl WorkflowTerminalOutcome {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Completed => "completed",
-            Self::Failed => "failed",
-            Self::Cancelled => "cancelled",
-            Self::Terminated => "terminated",
-            Self::TimedOut => "timed_out",
-            Self::ClosedUnknown => "closed_unknown",
-        }
-    }
-
-    fn from_storage(value: &str) -> Option<Self> {
-        match value {
-            "completed" => Some(Self::Completed),
-            "failed" => Some(Self::Failed),
-            "cancelled" => Some(Self::Cancelled),
-            "terminated" => Some(Self::Terminated),
-            "timed_out" => Some(Self::TimedOut),
-            "closed_unknown" => Some(Self::ClosedUnknown),
-            _ => None,
-        }
-    }
 }
 
 /// Stable, bounded code returned for a definitive Temporal start failure.
@@ -230,49 +185,6 @@ pub(crate) enum WorkflowLifecycleObservation {
         /// Time at which the caller made this observation.
         observed_at: OffsetDateTime,
     },
-}
-
-/// A row read from the committed v1 `workflow_index` schema.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct WorkflowIndexRow {
-    /// Persisted Symphony semantic Workflow ID.
-    pub(crate) workflow_id: String,
-    /// Persisted Temporal Run ID when Describe evidence has supplied one.
-    pub(crate) run_id: Option<String>,
-    /// Persisted stable runtime scope.
-    pub(crate) workspace_runtime_id: String,
-    /// Persisted repository storage key.
-    pub(crate) repo_id: String,
-    /// Persisted tracker issue storage key.
-    pub(crate) issue_ref: String,
-    /// Persisted activation tracker state.
-    pub(crate) from_state: String,
-    /// Persisted requested orchestration target.
-    pub(crate) target_kind: String,
-    /// Persisted caller-supplied tracker context.
-    pub(crate) current_state: String,
-    /// Persisted bounded lifecycle sentinel.
-    pub(crate) active_step: String,
-    /// Persisted waiting sentinel, unused by this summary slice.
-    pub(crate) waiting_kind: Option<String>,
-    /// Persisted activation provenance reference.
-    pub(crate) source_ref: String,
-    /// Persisted activation tracker revision.
-    pub(crate) source_tracker_revision: String,
-    /// Persisted authoritative Temporal execution start time.
-    pub(crate) started_at: String,
-    /// Persisted progress time, unchanged by this summary slice.
-    pub(crate) last_progress_at: Option<String>,
-    /// Persisted local lifecycle classification.
-    pub(crate) status: WorkflowIndexStatus,
-    /// Persisted bounded close classification.
-    pub(crate) terminal_outcome: Option<WorkflowTerminalOutcome>,
-    /// Persisted optional operator-action provenance.
-    pub(crate) operator_action_ref: Option<String>,
-    /// Persisted material-projection freshness.
-    pub(crate) freshness: Freshness,
-    /// Persisted observation time for the last material projection.
-    pub(crate) updated_at: String,
 }
 
 /// Typed result of applying one lifecycle observation.
@@ -1049,102 +961,6 @@ fn load_active_workflow(
             workflow_index_row,
         )
         .optional()
-}
-
-fn workflow_index_columns() -> [&'static str; 19] {
-    [
-        "workflow_id",
-        "run_id",
-        "workspace_runtime_id",
-        "repo_id",
-        "issue_ref",
-        "from_state",
-        "target_kind",
-        "current_state",
-        "active_step",
-        "waiting_kind",
-        "source_ref",
-        "source_tracker_revision",
-        "started_at",
-        "last_progress_at",
-        "status",
-        "terminal_outcome",
-        "operator_action_ref",
-        "freshness",
-        "updated_at",
-    ]
-}
-
-fn workflow_index_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorkflowIndexRow> {
-    let status_value: String = row.get(14)?;
-    let terminal_outcome_value: Option<String> = row.get(15)?;
-    let freshness_value: String = row.get(17)?;
-
-    Ok(WorkflowIndexRow {
-        workflow_id: row.get(0)?,
-        run_id: row.get(1)?,
-        workspace_runtime_id: row.get(2)?,
-        repo_id: row.get(3)?,
-        issue_ref: row.get(4)?,
-        from_state: row.get(5)?,
-        target_kind: row.get(6)?,
-        current_state: row.get(7)?,
-        active_step: row.get(8)?,
-        waiting_kind: row.get(9)?,
-        source_ref: row.get(10)?,
-        source_tracker_revision: row.get(11)?,
-        started_at: row.get(12)?,
-        last_progress_at: row.get(13)?,
-        status: workflow_index_status_from_storage(&status_value)
-            .ok_or_else(|| unsupported_storage_value(14, "status", &status_value))?,
-        terminal_outcome: terminal_outcome_value
-            .as_deref()
-            .map(|value| {
-                WorkflowTerminalOutcome::from_storage(value)
-                    .ok_or_else(|| unsupported_storage_value(15, "terminal_outcome", value))
-            })
-            .transpose()?,
-        operator_action_ref: row.get(16)?,
-        freshness: freshness_from_storage(&freshness_value)
-            .ok_or_else(|| unsupported_storage_value(17, "freshness", &freshness_value))?,
-        updated_at: row.get(18)?,
-    })
-}
-
-fn workflow_index_status_from_storage(value: &str) -> Option<WorkflowIndexStatus> {
-    match value {
-        "starting" => Some(WorkflowIndexStatus::Starting),
-        "running" => Some(WorkflowIndexStatus::Running),
-        "completed" => Some(WorkflowIndexStatus::Completed),
-        "failed" => Some(WorkflowIndexStatus::Failed),
-        "start_failed" => Some(WorkflowIndexStatus::StartFailed),
-        "stale_start" => Some(WorkflowIndexStatus::StaleStart),
-        "stale_missing" => Some(WorkflowIndexStatus::StaleMissing),
-        "closed_unknown" => Some(WorkflowIndexStatus::ClosedUnknown),
-        _ => None,
-    }
-}
-
-fn freshness_from_storage(value: &str) -> Option<Freshness> {
-    match value {
-        "fresh" => Some(Freshness::Fresh),
-        "stale" => Some(Freshness::Stale),
-        "refreshing" => Some(Freshness::Refreshing),
-        "failed" => Some(Freshness::Failed),
-        "unknown" => Some(Freshness::Unknown),
-        _ => None,
-    }
-}
-
-fn unsupported_storage_value(index: usize, column: &str, value: &str) -> rusqlite::Error {
-    rusqlite::Error::FromSqlConversionFailure(
-        index,
-        Type::Text,
-        Box::new(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("unsupported workflow_index {column} value {value:?}"),
-        )),
-    )
 }
 
 fn local_state_error_to_sqlite(error: LocalStateError) -> rusqlite::Error {

--- a/src/symphony/local_state/reader.rs
+++ b/src/symphony/local_state/reader.rs
@@ -1,0 +1,602 @@
+//! Active-only reads from the ready local `workflow_index`.
+//!
+//! This crate-internal boundary performs no initialization, migration,
+//! projection, repair, network access, or lifecycle interpretation.
+
+// The first Coordinator/App consumers are tracked separately. Keep this
+// focused internal seam warning-clean while its behavior is exercised here.
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+use rusqlite::{params_from_iter, Connection, ErrorCode, OpenFlags, OptionalExtension};
+use sea_query::{Expr, ExprTrait, Order, Query, SqliteQueryBuilder};
+use sea_query_rusqlite::RusqliteBinder;
+use thiserror::Error;
+
+use super::{
+    admin::{LocalStateAdmin, LocalStateHealth, LocalStateHealthDiagnostic},
+    database::{is_busy, is_corrupt},
+    workflow_index::{workflow_index_columns, workflow_index_row},
+    IssueRef, LocalStateDatabase, RepoId, WorkflowIndexRow, WorkflowIndexStatus,
+    WorkspaceRuntimeId, ACTIVE_WORKFLOW_STATUSES,
+};
+
+/// Maximum number of rows returned by one scoped active-workflow list.
+pub(crate) const ACTIVE_WORKFLOW_LIST_LIMIT: u64 = 100;
+
+/// Typed failure from an active local-state read.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum LocalStateReaderError {
+    /// The database did not pass the established read-only readiness check.
+    #[error("local state is not ready: {0:?}")]
+    NotReady(LocalStateHealthDiagnostic),
+    /// The issue reference did not belong to the explicitly supplied repository.
+    #[error("issue reference repository does not match the requested repository")]
+    IssueRepositoryMismatch,
+    /// A ready database became unavailable or exposed malformed read data.
+    #[error("local-state read failed for {path}: {failure:?}")]
+    ReadUnavailable {
+        /// Resolved database path used for the read.
+        path: PathBuf,
+        /// Stable failure classification; raw SQLite errors stay private.
+        failure: LocalStateReadFailure,
+    },
+}
+
+/// Stable classification for a failed read after readiness was established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalStateReadFailure {
+    /// Another connection prevented the bounded read from completing.
+    Busy,
+    /// The database could no longer be opened at its configured path.
+    CannotOpen,
+    /// SQLite identified malformed or corrupt database storage.
+    CorruptDatabase,
+    /// A selected `workflow_index` value did not match the v1 typed row contract.
+    MalformedWorkflowIndex,
+    /// The read failed for another non-mutating SQLite reason.
+    Other,
+}
+
+/// Read-only access to active rows in a compatible local-state database.
+///
+/// The reader exposes neither a generic Workflow lookup nor latest/history
+/// helpers. Returned rows are the persisted v1 projection facts, unchanged.
+#[derive(Debug, Clone)]
+pub(crate) struct LocalStateReader {
+    database: LocalStateDatabase,
+}
+
+impl LocalStateReader {
+    /// Binds active reads to one resolved local-state database handle.
+    pub(crate) fn new(database: LocalStateDatabase) -> Self {
+        Self { database }
+    }
+
+    /// Finds the active row for one fully qualified repository issue.
+    ///
+    /// `Ok(None)` means a compatible, ready database contained no `starting`
+    /// or `running` match. It does not mean that Temporal or tracker state has
+    /// established the absence of an active Workflow.
+    pub(crate) fn find_active_workflow_for_issue(
+        &self,
+        repo_id: &RepoId,
+        issue_ref: &IssueRef,
+    ) -> Result<Option<WorkflowIndexRow>, LocalStateReaderError> {
+        if issue_ref.repo_id != *repo_id {
+            return Err(LocalStateReaderError::IssueRepositoryMismatch);
+        }
+        let connection = self.open_ready_read_only()?;
+        let (sql, values) = Query::select()
+            .columns(workflow_index_columns())
+            .from("workflow_index")
+            .and_where(Expr::col("repo_id").eq(repo_id.database_key()))
+            .and_where(Expr::col("issue_ref").eq(issue_ref.database_key()))
+            // Active membership comes directly from #481's shared status
+            // contract; this query never derives lifecycle from timestamps,
+            // freshness, Run IDs, tracker state, or row ordering.
+            .and_where(Expr::col("status").is_in(active_status_spellings()))
+            .build_rusqlite(SqliteQueryBuilder);
+        connection
+            .query_row(
+                &sql,
+                params_from_iter(values.as_params()),
+                workflow_index_row,
+            )
+            .optional()
+            .map_err(|error| self.classify_read_error(error))
+    }
+
+    /// Lists active rows for one runtime and repository scope.
+    ///
+    /// Results are ordered by the stored fully qualified `issue_ref`, then by
+    /// `workflow_id`, both ascending, and are capped at
+    /// [`ACTIVE_WORKFLOW_LIST_LIMIT`]. Ordering is only deterministic
+    /// presentation order; it does not select a latest lifecycle episode.
+    pub(crate) fn list_active_workflows_for_scope(
+        &self,
+        workspace_runtime_id: &WorkspaceRuntimeId,
+        repo_id: &RepoId,
+    ) -> Result<Vec<WorkflowIndexRow>, LocalStateReaderError> {
+        let connection = self.open_ready_read_only()?;
+        let (sql, values) = Query::select()
+            .columns(workflow_index_columns())
+            .from("workflow_index")
+            .and_where(
+                Expr::col("workspace_runtime_id").eq(workspace_runtime_id.as_str().to_owned()),
+            )
+            .and_where(Expr::col("repo_id").eq(repo_id.database_key()))
+            .and_where(Expr::col("status").is_in(active_status_spellings()))
+            .order_by("issue_ref", Order::Asc)
+            .order_by("workflow_id", Order::Asc)
+            .limit(ACTIVE_WORKFLOW_LIST_LIMIT)
+            .build_rusqlite(SqliteQueryBuilder);
+        let mut statement = connection
+            .prepare(&sql)
+            .map_err(|error| self.classify_read_error(error))?;
+        let result = statement
+            .query_map(params_from_iter(values.as_params()), workflow_index_row)
+            .map_err(|error| self.classify_read_error(error))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|error| self.classify_read_error(error));
+        result
+    }
+
+    fn open_ready_read_only(&self) -> Result<Connection, LocalStateReaderError> {
+        // Readiness is the unavailable-versus-empty boundary. A missing,
+        // uninitialized, incompatible, or corrupt database never collapses
+        // into the successful absence values returned by the methods above.
+        match LocalStateAdmin::new(self.database.clone()).check_health() {
+            LocalStateHealth::Current(_) => {}
+            LocalStateHealth::NotReady(diagnostic) => {
+                return Err(LocalStateReaderError::NotReady(diagnostic));
+            }
+        }
+
+        // SQLite's ordinary open may create a file. The reader uses only
+        // read-only flags and never applies connection or journal PRAGMAs.
+        Connection::open_with_flags(self.database.path(), OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|error| self.classify_read_error(error))
+    }
+
+    fn classify_read_error(&self, error: rusqlite::Error) -> LocalStateReaderError {
+        let failure = if is_busy(&error) {
+            LocalStateReadFailure::Busy
+        } else if is_corrupt(&error) {
+            LocalStateReadFailure::CorruptDatabase
+        } else {
+            match error {
+                rusqlite::Error::SqliteFailure(inner, _) if inner.code == ErrorCode::CannotOpen => {
+                    LocalStateReadFailure::CannotOpen
+                }
+                rusqlite::Error::FromSqlConversionFailure(..)
+                | rusqlite::Error::InvalidColumnType(..)
+                | rusqlite::Error::InvalidColumnName(..)
+                | rusqlite::Error::Utf8Error(..)
+                | rusqlite::Error::IntegralValueOutOfRange(..) => {
+                    LocalStateReadFailure::MalformedWorkflowIndex
+                }
+                _ => LocalStateReadFailure::Other,
+            }
+        };
+        LocalStateReaderError::ReadUnavailable {
+            path: self.database.path().to_path_buf(),
+            failure,
+        }
+    }
+}
+
+fn active_status_spellings() -> impl Iterator<Item = &'static str> {
+    ACTIVE_WORKFLOW_STATUSES
+        .iter()
+        .copied()
+        .map(WorkflowIndexStatus::as_str)
+}
+
+// TODO(T2607-02): Only `workflow_index` is readable in this slice; absent
+// `tracker_cache`, `activity_progress`, or `artifact_index` data is not
+// evidence that those views are fresh, successful, or complete.
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use rusqlite::{params, Connection};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::symphony::local_state::{admin::LocalStateReadiness, Freshness, TrackerBackend};
+
+    struct Fixture {
+        _temporary: TempDir,
+        database: LocalStateDatabase,
+        reader: LocalStateReader,
+    }
+
+    fn fixture() -> Fixture {
+        let temporary = tempfile::tempdir().unwrap();
+        let database =
+            LocalStateDatabase::at_resolved_path(temporary.path().join("state.db")).unwrap();
+        database.initialize().unwrap();
+        let reader = LocalStateReader::new(database.clone());
+        Fixture {
+            _temporary: temporary,
+            database,
+            reader,
+        }
+    }
+
+    fn database_at(temporary: &TempDir, name: &str) -> LocalStateDatabase {
+        LocalStateDatabase::at_resolved_path(temporary.path().join(name)).unwrap()
+    }
+
+    fn repo() -> RepoId {
+        RepoId::new("github.com", "Alive24", "shea-symphony")
+    }
+
+    fn issue(repo_id: &RepoId, number: u64) -> IssueRef {
+        IssueRef::new(TrackerBackend::GithubProjectV2, repo_id.clone(), number)
+    }
+
+    fn insert_row(
+        database: &LocalStateDatabase,
+        workflow_id: &str,
+        runtime_id: &str,
+        repo_id: &RepoId,
+        issue_ref: &IssueRef,
+        status: WorkflowIndexStatus,
+        freshness: &str,
+    ) {
+        let connection = Connection::open(database.path()).unwrap();
+        connection
+            .execute(
+                "INSERT INTO workflow_index (
+                    workflow_id, run_id, workspace_runtime_id, repo_id, issue_ref,
+                    from_state, target_kind, current_state, active_step, waiting_kind,
+                    source_ref, source_tracker_revision, started_at, last_progress_at,
+                    status, terminal_outcome, operator_action_ref, freshness, updated_at
+                 ) VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, ?10, ?11, ?12,
+                    NULL, ?13, NULL, NULL, ?14, ?15
+                 )",
+                params![
+                    workflow_id,
+                    format!("run-{workflow_id}"),
+                    runtime_id,
+                    repo_id.database_key(),
+                    issue_ref.database_key(),
+                    "Todo",
+                    "implementation",
+                    "In Progress",
+                    "workflow_execution",
+                    format!("project-item:{}", issue_ref.number),
+                    "revision-1",
+                    "2026-07-25T10:00:00Z",
+                    status.as_str(),
+                    freshness,
+                    "2026-07-25T10:01:00Z",
+                ],
+            )
+            .unwrap();
+    }
+
+    fn schema_version(database: &LocalStateDatabase) -> u32 {
+        Connection::open(database.path())
+            .unwrap()
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn ready_empty_database_returns_absence_without_inference() {
+        let fixture = fixture();
+        let repo_id = repo();
+        let issue_ref = issue(&repo_id, 493);
+
+        assert_eq!(
+            fixture
+                .reader
+                .find_active_workflow_for_issue(&repo_id, &issue_ref)
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            fixture
+                .reader
+                .list_active_workflows_for_scope(&WorkspaceRuntimeId::new("runtime-a"), &repo_id,)
+                .unwrap(),
+            Vec::<WorkflowIndexRow>::new()
+        );
+        assert_eq!(
+            LocalStateAdmin::new(fixture.database).check_health(),
+            LocalStateHealth::Current(LocalStateReadiness {
+                path: fixture.reader.database.path().to_path_buf(),
+                schema_version: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn fully_qualified_lookup_returns_active_not_historical_episode() {
+        let fixture = fixture();
+        let repo_id = repo();
+        let issue_ref = issue(&repo_id, 493);
+        insert_row(
+            &fixture.database,
+            "workflow-historical",
+            "runtime-a",
+            &repo_id,
+            &issue_ref,
+            WorkflowIndexStatus::Completed,
+            Freshness::Fresh.as_str(),
+        );
+        insert_row(
+            &fixture.database,
+            "workflow-active",
+            "runtime-b",
+            &repo_id,
+            &issue_ref,
+            WorkflowIndexStatus::Running,
+            Freshness::Stale.as_str(),
+        );
+
+        let row = fixture
+            .reader
+            .find_active_workflow_for_issue(&repo_id, &issue_ref)
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.workflow_id, "workflow-active");
+        assert_eq!(row.status, WorkflowIndexStatus::Running);
+        // Freshness does not participate in active membership.
+        assert_eq!(row.freshness, Freshness::Stale);
+    }
+
+    #[test]
+    fn scoped_list_is_filtered_deterministic_and_bounded() {
+        let fixture = fixture();
+        let repo_id = repo();
+        for number in 1..=(ACTIVE_WORKFLOW_LIST_LIMIT + 5) {
+            let issue_ref = issue(&repo_id, number);
+            insert_row(
+                &fixture.database,
+                &format!("workflow-{number:03}"),
+                "runtime-a",
+                &repo_id,
+                &issue_ref,
+                WorkflowIndexStatus::Running,
+                Freshness::Fresh.as_str(),
+            );
+        }
+        let other_runtime_issue = issue(&repo_id, 500);
+        insert_row(
+            &fixture.database,
+            "workflow-other-runtime",
+            "runtime-b",
+            &repo_id,
+            &other_runtime_issue,
+            WorkflowIndexStatus::Starting,
+            Freshness::Unknown.as_str(),
+        );
+        let starting = fixture
+            .reader
+            .find_active_workflow_for_issue(&repo_id, &other_runtime_issue)
+            .unwrap()
+            .unwrap();
+        assert_eq!(starting.status, WorkflowIndexStatus::Starting);
+        let other_repo = RepoId::new("github.com", "Alive24", "other");
+        let other_repo_issue = issue(&other_repo, 1);
+        insert_row(
+            &fixture.database,
+            "workflow-other-repo",
+            "runtime-a",
+            &other_repo,
+            &other_repo_issue,
+            WorkflowIndexStatus::Running,
+            Freshness::Fresh.as_str(),
+        );
+        let historical_issue = issue(&repo_id, 999);
+        insert_row(
+            &fixture.database,
+            "workflow-historical",
+            "runtime-a",
+            &repo_id,
+            &historical_issue,
+            WorkflowIndexStatus::Failed,
+            Freshness::Fresh.as_str(),
+        );
+
+        let runtime_id = WorkspaceRuntimeId::new("runtime-a");
+        let first = fixture
+            .reader
+            .list_active_workflows_for_scope(&runtime_id, &repo_id)
+            .unwrap();
+        let second = fixture
+            .reader
+            .list_active_workflows_for_scope(&runtime_id, &repo_id)
+            .unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), ACTIVE_WORKFLOW_LIST_LIMIT as usize);
+        assert!(first.iter().all(|row| {
+            row.workspace_runtime_id == "runtime-a"
+                && row.repo_id == repo_id.database_key()
+                && row.status.is_active()
+        }));
+        let ordering = first
+            .iter()
+            .map(|row| (row.issue_ref.clone(), row.workflow_id.clone()))
+            .collect::<Vec<_>>();
+        let mut sorted = ordering.clone();
+        sorted.sort();
+        assert_eq!(ordering, sorted);
+        assert!(!first
+            .iter()
+            .any(|row| row.workflow_id == "workflow-other-runtime"
+                || row.workflow_id == "workflow-other-repo"
+                || row.workflow_id == "workflow-historical"));
+    }
+
+    #[test]
+    fn missing_and_uninitialized_paths_are_not_empty_results_or_mutated() {
+        let temporary = tempfile::tempdir().unwrap();
+        let missing = database_at(&temporary, "missing/parent/state.db");
+        let missing_reader = LocalStateReader::new(missing.clone());
+        let parent = missing.path().parent().unwrap();
+
+        assert_eq!(
+            missing_reader
+                .list_active_workflows_for_scope(&WorkspaceRuntimeId::new("runtime-a"), &repo(),),
+            Err(LocalStateReaderError::NotReady(
+                LocalStateHealthDiagnostic::MissingPath {
+                    path: missing.path().to_path_buf(),
+                },
+            ))
+        );
+        assert!(!parent.exists());
+
+        let uninitialized = database_at(&temporary, "uninitialized.db");
+        Connection::open(uninitialized.path()).unwrap();
+        let before = fs::read(uninitialized.path()).unwrap();
+        let reader = LocalStateReader::new(uninitialized.clone());
+        assert_eq!(
+            reader.list_active_workflows_for_scope(&WorkspaceRuntimeId::new("runtime-a"), &repo(),),
+            Err(LocalStateReaderError::NotReady(
+                LocalStateHealthDiagnostic::MigrationRequired {
+                    path: uninitialized.path().to_path_buf(),
+                    observed_schema_version: 0,
+                    supported_schema_version: 1,
+                },
+            ))
+        );
+        assert_eq!(fs::read(uninitialized.path()).unwrap(), before);
+        assert_eq!(schema_version(&uninitialized), 0);
+    }
+
+    #[test]
+    fn corrupt_future_and_unversioned_databases_are_typed_and_unchanged() {
+        let temporary = tempfile::tempdir().unwrap();
+        let corrupt = database_at(&temporary, "corrupt.db");
+        fs::write(corrupt.path(), b"not a sqlite database").unwrap();
+        let corrupt_before = fs::read(corrupt.path()).unwrap();
+        assert_eq!(
+            LocalStateReader::new(corrupt.clone())
+                .list_active_workflows_for_scope(&WorkspaceRuntimeId::new("runtime-a"), &repo(),),
+            Err(LocalStateReaderError::NotReady(
+                LocalStateHealthDiagnostic::CorruptDatabase {
+                    path: corrupt.path().to_path_buf(),
+                },
+            ))
+        );
+        assert_eq!(fs::read(corrupt.path()).unwrap(), corrupt_before);
+
+        let future = database_at(&temporary, "future.db");
+        future.initialize().unwrap();
+        Connection::open(future.path())
+            .unwrap()
+            .pragma_update(None, "user_version", 2)
+            .unwrap();
+        assert_eq!(
+            LocalStateReader::new(future.clone())
+                .list_active_workflows_for_scope(&WorkspaceRuntimeId::new("runtime-a"), &repo(),),
+            Err(LocalStateReaderError::NotReady(
+                LocalStateHealthDiagnostic::UnsupportedSchemaVersion {
+                    path: future.path().to_path_buf(),
+                    observed_schema_version: 2,
+                    supported_schema_version: 1,
+                },
+            ))
+        );
+        assert_eq!(schema_version(&future), 2);
+
+        let unversioned = database_at(&temporary, "unversioned.db");
+        Connection::open(unversioned.path())
+            .unwrap()
+            .execute("CREATE TABLE unexpected(value TEXT)", [])
+            .unwrap();
+        assert_eq!(
+            LocalStateReader::new(unversioned.clone())
+                .list_active_workflows_for_scope(&WorkspaceRuntimeId::new("runtime-a"), &repo(),),
+            Err(LocalStateReaderError::NotReady(
+                LocalStateHealthDiagnostic::UnversionedSchemaConflict {
+                    path: unversioned.path().to_path_buf(),
+                },
+            ))
+        );
+        assert_eq!(schema_version(&unversioned), 0);
+        let unexpected_count: u32 = Connection::open(unversioned.path())
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM unexpected", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(unexpected_count, 0);
+    }
+
+    #[test]
+    fn incomplete_schema_and_malformed_rows_are_typed_not_empty() {
+        let temporary = tempfile::tempdir().unwrap();
+        let incomplete = database_at(&temporary, "incomplete.db");
+        incomplete.initialize().unwrap();
+        Connection::open(incomplete.path())
+            .unwrap()
+            .execute("DROP TABLE workflow_index", [])
+            .unwrap();
+        assert_eq!(
+            LocalStateReader::new(incomplete.clone())
+                .list_active_workflows_for_scope(&WorkspaceRuntimeId::new("runtime-a"), &repo(),),
+            Err(LocalStateReaderError::NotReady(
+                LocalStateHealthDiagnostic::IncompleteCurrentSchema {
+                    path: incomplete.path().to_path_buf(),
+                    schema_version: 1,
+                    missing_tables: vec!["workflow_index".to_string()],
+                    missing_metadata_keys: vec![],
+                },
+            ))
+        );
+
+        let malformed = database_at(&temporary, "malformed-row.db");
+        malformed.initialize().unwrap();
+        let repo_id = repo();
+        let issue_ref = issue(&repo_id, 493);
+        insert_row(
+            &malformed,
+            "workflow-malformed",
+            "runtime-a",
+            &repo_id,
+            &issue_ref,
+            WorkflowIndexStatus::Running,
+            "not-a-freshness",
+        );
+        assert_eq!(
+            LocalStateReader::new(malformed.clone())
+                .find_active_workflow_for_issue(&repo_id, &issue_ref),
+            Err(LocalStateReaderError::ReadUnavailable {
+                path: malformed.path().to_path_buf(),
+                failure: LocalStateReadFailure::MalformedWorkflowIndex,
+            })
+        );
+        let stored_freshness: String = Connection::open(malformed.path())
+            .unwrap()
+            .query_row(
+                "SELECT freshness FROM workflow_index WHERE workflow_id = ?1",
+                ["workflow-malformed"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored_freshness, "not-a-freshness");
+    }
+
+    #[test]
+    fn lookup_rejects_a_repo_issue_scope_mismatch_before_opening_state() {
+        let temporary = tempfile::tempdir().unwrap();
+        let missing = database_at(&temporary, "missing.db");
+        let requested_repo = repo();
+        let other_repo = RepoId::new("github.com", "Alive24", "other");
+
+        assert_eq!(
+            LocalStateReader::new(missing.clone())
+                .find_active_workflow_for_issue(&requested_repo, &issue(&other_repo, 493),),
+            Err(LocalStateReaderError::IssueRepositoryMismatch)
+        );
+        assert!(!missing.path().exists());
+    }
+}

--- a/src/symphony/local_state/workflow_index.rs
+++ b/src/symphony/local_state/workflow_index.rs
@@ -1,0 +1,196 @@
+//! Shared typed representation of the v1 `workflow_index` storage contract.
+//!
+//! Projection and query code use the same row decoder so an active read cannot
+//! reinterpret lifecycle, freshness, or terminal values.
+
+use std::io;
+
+use rusqlite::types::Type;
+
+use super::{Freshness, WorkflowIndexStatus};
+
+/// A bounded terminal classification persisted in `workflow_index.terminal_outcome`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkflowTerminalOutcome {
+    /// The execution completed successfully.
+    Completed,
+    /// The execution failed.
+    Failed,
+    /// The execution was cancelled before normal completion.
+    Cancelled,
+    /// The execution was terminated by an operator or policy.
+    Terminated,
+    /// The execution timed out.
+    TimedOut,
+    /// A Describe-backed close was observed without a supported classification.
+    ClosedUnknown,
+}
+
+impl WorkflowTerminalOutcome {
+    /// Returns the stable v1 storage spelling of this outcome.
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Terminated => "terminated",
+            Self::TimedOut => "timed_out",
+            Self::ClosedUnknown => "closed_unknown",
+        }
+    }
+
+    fn from_storage(value: &str) -> Option<Self> {
+        match value {
+            "completed" => Some(Self::Completed),
+            "failed" => Some(Self::Failed),
+            "cancelled" => Some(Self::Cancelled),
+            "terminated" => Some(Self::Terminated),
+            "timed_out" => Some(Self::TimedOut),
+            "closed_unknown" => Some(Self::ClosedUnknown),
+            _ => None,
+        }
+    }
+}
+
+/// A row read from the committed v1 `workflow_index` schema.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkflowIndexRow {
+    /// Persisted Symphony semantic Workflow ID.
+    pub(crate) workflow_id: String,
+    /// Persisted Temporal Run ID when Describe evidence has supplied one.
+    pub(crate) run_id: Option<String>,
+    /// Persisted stable runtime scope.
+    pub(crate) workspace_runtime_id: String,
+    /// Persisted repository storage key.
+    pub(crate) repo_id: String,
+    /// Persisted tracker issue storage key.
+    pub(crate) issue_ref: String,
+    /// Persisted activation tracker state.
+    pub(crate) from_state: String,
+    /// Persisted requested orchestration target.
+    pub(crate) target_kind: String,
+    /// Persisted caller-supplied tracker context.
+    pub(crate) current_state: String,
+    /// Persisted bounded lifecycle sentinel.
+    pub(crate) active_step: String,
+    /// Persisted waiting sentinel, unused by this summary slice.
+    pub(crate) waiting_kind: Option<String>,
+    /// Persisted activation provenance reference.
+    pub(crate) source_ref: String,
+    /// Persisted activation tracker revision.
+    pub(crate) source_tracker_revision: String,
+    /// Persisted authoritative Temporal execution start time.
+    pub(crate) started_at: String,
+    /// Persisted progress time, unchanged by this summary slice.
+    pub(crate) last_progress_at: Option<String>,
+    /// Persisted local lifecycle classification.
+    pub(crate) status: WorkflowIndexStatus,
+    /// Persisted bounded close classification.
+    pub(crate) terminal_outcome: Option<WorkflowTerminalOutcome>,
+    /// Persisted optional operator-action provenance.
+    pub(crate) operator_action_ref: Option<String>,
+    /// Persisted material-projection freshness.
+    pub(crate) freshness: Freshness,
+    /// Persisted observation time for the last material projection.
+    pub(crate) updated_at: String,
+}
+
+pub(super) fn workflow_index_columns() -> [&'static str; 19] {
+    [
+        "workflow_id",
+        "run_id",
+        "workspace_runtime_id",
+        "repo_id",
+        "issue_ref",
+        "from_state",
+        "target_kind",
+        "current_state",
+        "active_step",
+        "waiting_kind",
+        "source_ref",
+        "source_tracker_revision",
+        "started_at",
+        "last_progress_at",
+        "status",
+        "terminal_outcome",
+        "operator_action_ref",
+        "freshness",
+        "updated_at",
+    ]
+}
+
+pub(super) fn workflow_index_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<WorkflowIndexRow> {
+    let status_value: String = row.get(14)?;
+    let terminal_outcome_value: Option<String> = row.get(15)?;
+    let freshness_value: String = row.get(17)?;
+
+    Ok(WorkflowIndexRow {
+        workflow_id: row.get(0)?,
+        run_id: row.get(1)?,
+        workspace_runtime_id: row.get(2)?,
+        repo_id: row.get(3)?,
+        issue_ref: row.get(4)?,
+        from_state: row.get(5)?,
+        target_kind: row.get(6)?,
+        current_state: row.get(7)?,
+        active_step: row.get(8)?,
+        waiting_kind: row.get(9)?,
+        source_ref: row.get(10)?,
+        source_tracker_revision: row.get(11)?,
+        started_at: row.get(12)?,
+        last_progress_at: row.get(13)?,
+        status: workflow_index_status_from_storage(&status_value)
+            .ok_or_else(|| unsupported_storage_value(14, "status", &status_value))?,
+        terminal_outcome: terminal_outcome_value
+            .as_deref()
+            .map(|value| {
+                WorkflowTerminalOutcome::from_storage(value)
+                    .ok_or_else(|| unsupported_storage_value(15, "terminal_outcome", value))
+            })
+            .transpose()?,
+        operator_action_ref: row.get(16)?,
+        freshness: freshness_from_storage(&freshness_value)
+            .ok_or_else(|| unsupported_storage_value(17, "freshness", &freshness_value))?,
+        updated_at: row.get(18)?,
+    })
+}
+
+fn workflow_index_status_from_storage(value: &str) -> Option<WorkflowIndexStatus> {
+    match value {
+        "starting" => Some(WorkflowIndexStatus::Starting),
+        "running" => Some(WorkflowIndexStatus::Running),
+        "completed" => Some(WorkflowIndexStatus::Completed),
+        "failed" => Some(WorkflowIndexStatus::Failed),
+        "start_failed" => Some(WorkflowIndexStatus::StartFailed),
+        "stale_start" => Some(WorkflowIndexStatus::StaleStart),
+        "stale_missing" => Some(WorkflowIndexStatus::StaleMissing),
+        "closed_unknown" => Some(WorkflowIndexStatus::ClosedUnknown),
+        _ => None,
+    }
+}
+
+fn freshness_from_storage(value: &str) -> Option<Freshness> {
+    match value {
+        "fresh" => Some(Freshness::Fresh),
+        "stale" => Some(Freshness::Stale),
+        "refreshing" => Some(Freshness::Refreshing),
+        "failed" => Some(Freshness::Failed),
+        "unknown" => Some(Freshness::Unknown),
+        _ => None,
+    }
+}
+
+pub(super) fn unsupported_storage_value(
+    index: usize,
+    column: &str,
+    value: &str,
+) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        index,
+        Type::Text,
+        Box::new(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported workflow_index {column} value {value:?}"),
+        )),
+    )
+}


### PR DESCRIPTION
## Summary
- Implements #493: T2607-02: read active workflow-index rows without lifecycle inference.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #493
