### PR TITLE
#502: T2607-03: start IssueWorkflow with Temporal-authoritative execution evidence

### DIFF
--- a/docs/milestones/2607-hardening/IMPLEMENTATION-BACKLOG.md
+++ b/docs/milestones/2607-hardening/IMPLEMENTATION-BACKLOG.md
@@ -110,8 +110,8 @@ Scope:
 
 - #501: pure activation classification, Coordinator-derived target kind,
   provenance validation, and exact episode-scoped Workflow ID construction;
-- #502 (`Todo`): optimistic Temporal start, native Run ID, immediate Describe,
-  and already-open execution handling;
+- #502: optimistic Temporal start, native Run ID, immediate Describe, and typed
+  duplicate execution handling;
 - #503 (`Backlog`): older start/Run-ID seed now overlapped by promoted #502; it
   is not a separate remaining implementation slice;
 - #504 (`Backlog`): Describe-backed targeted repair/reconciliation;

--- a/docs/milestones/2607-hardening/ISSUE-WORKFLOW.md
+++ b/docs/milestones/2607-hardening/ISSUE-WORKFLOW.md
@@ -34,12 +34,15 @@ Recommended input:
 IssueWorkflowInput {
   workflow_id
   repo_id
+  tracker_backend
   issue_ref
   from_tracker_state
   target_kind
+  source_kind
   source_ref
   source_tracker_revision
   started_at
+  audit_reason
   operator_action_ref?
   capacity_policy_ref?
 }
@@ -48,6 +51,13 @@ IssueWorkflowInput {
 The input tells the Workflow why this execution started and which tracker fact
 it observed. The Workflow should not infer its starting purpose by scanning
 tracker state again after start.
+
+`started_at` retains its durable wire name and records the pre-start activation
+episode timestamp in RFC 3339 UTC second precision. It is not Temporal's
+authoritative execution start time; Coordinator Describe observations call
+that separate value `temporal_started_at`. New fields use Serde defaults so
+histories containing the earlier input shape remain replay-compatible, while
+new Coordinator construction always populates them.
 
 ## Standard States
 

--- a/docs/milestones/2607-hardening/WORKFLOW-ACTIVATION.md
+++ b/docs/milestones/2607-hardening/WORKFLOW-ACTIVATION.md
@@ -190,6 +190,8 @@ Start uses `WorkflowIdReusePolicy::RejectDuplicate` and
 successful start response, terminates an existing execution, generates a
 replacement ID, or retries the start internally. An uncertain caller retry
 resubmits the exact same validated activation and Workflow ID.
+The Coordinator disables the SDK operation retry loop for both the start and
+immediate Describe calls so those cardinality limits include transport retries.
 
 The result keeps two facts independent:
 

--- a/docs/milestones/2607-hardening/WORKFLOW-ACTIVATION.md
+++ b/docs/milestones/2607-hardening/WORKFLOW-ACTIVATION.md
@@ -178,12 +178,37 @@ the tracker.
 Coordinator start is optimistic with Temporal as the authority:
 
 ```text
-read tracker executable state
-  -> derive workflow_id
-  -> start Temporal Workflow
-  -> Describe the current Temporal execution
-  -> project the Describe-backed Open observation into workflow_index
+consume one validated executable activation
+  -> serialize its durable IssueWorkflowInput
+  -> start Temporal Workflow once with the exact workflow_id
+  -> Describe once by workflow_id and known run_id when available
+  -> return independent start evidence and current execution observation
 ```
+
+Start uses `WorkflowIdReusePolicy::RejectDuplicate` and
+`WorkflowIdConflictPolicy::Fail`. It never uses an existing execution as a
+successful start response, terminates an existing execution, generates a
+replacement ID, or retries the start internally. An uncertain caller retry
+resubmits the exact same validated activation and Workflow ID.
+
+The result keeps two facts independent:
+
+```text
+start evidence =
+  Accepted { run_id }
+  | AlreadyStarted { run_id? }
+  | Indeterminate
+
+execution observation =
+  Open { workflow_id, run_id, temporal_started_at, status }
+  | Closed { workflow_id, run_id, temporal_started_at, status }
+  | DescribeRequired
+```
+
+This separation is required because an accepted no-op Workflow can close before
+Describe, while an indeterminate start can later converge to an Open or Closed
+current observation. Not-found or unavailable Describe evidence after an
+uncertain start never means "not started."
 
 The start response can prove that Temporal accepted a request and may carry a
 Run ID, but it cannot supply the authoritative execution `started_at` required
@@ -201,10 +226,20 @@ Start conflicts:
   Temporal evidence, and project/reconcile only that evidence; do not use it to
   reserve, reject, or retry a start;
 - Temporal open Workflow already exists: bind to the existing execution and
-  project its current Describe observation;
-- Temporal closed Workflow with the same `workflow_id`: create a new activation
-  episode with a new explicit timestamp or source identity; never invent a
+  return its current Describe observation; #504 owns local projection;
+- Temporal closed Workflow with the same `workflow_id`: reject the exact retry.
+  This start slice cannot create a new activation. A future discovery/caller
+  boundary may separately validate a genuinely new executable condition with a
+  new explicit episode timestamp or source identity; it must never invent a
   retry-time suffix.
+
+`IssueWorkflowInput.started_at` retains its existing wire name but means the
+pre-start activation episode timestamp. Temporal's authoritative execution
+start time is returned only as `temporal_started_at` from Describe.
+
+TODO(T2607-03): assign Temporal Search Attributes/Visibility indexing after
+#504/#505 establish the repair/read-model and real caller boundaries. This
+start slice does not register, write, or query Search Attributes.
 
 ## Repair Contract
 

--- a/docs/milestones/2607-hardening/implementation/T2607-03-workflow-coordinator.md
+++ b/docs/milestones/2607-hardening/implementation/T2607-03-workflow-coordinator.md
@@ -39,10 +39,10 @@ is the newer Temporal-authoritative contract: start is optimistic, current
 Describe evidence is projected after start, and SQLite conflicts are
 diagnostics rather than reservations or execution authority.
 
-Deferred ownership is explicit:
+Slice ownership is explicit:
 
-- #502 (`Todo`) owns Temporal start, native Run ID, immediate Describe, and
-  already-open execution handling;
+- #502 implements Temporal start, native Run ID, immediate Describe, and typed
+  duplicate execution handling without SQLite authority;
 - #503 (`Backlog`) is an older start/Run-ID seed now overlapped by promoted
   #502, not another remaining implementation slice;
 - #504 (`Backlog`) owns Describe-backed targeted repair/reconciliation;
@@ -210,22 +210,26 @@ issue:github.com/Alive24/shea-symphony:123:pulse:merging-to-merge:20260708T15001
 
 ## Start Flow
 
-TODO #502: implement the start contract from
-`WORKFLOW-ACTIVATION.md`. The future flow is:
+#502 implements the start contract from `WORKFLOW-ACTIVATION.md`:
 
 ```text
 receive already-observed executable activation facts
-  -> apply capacity policy (unowned T2607-03 gap)
-  -> start Temporal with the existing workflow_id
-  -> Describe the current execution
-  -> project only Describe-backed lifecycle evidence
+  -> build backward-compatible durable IssueWorkflowInput
+  -> start Temporal once with the exact existing workflow_id
+  -> Describe once by workflow_id and known run_id when available
+  -> return independent start evidence and execution observation
 ```
 
-Do not insert a SQLite `starting` reservation before Temporal start. If a
-Workflow with the same retry-stable ID is already open, establish that through
-Temporal and bind/project the described execution. A local active-row conflict
-is diagnostic input for #504 reconciliation, not authority to reject or
-authorize a start.
+Start sets `WorkflowIdReusePolicy::RejectDuplicate` and
+`WorkflowIdConflictPolicy::Fail`. Typed SDK `AlreadyStarted` evidence remains
+distinct from an indeterminate start operation. Accepted starts retain the real
+non-empty SDK handle Run ID. Start and Describe are orthogonal so a newly
+accepted Workflow that closes before Describe is still represented correctly.
+
+Do not insert a SQLite `starting` reservation before Temporal start. A local
+active-row conflict is diagnostic input for #504 reconciliation, not authority
+to reject or authorize a start. Capacity policy remains an unowned prerequisite
+for the future caller and is not implicitly implemented inside #502.
 
 ## Discovery Triggers
 
@@ -254,12 +258,20 @@ Repair does not move tracker business state directly.
 
 ## Temporal Interaction
 
-#502 and #504 use Temporal client APIs for start and current execution
-Describe. The pure #501 activation contract performs no Temporal I/O.
+#502 uses Temporal client APIs for one start and one current execution
+Describe. The pure #501 activation contract still performs no Temporal I/O.
 
 Start attributes should carry the validated repository/issue identity, observed
 tracker state/revision, Coordinator-derived target kind, source kind/reference,
 episode time, and audit reason. `IssueWorkflow` runs on `symphony-core`.
+
+`IssueWorkflowInput.started_at` is the RFC 3339 UTC-second activation episode
+time, not Temporal's authoritative start time. Describe returns the latter as
+`temporal_started_at`.
+
+TODO(T2607-03): Search Attributes/Visibility indexing is not designed or
+implemented by #502. Assign it only after #504/#505 establish repair/read-model
+and caller boundaries.
 
 ## SQLite Interaction
 
@@ -272,8 +284,10 @@ The pure #501 activation contract performs no SQLite reads or writes.
 ## Tracker Interaction
 
 #501 accepts an already-observed tracker snapshot and performs no tracker I/O.
-#502/#504/#505 may read at their durable boundaries, but Coordinator must not
-write tracker state. Tracker writes belong to `TrackerTransitionActivity`.
+#502 also performs no tracker I/O because it consumes the validated #501
+activation. #504/#505 may read at their assigned durable boundaries, but
+Coordinator must not write tracker state. Tracker writes belong to
+`TrackerTransitionActivity`.
 
 ## App And Operator Interaction
 
@@ -284,8 +298,11 @@ and adds no App, Tauri, Svelte, or CLI surface.
 ## Error Handling
 
 #501 uses typed validation errors for invalid issue/source/revision/audit/time
-input and Workflow ID overflow. #502, #504, #505, and the unowned capacity
-slice own typed I/O, conflict, capacity, and entrypoint outcomes without
+input and Workflow ID overflow. #502 distinguishes pre-dispatch
+input/configuration/payload failures, definitive server rejection,
+unavailable/indeterminate side-effect outcomes, and malformed/contradictory
+protocol evidence with Connect/Start/Describe attribution. #504, #505, and the
+unowned capacity slice own repair, entrypoint, and admission outcomes without
 changing this identity policy.
 
 ## #501 Acceptance Checks
@@ -315,3 +332,18 @@ changing this identity policy.
 - deferred #502/#504/#505 and unowned capacity work is explicit, #503 is
   recognized as an overlapped Backlog seed, and the older SQLite reservation
   model is not accidentally implemented.
+
+## #502 Acceptance Checks
+
+- Only `CoordinatorExecutableActivation` can enter the start boundary.
+- Durable input maps the exact Workflow ID, issue identity, observed state and
+  revision, derived target, source provenance, episode time, and audit reason.
+- Legacy durable input JSON without `tracker_backend`, `source_kind`, or
+  `audit_reason` still deserializes through Serde defaults.
+- Each invocation performs at most one start and one immediate Describe.
+- Accepted starts return the real SDK Run ID; duplicate starts remain typed.
+- Uncertain starts never become "not started" and may converge through Describe.
+- Open, Closed, and DescribeRequired observations remain independent of start
+  evidence.
+- No tracker, SQLite, capacity, Search Attribute, App, or Workflow business
+  state path is introduced.

--- a/docs/milestones/2607-hardening/implementation/T2607-03-workflow-coordinator.md
+++ b/docs/milestones/2607-hardening/implementation/T2607-03-workflow-coordinator.md
@@ -225,6 +225,8 @@ Start sets `WorkflowIdReusePolicy::RejectDuplicate` and
 distinct from an indeterminate start operation. Accepted starts retain the real
 non-empty SDK handle Run ID. Start and Describe are orthogonal so a newly
 accepted Workflow that closes before Describe is still represented correctly.
+The Coordinator connection disables the SDK operation retry loop; retries occur
+only when a caller deliberately resubmits the exact activation.
 
 Do not insert a SQLite `starting` reservation before Temporal start. A local
 active-row conflict is diagnostic input for #504 reconciliation, not authority

--- a/src/symphony/client.rs
+++ b/src/symphony/client.rs
@@ -8,15 +8,28 @@
 use std::str::FromStr;
 
 use temporalio_client::{
-    Client, ClientOptions, Connection, ConnectionOptions, WorkflowGetResultOptions,
-    WorkflowQueryOptions, WorkflowStartOptions,
+    errors::{ClientConnectError, WorkflowInteractionError, WorkflowStartError},
+    Client, ClientOptions, Connection, ConnectionOptions, WorkflowDescribeOptions,
+    WorkflowExecutionInfo, WorkflowGetResultOptions, WorkflowHandle, WorkflowQueryOptions,
+    WorkflowStartOptions,
+};
+use temporalio_common::protos::proto_ts_to_system_time;
+use temporalio_common::protos::temporal::api::enums::v1::{
+    WorkflowExecutionStatus, WorkflowIdConflictPolicy, WorkflowIdReusePolicy,
 };
 use temporalio_sdk_core::Url;
 use thiserror::Error;
+use time::{OffsetDateTime, UtcOffset};
 
 use crate::config::TemporalConfig;
+use crate::symphony::coordinator::start::{
+    CoordinatorAdapterStart, CoordinatorDescribeEvidence, CoordinatorFailureKind,
+    CoordinatorSdkErrorVariant, CoordinatorStartFailure, CoordinatorTemporalAdapter,
+    CoordinatorTemporalPhase, CoordinatorTemporalStatus,
+};
 use crate::symphony::dto::{IssueWorkflowInput, IssueWorkflowQueryResult, IssueWorkflowState};
 use crate::symphony::workflows::IssueWorkflow;
+use crate::symphony::WorkflowId;
 
 #[derive(Debug, Clone)]
 /// High-level client for Symphony's local Temporal namespace.
@@ -35,9 +48,10 @@ pub struct StartedIssueWorkflow {
     pub workflow_id: String,
     /// Temporal Run ID when the SDK start response exposes one.
     ///
-    /// The 2607 skeleton currently returns `None`; callers must use
-    /// [`workflow_id`](Self::workflow_id) as the durable lookup identity rather
-    /// than inventing a local Run ID.
+    /// A successful accepted start always returns `Some` with the real,
+    /// non-empty SDK handle Run ID. The optional wire shape is retained for
+    /// compatibility with existing public callers; Symphony never fabricates a
+    /// fallback Run ID.
     pub run_id: Option<String>,
 }
 
@@ -151,7 +165,7 @@ impl SymphonyTemporalClient {
     ) -> Result<StartedIssueWorkflow, TemporalRuntimeError> {
         let client = self.connect().await?;
         let workflow_id = input.workflow_id.clone();
-        client
+        let handle = client
             .start_workflow(
                 IssueWorkflow::run,
                 input,
@@ -159,6 +173,8 @@ impl SymphonyTemporalClient {
                     self.config.task_queues.core.as_str(),
                     workflow_id.as_str(),
                 )
+                .id_reuse_policy(WorkflowIdReusePolicy::RejectDuplicate)
+                .id_conflict_policy(WorkflowIdConflictPolicy::Fail)
                 .build(),
             )
             .await
@@ -166,10 +182,18 @@ impl SymphonyTemporalClient {
                 workflow_id: workflow_id.clone(),
                 source_error: error.to_string(),
             })?;
+        let run_id = handle
+            .run_id()
+            .filter(|run_id| !run_id.is_empty())
+            .map(str::to_owned)
+            .ok_or_else(|| TemporalRuntimeError::WorkflowOperation {
+                workflow_id: workflow_id.clone(),
+                source_error: "SDK accepted start without a non-empty Run ID".to_string(),
+            })?;
 
         Ok(StartedIssueWorkflow {
             workflow_id,
-            run_id: None,
+            run_id: Some(run_id),
         })
     }
 
@@ -217,6 +241,298 @@ impl SymphonyTemporalClient {
                 workflow_id: workflow_id.to_string(),
                 source_error: error.to_string(),
             })
+    }
+}
+
+impl CoordinatorTemporalAdapter for SymphonyTemporalClient {
+    async fn start_issue_workflow(
+        &self,
+        input: IssueWorkflowInput,
+    ) -> Result<CoordinatorAdapterStart, CoordinatorStartFailure> {
+        let workflow_id = WorkflowId::new(input.workflow_id.clone());
+        let client = self
+            .connect_for_coordinator(&workflow_id, None, CoordinatorTemporalPhase::Connect)
+            .await?;
+
+        // Reject both closed-ID reuse and running-ID conflict. Retrying an
+        // uncertain caller request must reuse this exact activation ID.
+        match client
+            .start_workflow(
+                IssueWorkflow::run,
+                input,
+                WorkflowStartOptions::new(
+                    self.config.task_queues.core.as_str(),
+                    workflow_id.as_str(),
+                )
+                .id_reuse_policy(WorkflowIdReusePolicy::RejectDuplicate)
+                .id_conflict_policy(WorkflowIdConflictPolicy::Fail)
+                // TODO(T2607-03): Temporal Search Attributes/Visibility
+                // indexing remains undesigned until #504/#505 establish
+                // repair/read-model and real caller boundaries.
+                .build(),
+            )
+            .await
+        {
+            Ok(handle) => Ok(CoordinatorAdapterStart::Accepted {
+                run_id: handle.run_id().unwrap_or_default().to_owned(),
+            }),
+            Err(WorkflowStartError::AlreadyStarted { run_id, source }) => {
+                Ok(typed_already_started(run_id, source.code()))
+            }
+            Err(WorkflowStartError::PayloadConversion(_)) => Err(CoordinatorStartFailure::new(
+                CoordinatorTemporalPhase::Start,
+                CoordinatorFailureKind::InputConfigurationPayload,
+                workflow_id,
+                None,
+                CoordinatorSdkErrorVariant::PayloadConversion,
+                None,
+            )),
+            Err(WorkflowStartError::Rpc(status)) => {
+                let code = status.code();
+                let failure = CoordinatorStartFailure::new(
+                    CoordinatorTemporalPhase::Start,
+                    if start_rpc_is_indeterminate(code) {
+                        CoordinatorFailureKind::UnavailableOrIndeterminate
+                    } else if code == temporalio_client::tonic::Code::AlreadyExists {
+                        CoordinatorFailureKind::MalformedProtocolEvidence
+                    } else {
+                        CoordinatorFailureKind::DefinitiveServerRejection
+                    },
+                    workflow_id,
+                    None,
+                    CoordinatorSdkErrorVariant::Rpc,
+                    Some(code),
+                );
+                if start_rpc_is_indeterminate(code) {
+                    Ok(CoordinatorAdapterStart::Indeterminate(failure))
+                } else {
+                    Err(failure)
+                }
+            }
+            Err(_) => Ok(CoordinatorAdapterStart::Indeterminate(
+                CoordinatorStartFailure::new(
+                    CoordinatorTemporalPhase::Start,
+                    CoordinatorFailureKind::UnavailableOrIndeterminate,
+                    workflow_id,
+                    None,
+                    CoordinatorSdkErrorVariant::Other,
+                    None,
+                ),
+            )),
+        }
+    }
+
+    async fn describe_issue_workflow(
+        &self,
+        workflow_id: &WorkflowId,
+        run_id: Option<&str>,
+    ) -> Result<CoordinatorDescribeEvidence, CoordinatorStartFailure> {
+        let workflow_id = workflow_id.clone();
+        let run_id = run_id.map(str::to_owned);
+        let client = self
+            .connect_for_coordinator(
+                &workflow_id,
+                run_id.clone(),
+                CoordinatorTemporalPhase::Describe,
+            )
+            .await?;
+        let handle = WorkflowHandle::<_, IssueWorkflow>::new(
+            client,
+            WorkflowExecutionInfo {
+                namespace: self.config.namespace.clone(),
+                workflow_id: workflow_id.as_str().to_owned(),
+                // A known Run ID pins Describe to the accepted or duplicate
+                // execution; otherwise Temporal resolves the current run.
+                run_id: run_id.clone(),
+                first_execution_run_id: None,
+            },
+        );
+
+        let description = handle
+            .describe(WorkflowDescribeOptions::default())
+            .await
+            .map_err(|error| describe_failure(&workflow_id, run_id.clone(), error))?;
+
+        // SDK convenience accessors assume required protobuf fields exist.
+        // Inspect raw evidence so a malformed response becomes a typed
+        // Coordinator result instead of panicking the caller.
+        let Some(info) = description.raw().workflow_execution_info.as_ref() else {
+            return Ok(CoordinatorDescribeEvidence {
+                workflow_id: String::new(),
+                run_id: String::new(),
+                temporal_started_at: None,
+                status: None,
+            });
+        };
+        let execution = info.execution.as_ref();
+        Ok(CoordinatorDescribeEvidence {
+            workflow_id: execution
+                .map(|value| value.workflow_id.clone())
+                .unwrap_or_default(),
+            run_id: execution
+                .map(|value| value.run_id.clone())
+                .unwrap_or_default(),
+            temporal_started_at: info
+                .start_time
+                .as_ref()
+                .and_then(proto_ts_to_system_time)
+                .map(OffsetDateTime::from)
+                .map(|value| value.to_offset(UtcOffset::UTC)),
+            status: WorkflowExecutionStatus::try_from(info.status)
+                .ok()
+                .and_then(map_temporal_status),
+        })
+    }
+}
+
+impl SymphonyTemporalClient {
+    async fn connect_for_coordinator(
+        &self,
+        workflow_id: &WorkflowId,
+        known_run_id: Option<String>,
+        phase: CoordinatorTemporalPhase,
+    ) -> Result<Client, CoordinatorStartFailure> {
+        let address = endpoint_url(&self.config.address).map_err(|_| {
+            CoordinatorStartFailure::new(
+                phase,
+                CoordinatorFailureKind::InputConfigurationPayload,
+                workflow_id.clone(),
+                known_run_id.clone(),
+                CoordinatorSdkErrorVariant::InvalidConfiguration,
+                None,
+            )
+        })?;
+        let connection_options = ConnectionOptions::new(address).build();
+        let connection = Connection::connect(connection_options)
+            .await
+            .map_err(|error| connect_failure(workflow_id, known_run_id.clone(), phase, error))?;
+
+        Client::new(
+            connection,
+            ClientOptions::new(self.config.namespace.as_str()).build(),
+        )
+        .map_err(|_| {
+            CoordinatorStartFailure::new(
+                phase,
+                CoordinatorFailureKind::InputConfigurationPayload,
+                workflow_id.clone(),
+                known_run_id,
+                CoordinatorSdkErrorVariant::ClientConstruction,
+                None,
+            )
+        })
+    }
+}
+
+fn connect_failure(
+    workflow_id: &WorkflowId,
+    known_run_id: Option<String>,
+    phase: CoordinatorTemporalPhase,
+    error: ClientConnectError,
+) -> CoordinatorStartFailure {
+    let (kind, grpc_code) = match &error {
+        ClientConnectError::InvalidUri(_)
+        | ClientConnectError::InvalidHeaders(_)
+        | ClientConnectError::InvalidConfig(_) => {
+            (CoordinatorFailureKind::InputConfigurationPayload, None)
+        }
+        ClientConnectError::SystemInfoCallError(status) => (
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            Some(status.code()),
+        ),
+        _ => (CoordinatorFailureKind::UnavailableOrIndeterminate, None),
+    };
+    CoordinatorStartFailure::new(
+        phase,
+        kind,
+        workflow_id.clone(),
+        known_run_id,
+        CoordinatorSdkErrorVariant::ClientConnect,
+        grpc_code,
+    )
+}
+
+fn describe_failure(
+    workflow_id: &WorkflowId,
+    run_id: Option<String>,
+    error: WorkflowInteractionError,
+) -> CoordinatorStartFailure {
+    let (kind, variant, grpc_code) = match error {
+        WorkflowInteractionError::NotFound(status) => (
+            // Not-found after an uncertain start cannot prove that no start
+            // occurred; retain it as an unresolved Describe observation.
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            CoordinatorSdkErrorVariant::NotFound,
+            Some(status.code()),
+        ),
+        WorkflowInteractionError::PayloadConversion(_) => (
+            CoordinatorFailureKind::MalformedProtocolEvidence,
+            CoordinatorSdkErrorVariant::PayloadConversion,
+            None,
+        ),
+        WorkflowInteractionError::Rpc(status) => (
+            if start_rpc_is_indeterminate(status.code()) {
+                CoordinatorFailureKind::UnavailableOrIndeterminate
+            } else {
+                CoordinatorFailureKind::DefinitiveServerRejection
+            },
+            CoordinatorSdkErrorVariant::Rpc,
+            Some(status.code()),
+        ),
+        WorkflowInteractionError::Other(_) => (
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            CoordinatorSdkErrorVariant::Other,
+            None,
+        ),
+        _ => (
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            CoordinatorSdkErrorVariant::Other,
+            None,
+        ),
+    };
+    CoordinatorStartFailure::new(
+        CoordinatorTemporalPhase::Describe,
+        kind,
+        workflow_id.clone(),
+        run_id,
+        variant,
+        grpc_code,
+    )
+}
+
+fn typed_already_started(
+    run_id: Option<String>,
+    grpc_code: temporalio_client::tonic::Code,
+) -> CoordinatorAdapterStart {
+    CoordinatorAdapterStart::AlreadyStarted { run_id, grpc_code }
+}
+
+fn start_rpc_is_indeterminate(code: temporalio_client::tonic::Code) -> bool {
+    use temporalio_client::tonic::Code;
+
+    matches!(
+        code,
+        Code::Cancelled
+            | Code::Unknown
+            | Code::DeadlineExceeded
+            | Code::Aborted
+            | Code::Internal
+            | Code::Unavailable
+            | Code::DataLoss
+    )
+}
+
+fn map_temporal_status(status: WorkflowExecutionStatus) -> Option<CoordinatorTemporalStatus> {
+    match status {
+        WorkflowExecutionStatus::Unspecified => None,
+        WorkflowExecutionStatus::Running => Some(CoordinatorTemporalStatus::Running),
+        WorkflowExecutionStatus::Completed => Some(CoordinatorTemporalStatus::Completed),
+        WorkflowExecutionStatus::Failed => Some(CoordinatorTemporalStatus::Failed),
+        WorkflowExecutionStatus::Canceled => Some(CoordinatorTemporalStatus::Canceled),
+        WorkflowExecutionStatus::Terminated => Some(CoordinatorTemporalStatus::Terminated),
+        WorkflowExecutionStatus::ContinuedAsNew => Some(CoordinatorTemporalStatus::ContinuedAsNew),
+        WorkflowExecutionStatus::TimedOut => Some(CoordinatorTemporalStatus::TimedOut),
+        WorkflowExecutionStatus::Paused => Some(CoordinatorTemporalStatus::Paused),
     }
 }
 
@@ -272,5 +588,49 @@ mod tests {
         let error = result.err().unwrap();
         assert!(matches!(error, TemporalRuntimeError::Unavailable { .. }));
         assert!(error.to_string().contains("temporal-noop-smoke"));
+    }
+
+    #[tokio::test]
+    async fn coordinator_describe_connect_failure_retains_phase_identity_and_known_run() {
+        let client = SymphonyTemporalClient::new(config("http://["));
+        let workflow_id = WorkflowId::new("issue:502");
+
+        let result = client
+            .connect_for_coordinator(
+                &workflow_id,
+                Some("run-known".to_string()),
+                CoordinatorTemporalPhase::Describe,
+            )
+            .await;
+        let Err(failure) = result else {
+            panic!("invalid endpoint unexpectedly connected");
+        };
+
+        assert_eq!(failure.phase(), CoordinatorTemporalPhase::Describe);
+        assert_eq!(
+            failure.kind(),
+            CoordinatorFailureKind::InputConfigurationPayload
+        );
+        assert_eq!(failure.workflow_id(), &workflow_id);
+        assert_eq!(failure.known_run_id(), Some("run-known"));
+        assert_eq!(
+            failure.sdk_error_variant(),
+            CoordinatorSdkErrorVariant::InvalidConfiguration
+        );
+        assert_eq!(failure.grpc_code(), None);
+    }
+
+    #[test]
+    fn typed_duplicate_mapping_preserves_run_id_and_grpc_code() {
+        assert_eq!(
+            typed_already_started(
+                Some("run-existing".to_string()),
+                temporalio_client::tonic::Code::AlreadyExists,
+            ),
+            CoordinatorAdapterStart::AlreadyStarted {
+                run_id: Some("run-existing".to_string()),
+                grpc_code: temporalio_client::tonic::Code::AlreadyExists,
+            }
+        );
     }
 }

--- a/src/symphony/client.rs
+++ b/src/symphony/client.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 use temporalio_client::{
     errors::{ClientConnectError, WorkflowInteractionError, WorkflowStartError},
-    Client, ClientOptions, Connection, ConnectionOptions, WorkflowDescribeOptions,
+    Client, ClientOptions, Connection, ConnectionOptions, RetryOptions, WorkflowDescribeOptions,
     WorkflowExecutionInfo, WorkflowGetResultOptions, WorkflowHandle, WorkflowQueryOptions,
     WorkflowStartOptions,
 };
@@ -128,8 +128,23 @@ impl SymphonyTemporalClient {
     /// crate-visible so external consumers use the typed operations instead of
     /// bypassing Symphony's namespace and error semantics.
     pub(crate) async fn connect(&self) -> Result<Client, TemporalRuntimeError> {
+        self.connect_with_retry_options(RetryOptions::default())
+            .await
+    }
+
+    async fn connect_without_operation_retries(&self) -> Result<Client, TemporalRuntimeError> {
+        self.connect_with_retry_options(single_attempt_retry_options())
+            .await
+    }
+
+    async fn connect_with_retry_options(
+        &self,
+        retry_options: RetryOptions,
+    ) -> Result<Client, TemporalRuntimeError> {
         let address = endpoint_url(&self.config.address)?;
-        let connection_options = ConnectionOptions::new(address).build();
+        let connection_options = ConnectionOptions::new(address)
+            .retry_options(retry_options)
+            .build();
         let connection = Connection::connect(connection_options)
             .await
             .map_err(|error| TemporalRuntimeError::Unavailable {
@@ -163,7 +178,9 @@ impl SymphonyTemporalClient {
         &self,
         input: IssueWorkflowInput,
     ) -> Result<StartedIssueWorkflow, TemporalRuntimeError> {
-        let client = self.connect().await?;
+        // Start uncertainty is recovered through stable identity, not hidden
+        // transport retries inside this single caller invocation.
+        let client = self.connect_without_operation_retries().await?;
         let workflow_id = input.workflow_id.clone();
         let handle = client
             .start_workflow(
@@ -402,7 +419,11 @@ impl SymphonyTemporalClient {
                 None,
             )
         })?;
-        let connection_options = ConnectionOptions::new(address).build();
+        // Coordinator owns uncertain outcomes explicitly; hidden SDK retries
+        // would violate the one-start/one-Describe invocation contract.
+        let connection_options = ConnectionOptions::new(address)
+            .retry_options(single_attempt_retry_options())
+            .build();
         let connection = Connection::connect(connection_options)
             .await
             .map_err(|error| connect_failure(workflow_id, known_run_id.clone(), phase, error))?;
@@ -536,6 +557,10 @@ fn map_temporal_status(status: WorkflowExecutionStatus) -> Option<CoordinatorTem
     }
 }
 
+fn single_attempt_retry_options() -> RetryOptions {
+    RetryOptions::no_retries()
+}
+
 fn endpoint_url(address: &str) -> Result<Url, TemporalRuntimeError> {
     // Workflow config uses operator-friendly local addresses by default; the
     // SDK expects a URL, so normalize missing schemes at this boundary.
@@ -577,6 +602,14 @@ mod tests {
         let url = endpoint_url("localhost:7233").unwrap();
 
         assert_eq!(url.as_str(), "http://localhost:7233/");
+    }
+
+    #[test]
+    fn coordinator_side_effect_client_disables_sdk_operation_retries() {
+        let options = single_attempt_retry_options();
+
+        assert_eq!(options.max_retries, 1);
+        assert_eq!(options.max_elapsed_time, None);
     }
 
     #[tokio::test]

--- a/src/symphony/coordinator/mod.rs
+++ b/src/symphony/coordinator/mod.rs
@@ -1,10 +1,9 @@
-//! Pure activation and identity policy for Coordinator workflow episodes.
+//! Activation, identity, and Temporal start policy for Coordinator episodes.
 //!
-//! This module classifies tracker snapshots that a caller has already
-//! observed. It performs no tracker, SQLite, Temporal, capacity, filesystem,
-//! process, or App I/O. Later Coordinator slices may consume these facts, but
-//! they must not bypass this module's state policy or construct their own
-//! Workflow IDs.
+//! The activation contract classifies tracker snapshots that a caller has
+//! already observed without I/O. The start boundary consumes only those
+//! validated executable facts and performs one Temporal start plus one
+//! immediate Describe. Neither boundary reads tracker or SQLite state.
 
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
@@ -16,6 +15,8 @@ use thiserror::Error;
 use time::{OffsetDateTime, UtcOffset};
 
 use super::{IssueRef, WorkflowId};
+
+pub(crate) mod start;
 
 /// Maximum accepted byte length of an activation's audit reason.
 pub(crate) const MAX_AUDIT_REASON_BYTES: usize = 512;

--- a/src/symphony/coordinator/start.rs
+++ b/src/symphony/coordinator/start.rs
@@ -1,0 +1,1154 @@
+//! Temporal-authoritative start and immediate execution observation.
+//!
+//! This crate-private boundary consumes only validated executable activation
+//! facts. One invocation issues at most one start request followed by at most
+//! one Describe request, preserving uncertain side effects and partial
+//! evidence without consulting tracker or SQLite state.
+
+use temporalio_client::tonic::Code;
+use time::OffsetDateTime;
+
+use crate::symphony::dto::IssueWorkflowInput;
+
+use super::CoordinatorExecutableActivation;
+use crate::symphony::WorkflowId;
+
+/// Phase in which a Coordinator Temporal failure was observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoordinatorTemporalPhase {
+    /// Temporal client configuration or connection establishment.
+    Connect,
+    /// The single Workflow start request.
+    Start,
+    /// The single immediate current-execution Describe request.
+    Describe,
+}
+
+/// Bounded semantic category for a Temporal boundary failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoordinatorFailureKind {
+    /// Input, configuration, or payload conversion failed before start dispatch.
+    InputConfigurationPayload,
+    /// Temporal definitively rejected the requested operation.
+    DefinitiveServerRejection,
+    /// Availability or transport evidence cannot determine the side effect.
+    UnavailableOrIndeterminate,
+    /// Temporal or adapter evidence was missing or internally contradictory.
+    MalformedProtocolEvidence,
+}
+
+/// SDK error variant retained without unbounded SDK payload text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoordinatorSdkErrorVariant {
+    /// Symphony rejected invalid Temporal configuration.
+    InvalidConfiguration,
+    /// The SDK failed while connecting to Temporal.
+    ClientConnect,
+    /// The SDK failed while constructing the namespace client.
+    ClientConstruction,
+    /// The SDK could not serialize or decode a payload.
+    PayloadConversion,
+    /// The SDK returned typed duplicate-start evidence.
+    AlreadyStarted,
+    /// The SDK returned a gRPC operation failure.
+    Rpc,
+    /// The SDK reported that the described execution was not found.
+    NotFound,
+    /// The SDK returned a future or otherwise unclassified error variant.
+    Other,
+    /// Shea rejected malformed evidence after a nominal SDK success.
+    EvidenceValidation,
+}
+
+/// Bounded failure evidence for one Temporal phase.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CoordinatorStartFailure {
+    phase: CoordinatorTemporalPhase,
+    kind: CoordinatorFailureKind,
+    workflow_id: WorkflowId,
+    known_run_id: Option<String>,
+    sdk_error_variant: CoordinatorSdkErrorVariant,
+    grpc_code: Option<Code>,
+}
+
+impl CoordinatorStartFailure {
+    /// Builds bounded phase evidence without retaining SDK messages or payloads.
+    pub(crate) fn new(
+        phase: CoordinatorTemporalPhase,
+        kind: CoordinatorFailureKind,
+        workflow_id: WorkflowId,
+        known_run_id: Option<String>,
+        sdk_error_variant: CoordinatorSdkErrorVariant,
+        grpc_code: Option<Code>,
+    ) -> Self {
+        Self {
+            phase,
+            kind,
+            workflow_id,
+            known_run_id,
+            sdk_error_variant,
+            grpc_code,
+        }
+    }
+
+    /// Returns the phase that produced the evidence.
+    pub(crate) const fn phase(&self) -> CoordinatorTemporalPhase {
+        self.phase
+    }
+
+    /// Returns the bounded semantic failure category.
+    pub(crate) const fn kind(&self) -> CoordinatorFailureKind {
+        self.kind
+    }
+
+    /// Borrows the exact retry-stable Workflow ID.
+    pub(crate) const fn workflow_id(&self) -> &WorkflowId {
+        &self.workflow_id
+    }
+
+    /// Borrows a Run ID known at the failing boundary, when any.
+    pub(crate) fn known_run_id(&self) -> Option<&str> {
+        self.known_run_id.as_deref()
+    }
+
+    /// Returns the typed SDK error variant.
+    pub(crate) const fn sdk_error_variant(&self) -> CoordinatorSdkErrorVariant {
+        self.sdk_error_variant
+    }
+
+    /// Returns the gRPC status code when the SDK exposed one.
+    pub(crate) const fn grpc_code(&self) -> Option<Code> {
+        self.grpc_code
+    }
+}
+
+/// Evidence produced by exactly one Temporal start attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CoordinatorStartEvidence {
+    /// Temporal accepted a new execution and returned its real Run ID.
+    Accepted {
+        /// Temporal-native Run ID from the SDK start handle.
+        run_id: String,
+    },
+    /// Temporal rejected the exact ID because an execution already exists.
+    AlreadyStarted {
+        /// Existing Run ID when Temporal included it in typed error details.
+        run_id: Option<String>,
+    },
+    /// Transport or availability evidence cannot determine the start side effect.
+    Indeterminate,
+}
+
+impl CoordinatorStartEvidence {
+    fn known_run_id(&self) -> Option<&str> {
+        match self {
+            Self::Accepted { run_id } => Some(run_id),
+            Self::AlreadyStarted { run_id } => run_id.as_deref(),
+            Self::Indeterminate => None,
+        }
+    }
+}
+
+/// Temporal execution status retained from current Describe evidence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoordinatorTemporalStatus {
+    /// Execution is accepting Workflow Tasks.
+    Running,
+    /// Execution completed successfully.
+    Completed,
+    /// Execution failed.
+    Failed,
+    /// Execution was canceled.
+    Canceled,
+    /// Execution was terminated.
+    Terminated,
+    /// Execution continued under a new Run ID.
+    ContinuedAsNew,
+    /// Execution timed out.
+    TimedOut,
+    /// Execution is paused but remains open.
+    Paused,
+}
+
+impl CoordinatorTemporalStatus {
+    /// Returns the stable lowercase snake-case Temporal spelling.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Canceled => "canceled",
+            Self::Terminated => "terminated",
+            Self::ContinuedAsNew => "continued_as_new",
+            Self::TimedOut => "timed_out",
+            Self::Paused => "paused",
+        }
+    }
+
+    const fn is_open(self) -> bool {
+        matches!(self, Self::Running | Self::Paused)
+    }
+}
+
+/// Current Describe observation, independent from start evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CoordinatorExecutionObservation {
+    /// Current execution remains open.
+    Open {
+        /// Exact Temporal Workflow ID.
+        workflow_id: WorkflowId,
+        /// Exact Temporal Run ID.
+        run_id: String,
+        /// Temporal server's authoritative execution start time.
+        temporal_started_at: OffsetDateTime,
+        /// Current open execution status.
+        status: CoordinatorTemporalStatus,
+    },
+    /// Current execution closed before or during immediate observation.
+    Closed {
+        /// Exact Temporal Workflow ID.
+        workflow_id: WorkflowId,
+        /// Exact Temporal Run ID.
+        run_id: String,
+        /// Temporal server's authoritative execution start time.
+        temporal_started_at: OffsetDateTime,
+        /// Current terminal execution status.
+        status: CoordinatorTemporalStatus,
+    },
+    /// One Describe was insufficient to establish a valid current observation.
+    DescribeRequired,
+}
+
+/// Combined start and Describe facts from one bounded Coordinator invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CoordinatorStartResult {
+    /// Exact retry-stable Workflow ID consumed by this invocation.
+    pub(crate) workflow_id: WorkflowId,
+    /// Evidence from the single start request.
+    pub(crate) start_evidence: CoordinatorStartEvidence,
+    /// Independent observation from the single immediate Describe request.
+    pub(crate) execution_observation: CoordinatorExecutionObservation,
+    /// Start uncertainty diagnostic when [`CoordinatorStartEvidence::Indeterminate`].
+    pub(crate) start_failure: Option<CoordinatorStartFailure>,
+    /// gRPC status retained from typed duplicate-start SDK evidence.
+    pub(crate) already_started_grpc_code: Option<Code>,
+    /// SDK variant retained when duplicate evidence was observed.
+    pub(crate) already_started_sdk_error_variant: Option<CoordinatorSdkErrorVariant>,
+    /// Describe diagnostic when observation remains required.
+    pub(crate) describe_failure: Option<CoordinatorStartFailure>,
+}
+
+/// Raw successful Describe fields returned by a Temporal adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CoordinatorDescribeEvidence {
+    /// Workflow ID reported by Temporal.
+    pub(crate) workflow_id: String,
+    /// Run ID reported by Temporal.
+    pub(crate) run_id: String,
+    /// Server execution start time, absent only in malformed protocol evidence.
+    pub(crate) temporal_started_at: Option<OffsetDateTime>,
+    /// Raw typed status; `None` represents the protocol's unspecified value.
+    pub(crate) status: Option<CoordinatorTemporalStatus>,
+}
+
+/// Result of one adapter start request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CoordinatorAdapterStart {
+    /// Temporal accepted the request.
+    Accepted {
+        /// Run ID retained from the returned SDK handle.
+        run_id: String,
+    },
+    /// The SDK preserved typed duplicate-start evidence.
+    AlreadyStarted {
+        /// Existing Run ID when supplied by Temporal error details.
+        run_id: Option<String>,
+        /// Original gRPC status code retained from the SDK error.
+        grpc_code: Code,
+    },
+    /// Start may have occurred despite the observed operation failure.
+    Indeterminate(CoordinatorStartFailure),
+}
+
+/// Minimal Temporal operations owned by the Coordinator start boundary.
+pub(crate) trait CoordinatorTemporalAdapter {
+    /// Issues exactly one start request using the supplied durable input.
+    async fn start_issue_workflow(
+        &self,
+        input: IssueWorkflowInput,
+    ) -> Result<CoordinatorAdapterStart, CoordinatorStartFailure>;
+
+    /// Issues exactly one Describe by Workflow ID and known Run ID when present.
+    async fn describe_issue_workflow(
+        &self,
+        workflow_id: &WorkflowId,
+        run_id: Option<&str>,
+    ) -> Result<CoordinatorDescribeEvidence, CoordinatorStartFailure>;
+}
+
+/// Starts and immediately describes one validated executable activation.
+///
+/// A caller retry must pass the same activation again. This function never
+/// generates a replacement ID, retries a side effect, polls, scans, or touches
+/// tracker/SQLite state.
+pub(crate) async fn start_executable_activation<A: CoordinatorTemporalAdapter>(
+    adapter: &A,
+    activation: CoordinatorExecutableActivation,
+) -> Result<CoordinatorStartResult, CoordinatorStartFailure> {
+    let workflow_id = activation.workflow_id().clone();
+    let input = issue_workflow_input(&activation);
+
+    // One SDK call owns the start side effect. An indeterminate transport
+    // result is retained as evidence and never converted into "not started".
+    let adapter_start = adapter.start_issue_workflow(input).await?;
+    let normalized_start = normalize_start(&workflow_id, adapter_start)?;
+    let start_evidence = normalized_start.evidence;
+    let known_run_id = start_evidence.known_run_id().map(str::to_owned);
+
+    // Describe is a separate observation. A no-op execution may already be
+    // closed, so start acceptance never implies the Open variant.
+    let described = adapter
+        .describe_issue_workflow(&workflow_id, known_run_id.as_deref())
+        .await;
+    let (execution_observation, describe_failure) = match described {
+        Ok(evidence) => match normalize_describe(&workflow_id, known_run_id.as_deref(), evidence) {
+            Ok(observation) => (observation, None),
+            Err(failure) => (
+                CoordinatorExecutionObservation::DescribeRequired,
+                Some(failure),
+            ),
+        },
+        Err(failure) => (
+            CoordinatorExecutionObservation::DescribeRequired,
+            Some(failure),
+        ),
+    };
+
+    Ok(CoordinatorStartResult {
+        workflow_id,
+        start_evidence,
+        execution_observation,
+        start_failure: normalized_start.failure,
+        already_started_grpc_code: normalized_start.already_started_grpc_code,
+        already_started_sdk_error_variant: normalized_start.already_started_sdk_error_variant,
+        describe_failure,
+    })
+}
+
+fn issue_workflow_input(activation: &CoordinatorExecutableActivation) -> IssueWorkflowInput {
+    let issue_ref = activation.issue_ref();
+    let source_ref = activation.source_ref().to_owned();
+    IssueWorkflowInput {
+        workflow_id: activation.workflow_id().as_str().to_owned(),
+        repo_id: issue_ref.repo_id.database_key(),
+        tracker_backend: issue_ref.tracker_backend.as_str().to_owned(),
+        issue_ref: issue_ref.display_ref(),
+        from_tracker_state: activation.observed().state().as_str().to_owned(),
+        target_kind: activation.target_kind().as_str().to_owned(),
+        source_kind: activation.source_kind().as_str().to_owned(),
+        source_ref: source_ref.clone(),
+        source_tracker_revision: activation.observed().revision().to_owned(),
+        // This timestamp identifies the pre-start activation episode. It must
+        // remain distinct from Temporal's Describe-backed execution start time.
+        started_at: format_rfc3339_utc_seconds(activation.episode_time()),
+        audit_reason: activation.audit_reason().to_owned(),
+        operator_action_ref: (activation.source_kind()
+            == super::CoordinatorSourceKind::OperatorAction)
+            .then_some(source_ref),
+        // Capacity admission is deliberately unowned by this slice.
+        capacity_policy_ref: None,
+    }
+}
+
+fn format_rfc3339_utc_seconds(value: OffsetDateTime) -> String {
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        value.year(),
+        u8::from(value.month()),
+        value.day(),
+        value.hour(),
+        value.minute(),
+        value.second()
+    )
+}
+
+struct NormalizedStart {
+    evidence: CoordinatorStartEvidence,
+    failure: Option<CoordinatorStartFailure>,
+    already_started_grpc_code: Option<Code>,
+    already_started_sdk_error_variant: Option<CoordinatorSdkErrorVariant>,
+}
+
+fn normalize_start(
+    workflow_id: &WorkflowId,
+    start: CoordinatorAdapterStart,
+) -> Result<NormalizedStart, CoordinatorStartFailure> {
+    match start {
+        CoordinatorAdapterStart::Accepted { run_id } if !run_id.is_empty() => Ok(NormalizedStart {
+            evidence: CoordinatorStartEvidence::Accepted { run_id },
+            failure: None,
+            already_started_grpc_code: None,
+            already_started_sdk_error_variant: None,
+        }),
+        CoordinatorAdapterStart::Accepted { run_id } => Err(malformed_failure(
+            CoordinatorTemporalPhase::Start,
+            workflow_id,
+            nonempty_run_id(run_id),
+        )),
+        CoordinatorAdapterStart::AlreadyStarted { run_id, grpc_code }
+            if run_id.as_deref() != Some("") && grpc_code == Code::AlreadyExists =>
+        {
+            Ok(NormalizedStart {
+                evidence: CoordinatorStartEvidence::AlreadyStarted { run_id },
+                failure: None,
+                already_started_grpc_code: Some(grpc_code),
+                already_started_sdk_error_variant: Some(CoordinatorSdkErrorVariant::AlreadyStarted),
+            })
+        }
+        CoordinatorAdapterStart::AlreadyStarted { run_id, grpc_code } => {
+            Err(CoordinatorStartFailure::new(
+                CoordinatorTemporalPhase::Start,
+                CoordinatorFailureKind::MalformedProtocolEvidence,
+                workflow_id.clone(),
+                run_id.filter(|value| !value.is_empty()),
+                CoordinatorSdkErrorVariant::EvidenceValidation,
+                Some(grpc_code),
+            ))
+        }
+        CoordinatorAdapterStart::Indeterminate(failure) => Ok(NormalizedStart {
+            evidence: CoordinatorStartEvidence::Indeterminate,
+            failure: Some(failure),
+            already_started_grpc_code: None,
+            already_started_sdk_error_variant: None,
+        }),
+    }
+}
+
+fn normalize_describe(
+    expected_workflow_id: &WorkflowId,
+    expected_run_id: Option<&str>,
+    described: CoordinatorDescribeEvidence,
+) -> Result<CoordinatorExecutionObservation, CoordinatorStartFailure> {
+    let valid_identity = described.workflow_id == expected_workflow_id.as_str()
+        && !described.run_id.is_empty()
+        && expected_run_id.is_none_or(|run_id| run_id == described.run_id);
+    let known_run_id = expected_run_id
+        .map(str::to_owned)
+        .or_else(|| nonempty_run_id(described.run_id.clone()));
+    let Some(temporal_started_at) = described.temporal_started_at else {
+        return Err(malformed_failure(
+            CoordinatorTemporalPhase::Describe,
+            expected_workflow_id,
+            known_run_id,
+        ));
+    };
+    let Some(status) = described.status else {
+        return Err(malformed_failure(
+            CoordinatorTemporalPhase::Describe,
+            expected_workflow_id,
+            known_run_id,
+        ));
+    };
+    if !valid_identity {
+        return Err(malformed_failure(
+            CoordinatorTemporalPhase::Describe,
+            expected_workflow_id,
+            known_run_id,
+        ));
+    }
+
+    let fields = (
+        expected_workflow_id.clone(),
+        described.run_id,
+        temporal_started_at,
+        status,
+    );
+    if status.is_open() {
+        Ok(CoordinatorExecutionObservation::Open {
+            workflow_id: fields.0,
+            run_id: fields.1,
+            temporal_started_at: fields.2,
+            status: fields.3,
+        })
+    } else {
+        Ok(CoordinatorExecutionObservation::Closed {
+            workflow_id: fields.0,
+            run_id: fields.1,
+            temporal_started_at: fields.2,
+            status: fields.3,
+        })
+    }
+}
+
+fn nonempty_run_id(run_id: String) -> Option<String> {
+    (!run_id.is_empty()).then_some(run_id)
+}
+
+fn malformed_failure(
+    phase: CoordinatorTemporalPhase,
+    workflow_id: &WorkflowId,
+    known_run_id: Option<String>,
+) -> CoordinatorStartFailure {
+    CoordinatorStartFailure::new(
+        phase,
+        CoordinatorFailureKind::MalformedProtocolEvidence,
+        workflow_id.clone(),
+        known_run_id,
+        CoordinatorSdkErrorVariant::EvidenceValidation,
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use time::macros::datetime;
+
+    use super::*;
+    use crate::symphony::coordinator::{
+        CoordinatorActivationDecision, CoordinatorActivationRequest, CoordinatorSourceKind,
+        CoordinatorTrackerState, ObservedTrackerSnapshot,
+    };
+    use crate::symphony::{IssueRef, RepoId, TrackerBackend};
+
+    #[derive(Debug)]
+    struct FakeAdapter {
+        start: Mutex<Option<Result<CoordinatorAdapterStart, CoordinatorStartFailure>>>,
+        describe: Mutex<Option<Result<CoordinatorDescribeEvidence, CoordinatorStartFailure>>>,
+        calls: Mutex<Vec<(&'static str, String, Option<String>)>>,
+        input: Mutex<Option<IssueWorkflowInput>>,
+    }
+
+    impl FakeAdapter {
+        fn new(
+            start: Result<CoordinatorAdapterStart, CoordinatorStartFailure>,
+            describe: Result<CoordinatorDescribeEvidence, CoordinatorStartFailure>,
+        ) -> Self {
+            Self {
+                start: Mutex::new(Some(start)),
+                describe: Mutex::new(Some(describe)),
+                calls: Mutex::new(Vec::new()),
+                input: Mutex::new(None),
+            }
+        }
+    }
+
+    impl CoordinatorTemporalAdapter for FakeAdapter {
+        async fn start_issue_workflow(
+            &self,
+            input: IssueWorkflowInput,
+        ) -> Result<CoordinatorAdapterStart, CoordinatorStartFailure> {
+            let result = self.start.lock().unwrap().take().unwrap();
+            self.calls
+                .lock()
+                .unwrap()
+                .push(("start", input.workflow_id.clone(), None));
+            *self.input.lock().unwrap() = Some(input);
+            result
+        }
+
+        async fn describe_issue_workflow(
+            &self,
+            workflow_id: &WorkflowId,
+            run_id: Option<&str>,
+        ) -> Result<CoordinatorDescribeEvidence, CoordinatorStartFailure> {
+            let result = self.describe.lock().unwrap().take().unwrap();
+            self.calls.lock().unwrap().push((
+                "describe",
+                workflow_id.as_str().to_owned(),
+                run_id.map(str::to_owned),
+            ));
+            result
+        }
+    }
+
+    fn activation(source_kind: CoordinatorSourceKind) -> CoordinatorExecutableActivation {
+        let request = CoordinatorActivationRequest::new(
+            IssueRef::new(
+                TrackerBackend::GithubProjectV2,
+                RepoId::new("github.com", "Alive24", "shea-symphony"),
+                502,
+            ),
+            Some(CoordinatorTrackerState::Todo),
+            Some("revision-502".to_owned()),
+            datetime!(2026-07-28 09:44:00 UTC),
+            source_kind,
+            "operator/action 502",
+            "Start the validated activation.",
+        )
+        .unwrap();
+        let observed =
+            ObservedTrackerSnapshot::new(CoordinatorTrackerState::Todo, "revision-502").unwrap();
+        let CoordinatorActivationDecision::Executable(activation) =
+            request.evaluate(&observed).unwrap()
+        else {
+            panic!("expected executable activation");
+        };
+        activation
+    }
+
+    fn described(
+        activation: &CoordinatorExecutableActivation,
+        run_id: &str,
+        status: CoordinatorTemporalStatus,
+    ) -> CoordinatorDescribeEvidence {
+        CoordinatorDescribeEvidence {
+            workflow_id: activation.workflow_id().as_str().to_owned(),
+            run_id: run_id.to_owned(),
+            temporal_started_at: Some(datetime!(2026-07-28 09:44:01 UTC)),
+            status: Some(status),
+        }
+    }
+
+    fn failure(
+        activation: &CoordinatorExecutableActivation,
+        phase: CoordinatorTemporalPhase,
+        kind: CoordinatorFailureKind,
+        variant: CoordinatorSdkErrorVariant,
+        code: Option<Code>,
+    ) -> CoordinatorStartFailure {
+        CoordinatorStartFailure::new(
+            phase,
+            kind,
+            activation.workflow_id().clone(),
+            None,
+            variant,
+            code,
+        )
+    }
+
+    #[tokio::test]
+    async fn activation_mapping_populates_every_durable_input_field() {
+        let activation = activation(CoordinatorSourceKind::OperatorAction);
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::Accepted {
+                run_id: "run-accepted".to_owned(),
+            }),
+            Ok(described(
+                &activation,
+                "run-accepted",
+                CoordinatorTemporalStatus::Running,
+            )),
+        );
+
+        let result = start_executable_activation(&adapter, activation.clone())
+            .await
+            .unwrap();
+        let input = adapter.input.lock().unwrap().clone().unwrap();
+
+        assert_eq!(input.workflow_id, activation.workflow_id().as_str());
+        assert_eq!(input.repo_id, "github.com/Alive24/shea-symphony");
+        assert_eq!(input.tracker_backend, "github_project_v2");
+        assert_eq!(input.issue_ref, "#502");
+        assert_eq!(input.from_tracker_state, "todo");
+        assert_eq!(input.target_kind, "work");
+        assert_eq!(input.source_kind, "operator-action");
+        assert_eq!(input.source_ref, "operator/action 502");
+        assert_eq!(input.source_tracker_revision, "revision-502");
+        assert_eq!(input.started_at, "2026-07-28T09:44:00Z");
+        assert_eq!(input.audit_reason, "Start the validated activation.");
+        assert_eq!(
+            input.operator_action_ref.as_deref(),
+            Some("operator/action 502")
+        );
+        assert_eq!(input.capacity_policy_ref, None);
+        assert!(matches!(
+            result.start_evidence,
+            CoordinatorStartEvidence::Accepted { ref run_id } if run_id == "run-accepted"
+        ));
+    }
+
+    #[test]
+    fn non_operator_activation_cannot_gain_operator_or_capacity_provenance() {
+        let activation = activation(CoordinatorSourceKind::Doctor);
+        let input = issue_workflow_input(&activation);
+
+        assert_eq!(input.source_kind, "doctor");
+        assert_eq!(input.source_ref, activation.source_ref());
+        assert_eq!(input.operator_action_ref, None);
+        assert_eq!(input.capacity_policy_ref, None);
+        assert_eq!(input.workflow_id, activation.workflow_id().as_str());
+        assert_eq!(input.target_kind, activation.target_kind().as_str());
+        assert_eq!(input.started_at, "2026-07-28T09:44:00Z");
+    }
+
+    #[tokio::test]
+    async fn accepted_start_and_closed_describe_remain_orthogonal() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::Accepted {
+                run_id: "run-fast".to_owned(),
+            }),
+            Ok(described(
+                &activation,
+                "run-fast",
+                CoordinatorTemporalStatus::Completed,
+            )),
+        );
+
+        let result = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            result.start_evidence,
+            CoordinatorStartEvidence::Accepted { ref run_id } if run_id == "run-fast"
+        ));
+        assert!(matches!(
+            result.execution_observation,
+            CoordinatorExecutionObservation::Closed {
+                ref run_id,
+                status: CoordinatorTemporalStatus::Completed,
+                ..
+            } if run_id == "run-fast"
+        ));
+    }
+
+    #[tokio::test]
+    async fn duplicate_without_run_id_describes_current_execution_by_workflow_id() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::AlreadyStarted {
+                run_id: None,
+                grpc_code: Code::AlreadyExists,
+            }),
+            Ok(described(
+                &activation,
+                "run-existing",
+                CoordinatorTemporalStatus::Running,
+            )),
+        );
+
+        let result = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap();
+
+        assert_eq!(adapter.calls.lock().unwrap()[1].2, None);
+        assert!(matches!(
+            result.start_evidence,
+            CoordinatorStartEvidence::AlreadyStarted { run_id: None }
+        ));
+        assert_eq!(result.already_started_grpc_code, Some(Code::AlreadyExists));
+        assert_eq!(
+            result.already_started_sdk_error_variant,
+            Some(CoordinatorSdkErrorVariant::AlreadyStarted)
+        );
+        assert!(matches!(
+            result.execution_observation,
+            CoordinatorExecutionObservation::Open { ref run_id, .. }
+                if run_id == "run-existing"
+        ));
+    }
+
+    #[tokio::test]
+    async fn indeterminate_start_can_converge_to_open_describe() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let uncertainty = failure(
+            &activation,
+            CoordinatorTemporalPhase::Start,
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            CoordinatorSdkErrorVariant::Rpc,
+            Some(Code::Unavailable),
+        );
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::Indeterminate(uncertainty.clone())),
+            Ok(described(
+                &activation,
+                "run-converged",
+                CoordinatorTemporalStatus::Running,
+            )),
+        );
+
+        let result = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap();
+
+        assert_eq!(result.start_failure, Some(uncertainty));
+        assert!(matches!(
+            result.start_evidence,
+            CoordinatorStartEvidence::Indeterminate
+        ));
+        assert!(matches!(
+            result.execution_observation,
+            CoordinatorExecutionObservation::Open { ref run_id, .. }
+                if run_id == "run-converged"
+        ));
+    }
+
+    #[tokio::test]
+    async fn indeterminate_start_can_converge_to_closed_describe() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let uncertainty = failure(
+            &activation,
+            CoordinatorTemporalPhase::Start,
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            CoordinatorSdkErrorVariant::Rpc,
+            Some(Code::DeadlineExceeded),
+        );
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::Indeterminate(uncertainty)),
+            Ok(described(
+                &activation,
+                "run-converged-closed",
+                CoordinatorTemporalStatus::Failed,
+            )),
+        );
+
+        let result = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            result.start_evidence,
+            CoordinatorStartEvidence::Indeterminate
+        ));
+        assert!(matches!(
+            result.execution_observation,
+            CoordinatorExecutionObservation::Closed {
+                ref run_id,
+                status: CoordinatorTemporalStatus::Failed,
+                ..
+            } if run_id == "run-converged-closed"
+        ));
+    }
+
+    #[tokio::test]
+    async fn unavailable_describe_after_uncertain_start_preserves_both_diagnostics() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let start_failure = failure(
+            &activation,
+            CoordinatorTemporalPhase::Start,
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            CoordinatorSdkErrorVariant::Rpc,
+            Some(Code::Unavailable),
+        );
+        let describe_failure = failure(
+            &activation,
+            CoordinatorTemporalPhase::Describe,
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            CoordinatorSdkErrorVariant::Rpc,
+            Some(Code::Unavailable),
+        );
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::Indeterminate(
+                start_failure.clone(),
+            )),
+            Err(describe_failure.clone()),
+        );
+
+        let result = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap();
+
+        assert_eq!(result.start_failure, Some(start_failure));
+        assert_eq!(result.describe_failure, Some(describe_failure));
+        assert_eq!(
+            result.execution_observation,
+            CoordinatorExecutionObservation::DescribeRequired
+        );
+    }
+
+    #[tokio::test]
+    async fn describe_not_found_preserves_duplicate_start_evidence() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let describe_failure = CoordinatorStartFailure::new(
+            CoordinatorTemporalPhase::Describe,
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            activation.workflow_id().clone(),
+            Some("run-closed".to_owned()),
+            CoordinatorSdkErrorVariant::NotFound,
+            Some(Code::NotFound),
+        );
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::AlreadyStarted {
+                run_id: Some("run-closed".to_owned()),
+                grpc_code: Code::AlreadyExists,
+            }),
+            Err(describe_failure.clone()),
+        );
+
+        let result = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            result.start_evidence,
+            CoordinatorStartEvidence::AlreadyStarted {
+                run_id: Some(ref run_id)
+            } if run_id == "run-closed"
+        ));
+        assert_eq!(result.describe_failure, Some(describe_failure));
+        assert_eq!(
+            result.execution_observation,
+            CoordinatorExecutionObservation::DescribeRequired
+        );
+        let failure = result.describe_failure.unwrap();
+        assert_eq!(failure.phase(), CoordinatorTemporalPhase::Describe);
+        assert_eq!(
+            failure.kind(),
+            CoordinatorFailureKind::UnavailableOrIndeterminate
+        );
+        assert_eq!(
+            failure.sdk_error_variant(),
+            CoordinatorSdkErrorVariant::NotFound
+        );
+        assert_eq!(failure.grpc_code(), Some(Code::NotFound));
+        assert_eq!(failure.workflow_id(), &result.workflow_id);
+        assert_eq!(failure.known_run_id(), Some("run-closed"));
+    }
+
+    #[tokio::test]
+    async fn malformed_or_contradictory_describe_requires_new_observation() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::Accepted {
+                run_id: "run-known".to_owned(),
+            }),
+            Ok(CoordinatorDescribeEvidence {
+                workflow_id: activation.workflow_id().as_str().to_owned(),
+                run_id: "run-contradiction".to_owned(),
+                temporal_started_at: Some(datetime!(2026-07-28 09:44:01 UTC)),
+                status: Some(CoordinatorTemporalStatus::Running),
+            }),
+        );
+
+        let result = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap();
+        let failure = result.describe_failure.unwrap();
+
+        assert_eq!(
+            result.execution_observation,
+            CoordinatorExecutionObservation::DescribeRequired
+        );
+        assert_eq!(
+            failure.kind(),
+            CoordinatorFailureKind::MalformedProtocolEvidence
+        );
+        assert_eq!(failure.phase(), CoordinatorTemporalPhase::Describe);
+    }
+
+    #[tokio::test]
+    async fn duplicate_and_indeterminate_starts_can_observe_closed_execution() {
+        for (start, run_id, status) in [
+            (
+                CoordinatorAdapterStart::AlreadyStarted {
+                    run_id: Some("run-duplicate-closed".to_owned()),
+                    grpc_code: Code::AlreadyExists,
+                },
+                "run-duplicate-closed",
+                CoordinatorTemporalStatus::Failed,
+            ),
+            (
+                CoordinatorAdapterStart::Indeterminate(CoordinatorStartFailure::new(
+                    CoordinatorTemporalPhase::Start,
+                    CoordinatorFailureKind::UnavailableOrIndeterminate,
+                    activation(CoordinatorSourceKind::Tracker)
+                        .workflow_id()
+                        .clone(),
+                    None,
+                    CoordinatorSdkErrorVariant::Rpc,
+                    Some(Code::DeadlineExceeded),
+                )),
+                "run-indeterminate-closed",
+                CoordinatorTemporalStatus::TimedOut,
+            ),
+        ] {
+            let activation = activation(CoordinatorSourceKind::Tracker);
+            let adapter = FakeAdapter::new(Ok(start), Ok(described(&activation, run_id, status)));
+
+            let result = start_executable_activation(&adapter, activation.clone())
+                .await
+                .unwrap();
+
+            assert_eq!(result.workflow_id, *activation.workflow_id());
+            assert!(matches!(
+                result.execution_observation,
+                CoordinatorExecutionObservation::Closed {
+                    run_id: ref observed_run_id,
+                    ..
+                } if observed_run_id == run_id
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn accepted_and_indeterminate_starts_can_require_later_describe() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let uncertainty = failure(
+            &activation,
+            CoordinatorTemporalPhase::Start,
+            CoordinatorFailureKind::UnavailableOrIndeterminate,
+            CoordinatorSdkErrorVariant::Rpc,
+            Some(Code::Unavailable),
+        );
+
+        for start in [
+            CoordinatorAdapterStart::Accepted {
+                run_id: "run-accepted-unobserved".to_owned(),
+            },
+            CoordinatorAdapterStart::Indeterminate(uncertainty.clone()),
+        ] {
+            let describe_failure = failure(
+                &activation,
+                CoordinatorTemporalPhase::Describe,
+                CoordinatorFailureKind::UnavailableOrIndeterminate,
+                CoordinatorSdkErrorVariant::Rpc,
+                Some(Code::Unavailable),
+            );
+            let adapter = FakeAdapter::new(Ok(start), Err(describe_failure.clone()));
+
+            let result = start_executable_activation(&adapter, activation.clone())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                result.execution_observation,
+                CoordinatorExecutionObservation::DescribeRequired
+            );
+            assert_eq!(result.describe_failure, Some(describe_failure));
+        }
+    }
+
+    #[tokio::test]
+    async fn malformed_accepted_start_is_attributed_before_describe() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::Accepted {
+                run_id: String::new(),
+            }),
+            Ok(described(
+                &activation,
+                "unused",
+                CoordinatorTemporalStatus::Running,
+            )),
+        );
+
+        let failure = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap_err();
+
+        assert_eq!(failure.phase(), CoordinatorTemporalPhase::Start);
+        assert_eq!(
+            failure.kind(),
+            CoordinatorFailureKind::MalformedProtocolEvidence
+        );
+        assert_eq!(
+            failure.sdk_error_variant(),
+            CoordinatorSdkErrorVariant::EvidenceValidation
+        );
+        assert_eq!(adapter.calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn contradictory_typed_duplicate_code_is_malformed_evidence() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::AlreadyStarted {
+                run_id: Some("run-contradiction".to_owned()),
+                grpc_code: Code::Unknown,
+            }),
+            Ok(described(
+                &activation,
+                "unused",
+                CoordinatorTemporalStatus::Running,
+            )),
+        );
+
+        let failure = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            failure.kind(),
+            CoordinatorFailureKind::MalformedProtocolEvidence
+        );
+        assert_eq!(
+            failure.sdk_error_variant(),
+            CoordinatorSdkErrorVariant::EvidenceValidation
+        );
+        assert_eq!(failure.grpc_code(), Some(Code::Unknown));
+        assert_eq!(failure.known_run_id(), Some("run-contradiction"));
+        assert_eq!(adapter.calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn predispatch_and_definitive_start_failures_skip_describe() {
+        for (phase, kind, variant, code) in [
+            (
+                CoordinatorTemporalPhase::Connect,
+                CoordinatorFailureKind::InputConfigurationPayload,
+                CoordinatorSdkErrorVariant::InvalidConfiguration,
+                None,
+            ),
+            (
+                CoordinatorTemporalPhase::Start,
+                CoordinatorFailureKind::InputConfigurationPayload,
+                CoordinatorSdkErrorVariant::PayloadConversion,
+                None,
+            ),
+            (
+                CoordinatorTemporalPhase::Start,
+                CoordinatorFailureKind::DefinitiveServerRejection,
+                CoordinatorSdkErrorVariant::Rpc,
+                Some(Code::PermissionDenied),
+            ),
+        ] {
+            let activation = activation(CoordinatorSourceKind::Tracker);
+            let start_failure = failure(&activation, phase, kind, variant, code);
+            let adapter = FakeAdapter::new(
+                Err(start_failure.clone()),
+                Ok(described(
+                    &activation,
+                    "unused",
+                    CoordinatorTemporalStatus::Running,
+                )),
+            );
+
+            let observed = start_executable_activation(&adapter, activation)
+                .await
+                .unwrap_err();
+
+            assert_eq!(observed, start_failure);
+            assert_eq!(observed.phase(), phase);
+            assert_eq!(adapter.calls.lock().unwrap().len(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn one_invocation_never_retries_or_generates_replacement_identity() {
+        let activation = activation(CoordinatorSourceKind::Tracker);
+        let expected_id = activation.workflow_id().as_str().to_owned();
+        let adapter = FakeAdapter::new(
+            Ok(CoordinatorAdapterStart::Accepted {
+                run_id: "run-once".to_owned(),
+            }),
+            Ok(described(
+                &activation,
+                "run-once",
+                CoordinatorTemporalStatus::Paused,
+            )),
+        );
+
+        let result = start_executable_activation(&adapter, activation)
+            .await
+            .unwrap();
+        let calls = adapter.calls.lock().unwrap();
+
+        assert_eq!(
+            calls.as_slice(),
+            [
+                ("start", expected_id.clone(), None),
+                ("describe", expected_id, Some("run-once".to_owned()))
+            ]
+        );
+        assert!(matches!(
+            result.execution_observation,
+            CoordinatorExecutionObservation::Open {
+                status: CoordinatorTemporalStatus::Paused,
+                ..
+            }
+        ));
+    }
+}

--- a/src/symphony/dto.rs
+++ b/src/symphony/dto.rs
@@ -20,18 +20,41 @@ pub struct IssueWorkflowInput {
     pub workflow_id: String,
     /// Stable repository identity, normally host/owner/repository derived.
     pub repo_id: String,
+    /// Stable tracker adapter spelling that resolves the issue.
+    ///
+    /// Legacy histories omit this field, so replay defaults it to an empty
+    /// value. New Coordinator starts always populate it from the validated
+    /// issue identity.
+    #[serde(default)]
+    pub tracker_backend: String,
     /// Tracker-native issue reference such as `#477`.
     pub issue_ref: String,
     /// Authoritative tracker state that made this execution eligible to start.
     pub from_tracker_state: String,
     /// Requested orchestration target, such as contract check or agent work.
     pub target_kind: String,
+    /// Stable activation provenance category such as `tracker`.
+    ///
+    /// Legacy histories omit this field; newly constructed activation inputs
+    /// always carry the Coordinator-validated lowercase kebab-case spelling.
+    #[serde(default)]
+    pub source_kind: String,
     /// Reference to the tracker transition or operator action that activated work.
     pub source_ref: String,
     /// Tracker revision observed when the start decision was made.
     pub source_tracker_revision: String,
-    /// Human-readable UTC timestamp captured outside deterministic Workflow code.
+    /// Pre-start activation episode timestamp in RFC 3339 UTC second precision.
+    ///
+    /// The retained wire name is `started_at` for replay compatibility. This is
+    /// not Temporal's authoritative execution start time; current Describe
+    /// evidence supplies that separately as `temporal_started_at`.
     pub started_at: String,
+    /// Bounded human-readable provenance for why the activation was accepted.
+    ///
+    /// Legacy histories omit this field. It is diagnostic context rather than
+    /// Workflow identity and never contains tracker payloads or transcripts.
+    #[serde(default)]
+    pub audit_reason: String,
     /// Optional durable reference to the operator action that requested execution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub operator_action_ref: Option<String>,
@@ -717,12 +740,15 @@ mod tests {
             workflow_id: "issue:shea-symphony:475:pulse:todo-to-work:20260709-175700Z:project"
                 .to_string(),
             repo_id: "Alive24/shea-symphony".to_string(),
+            tracker_backend: "github_project_v2".to_string(),
             issue_ref: "#475".to_string(),
             from_tracker_state: "Todo".to_string(),
             target_kind: "work".to_string(),
+            source_kind: "tracker".to_string(),
             source_ref: "project-v2".to_string(),
             source_tracker_revision: "rev-1".to_string(),
             started_at: "2026-07-09T17:57:00Z".to_string(),
+            audit_reason: "Activate the observed revision.".to_string(),
             operator_action_ref: None,
             capacity_policy_ref: Some("default-local".to_string()),
         }
@@ -752,6 +778,28 @@ mod tests {
             .as_object()
             .unwrap()
             .contains_key("repo_id"));
+    }
+
+    #[test]
+    fn legacy_issue_workflow_input_defaults_new_durable_fields() {
+        let legacy = json!({
+            "workflow_id": "issue:legacy",
+            "repo_id": "github.com/Alive24/shea-symphony",
+            "issue_ref": "#475",
+            "from_tracker_state": "todo",
+            "target_kind": "work",
+            "source_ref": "project-v2",
+            "source_tracker_revision": "rev-1",
+            "started_at": "2026-07-09T17:57:00Z"
+        });
+
+        let input: IssueWorkflowInput = serde_json::from_value(legacy).unwrap();
+
+        assert_eq!(input.tracker_backend, "");
+        assert_eq!(input.source_kind, "");
+        assert_eq!(input.audit_reason, "");
+        assert_eq!(input.operator_action_ref, None);
+        assert_eq!(input.capacity_policy_ref, None);
     }
 
     #[test]

--- a/tests/temporal_noop_smoke.rs
+++ b/tests/temporal_noop_smoke.rs
@@ -22,8 +22,8 @@ use shea_symphony::{
     RuntimeConfig, WorkflowStore,
 };
 use temporalio_client::{
-    Client, ClientOptions, Connection, ConnectionOptions, UntypedWorkflow, WorkflowDescribeOptions,
-    WorkflowExecutionInfo, WorkflowHandle,
+    Client, ClientOptions, Connection, ConnectionOptions, RetryOptions, UntypedWorkflow,
+    WorkflowDescribeOptions, WorkflowExecutionInfo, WorkflowHandle,
 };
 use temporalio_common::protos::temporal::api::enums::v1::WorkflowExecutionStatus;
 use temporalio_sdk_core::Url;
@@ -527,12 +527,16 @@ async fn describe_execution(
         workflow_id: workflow_id.to_string(),
         detail: error.to_string(),
     })?;
-    let connection = Connection::connect(ConnectionOptions::new(address).build())
-        .await
-        .map_err(|error| SmokeFailure::WorkflowDescribe {
-            workflow_id: workflow_id.to_string(),
-            detail: error.to_string(),
-        })?;
+    let connection = Connection::connect(
+        ConnectionOptions::new(address)
+            .retry_options(RetryOptions::no_retries())
+            .build(),
+    )
+    .await
+    .map_err(|error| SmokeFailure::WorkflowDescribe {
+        workflow_id: workflow_id.to_string(),
+        detail: error.to_string(),
+    })?;
     let client = Client::new(
         connection,
         ClientOptions::new(config.namespace.as_str()).build(),

--- a/tests/temporal_noop_smoke.rs
+++ b/tests/temporal_noop_smoke.rs
@@ -21,6 +21,12 @@ use shea_symphony::{
     symphony::{IssueWorkflowInput, IssueWorkflowQueryResult, SymphonyTemporalClient},
     RuntimeConfig, WorkflowStore,
 };
+use temporalio_client::{
+    Client, ClientOptions, Connection, ConnectionOptions, UntypedWorkflow, WorkflowDescribeOptions,
+    WorkflowExecutionInfo, WorkflowHandle,
+};
+use temporalio_common::protos::temporal::api::enums::v1::WorkflowExecutionStatus;
+use temporalio_sdk_core::Url;
 
 const SMOKE_ENABLED_ENV: &str = "SHEA_TEMPORAL_SMOKE";
 const WORKFLOW_PROFILE: &str = ".shea/workflows/shea-symphony.md";
@@ -71,6 +77,10 @@ enum SmokeFailure {
         diagnostic: String,
     },
     WorkflowStart {
+        workflow_id: String,
+        detail: String,
+    },
+    WorkflowDescribe {
         workflow_id: String,
         detail: String,
     },
@@ -139,6 +149,13 @@ impl fmt::Display for SmokeFailure {
             } => write!(
                 formatter,
                 "workflow-start diagnostic for {workflow_id}: {detail}"
+            ),
+            Self::WorkflowDescribe {
+                workflow_id,
+                detail,
+            } => write!(
+                formatter,
+                "workflow-describe diagnostic for {workflow_id}: {detail}"
             ),
             Self::QueryTimeout {
                 workflow_id,
@@ -482,15 +499,78 @@ fn synthetic_input() -> IssueWorkflowInput {
     IssueWorkflowInput {
         workflow_id,
         repo_id: "synthetic/temporal-smoke".to_string(),
+        tracker_backend: "synthetic".to_string(),
         issue_ref: format!("synthetic:temporal-smoke:{timestamp}"),
         from_tracker_state: "SyntheticSmoke".to_string(),
         target_kind: "noop-smoke".to_string(),
+        source_kind: "smoke".to_string(),
         source_ref: "test-owned:temporal-noop-smoke".to_string(),
         source_tracker_revision: "synthetic-revision-1".to_string(),
         started_at: format!("unix-millis:{timestamp}"),
+        audit_reason: "Exercise the explicit local Temporal smoke.".to_string(),
         operator_action_ref: None,
         capacity_policy_ref: None,
     }
+}
+
+async fn describe_execution(
+    config: &TemporalConfig,
+    workflow_id: &str,
+    run_id: Option<&str>,
+) -> Result<(String, String, SystemTime, WorkflowExecutionStatus), SmokeFailure> {
+    let normalized = if config.address.contains("://") {
+        config.address.clone()
+    } else {
+        format!("http://{}", config.address)
+    };
+    let address = Url::parse(&normalized).map_err(|error| SmokeFailure::WorkflowDescribe {
+        workflow_id: workflow_id.to_string(),
+        detail: error.to_string(),
+    })?;
+    let connection = Connection::connect(ConnectionOptions::new(address).build())
+        .await
+        .map_err(|error| SmokeFailure::WorkflowDescribe {
+            workflow_id: workflow_id.to_string(),
+            detail: error.to_string(),
+        })?;
+    let client = Client::new(
+        connection,
+        ClientOptions::new(config.namespace.as_str()).build(),
+    )
+    .map_err(|error| SmokeFailure::WorkflowDescribe {
+        workflow_id: workflow_id.to_string(),
+        detail: error.to_string(),
+    })?;
+    let handle = WorkflowHandle::<_, UntypedWorkflow>::new(
+        client,
+        WorkflowExecutionInfo {
+            namespace: config.namespace.clone(),
+            workflow_id: workflow_id.to_string(),
+            run_id: run_id.map(str::to_string),
+            first_execution_run_id: None,
+        },
+    );
+    let description = handle
+        .describe(WorkflowDescribeOptions::default())
+        .await
+        .map_err(|error| SmokeFailure::WorkflowDescribe {
+            workflow_id: workflow_id.to_string(),
+            detail: error.to_string(),
+        })?;
+    let temporal_started_at =
+        description
+            .start_time()
+            .ok_or_else(|| SmokeFailure::WorkflowDescribe {
+                workflow_id: workflow_id.to_string(),
+                detail: "Describe omitted Temporal's authoritative start time".to_string(),
+            })?;
+
+    Ok((
+        description.id().to_string(),
+        description.run_id().to_string(),
+        temporal_started_at,
+        description.status(),
+    ))
 }
 
 async fn wait_for_query(
@@ -532,13 +612,69 @@ async fn exercise_noop_workflow(
 ) -> Result<(), SmokeFailure> {
     let input = synthetic_input();
     let workflow_id = input.workflow_id.clone();
-    client
+    let retry_input = input.clone();
+    let started = client
         .start_noop_issue_workflow(input)
         .await
         .map_err(|error| SmokeFailure::WorkflowStart {
             workflow_id: workflow_id.clone(),
             detail: error.to_string(),
         })?;
+    let run_id = started
+        .run_id
+        .filter(|run_id| !run_id.is_empty())
+        .ok_or_else(|| SmokeFailure::WorkflowStart {
+            workflow_id: workflow_id.clone(),
+            detail: "accepted start did not preserve the SDK Run ID".to_string(),
+        })?;
+    if started.workflow_id != workflow_id {
+        return Err(SmokeFailure::WorkflowStart {
+            workflow_id: workflow_id.clone(),
+            detail: format!(
+                "accepted start returned mismatched Workflow ID {}",
+                started.workflow_id
+            ),
+        });
+    }
+    println!("temporal smoke: accepted {workflow_id} with real Run ID {run_id}");
+
+    let (described_workflow_id, described_run_id, temporal_started_at, status) =
+        describe_execution(client.config(), &workflow_id, Some(&run_id)).await?;
+    if described_workflow_id != workflow_id
+        || described_run_id != run_id
+        || status == WorkflowExecutionStatus::Unspecified
+    {
+        return Err(SmokeFailure::WorkflowDescribe {
+            workflow_id: workflow_id.clone(),
+            detail: format!(
+                "unexpected immediate evidence: workflow_id={described_workflow_id}, \
+                 run_id={described_run_id}, start={temporal_started_at:?}, status={status:?}"
+            ),
+        });
+    }
+    println!(
+        "temporal smoke: immediate Describe matched {workflow_id}/{run_id} \
+         with server start {temporal_started_at:?} and status {status:?}"
+    );
+
+    // The exact retry-stable ID must be rejected while the first execution is
+    // open; the client must not bind to it or generate a replacement episode.
+    if let Ok(unexpected) = client.start_noop_issue_workflow(retry_input.clone()).await {
+        return Err(SmokeFailure::WorkflowStart {
+            workflow_id: workflow_id.clone(),
+            detail: format!("exact open-execution retry unexpectedly accepted: {unexpected:?}"),
+        });
+    }
+    let (_, retry_described_run_id, _, _) =
+        describe_execution(client.config(), &workflow_id, None).await?;
+    if retry_described_run_id != run_id {
+        return Err(SmokeFailure::WorkflowDescribe {
+            workflow_id: workflow_id.clone(),
+            detail: format!(
+                "exact retry changed current Run ID from {run_id} to {retry_described_run_id}"
+            ),
+        });
+    }
 
     let query = wait_for_query(client, &workflow_id, worker).await?;
     if query.workflow_id != workflow_id
@@ -580,6 +716,16 @@ async fn exercise_noop_workflow(
         });
     }
     println!("temporal smoke: observed completed NoopCoreActivity result for {workflow_id}");
+
+    // RejectDuplicate also forbids reusing the same episode-scoped ID after
+    // closure. A later caller may create a separately validated activation;
+    // this start boundary never invents one on retry.
+    if let Ok(unexpected) = client.start_noop_issue_workflow(retry_input).await {
+        return Err(SmokeFailure::WorkflowStart {
+            workflow_id,
+            detail: format!("exact closed-execution retry unexpectedly accepted: {unexpected:?}"),
+        });
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Implements #502: T2607-03: start IssueWorkflow with Temporal-authoritative execution evidence.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #502
