### PR TITLE
#485: T2607-04: normalize configured tracker state inputs at the typed transition boundary

### DIFF
--- a/src/symphony/activities.rs
+++ b/src/symphony/activities.rs
@@ -130,14 +130,30 @@ fn smoke_query_hold_from_values(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::StateMap;
     use crate::symphony::dto::{
-        TrackerState, TrackerTransitionEvidenceRefs, TrackerTransitionIssueRef,
-        TrackerTransitionKind, TrackerTransitionOutcome, TrackerTransitionReason,
-        TrackerTransitionRequester,
+        TrackerTransitionEvidenceRefs, TrackerTransitionIssueRef, TrackerTransitionKind,
+        TrackerTransitionOutcome, TrackerTransitionReason, TrackerTransitionRequester,
     };
+
+    fn default_state_map() -> StateMap {
+        StateMap {
+            backlog: "Backlog".to_string(),
+            todo: "Todo".to_string(),
+            need_to_clarify: "Need to Clarify".to_string(),
+            in_progress: "In Progress".to_string(),
+            need_human_input: "Need Human Input".to_string(),
+            agent_review: "Agent Review".to_string(),
+            human_review: "Human Review".to_string(),
+            rework: "Rework".to_string(),
+            merging: "Merging".to_string(),
+            done: "Done".to_string(),
+        }
+    }
 
     fn tracker_transition_request() -> TrackerTransitionRequest {
         TrackerTransitionRequest::new(
+            &default_state_map(),
             "issue:shea-symphony:494:pulse:handoff",
             Some("temporal-run-494".to_string()),
             TrackerTransitionIssueRef::new(
@@ -146,8 +162,8 @@ mod tests {
                 "#494",
             )
             .unwrap(),
-            TrackerState::new("In Progress").unwrap(),
-            TrackerState::new("Agent Review").unwrap(),
+            "In Progress",
+            "Agent Review",
             TrackerTransitionKind::new("main_handoff").unwrap(),
             TrackerTransitionRequester::new("issue_workflow").unwrap(),
             TrackerTransitionReason::new(

--- a/src/symphony/dto.rs
+++ b/src/symphony/dto.rs
@@ -9,6 +9,9 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 
+use crate::config::StateMap;
+use crate::tracker::{resolve_configured_tracker_state, TrackerStateResolutionError};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Durable input used to start one executable Issue Workflow episode.
 ///
@@ -180,6 +183,17 @@ pub(crate) enum TrackerTransitionContractError {
     /// A serialized idempotency key did not carry the current format version.
     #[error("idempotency_key must use the {TRANSITION_IDEMPOTENCY_KEY_VERSION} format")]
     UnsupportedIdempotencyKeyVersion,
+}
+
+/// Construction failure for a transition request before it enters Temporal history.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub(crate) enum TrackerTransitionRequestError {
+    /// The supplied state input was not uniquely declared by the active tracker configuration.
+    #[error(transparent)]
+    StateResolution(#[from] TrackerStateResolutionError),
+    /// A compact transition DTO field violated its stable wire contract.
+    #[error(transparent)]
+    Contract(#[from] TrackerTransitionContractError),
 }
 
 /// Small validated string used by the transition DTO's opaque references.
@@ -578,21 +592,30 @@ impl TrackerTransitionRequest {
     /// Builds a compact transition intent and its deterministic retry identity.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
+        state_map: &StateMap,
         workflow_id: impl Into<String>,
         run_id: Option<String>,
         issue_ref: TrackerTransitionIssueRef,
-        expected_from_state: TrackerState,
-        requested_to_state: TrackerState,
+        expected_from_state: &str,
+        requested_to_state: &str,
         transition_kind: TrackerTransitionKind,
         requester: TrackerTransitionRequester,
         reason: TrackerTransitionReason,
         evidence_refs: TrackerTransitionEvidenceRefs,
         attempt_slot: u32,
-    ) -> Result<Self, TrackerTransitionContractError> {
+    ) -> Result<Self, TrackerTransitionRequestError> {
         let workflow_id = TrackerTransitionWorkflowId::new(workflow_id)?;
         let run_id = run_id
             .map(|value| CompactTransitionValue::new("run_id", value))
             .transpose()?;
+        // Resolve before deriving the retry key so equivalent configured inputs
+        // cannot represent different durable transition intents.
+        let expected_from_state = TrackerState::new(
+            resolve_configured_tracker_state(state_map, expected_from_state)?.canonical_key(),
+        )?;
+        let requested_to_state = TrackerState::new(
+            resolve_configured_tracker_state(state_map, requested_to_state)?.canonical_key(),
+        )?;
         let idempotency_key = TransitionIdempotencyKey::for_transition(
             &workflow_id,
             &issue_ref,
@@ -735,6 +758,21 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn default_state_map() -> StateMap {
+        StateMap {
+            backlog: "Backlog".to_string(),
+            todo: "Todo".to_string(),
+            need_to_clarify: "Need to Clarify".to_string(),
+            in_progress: "In Progress".to_string(),
+            need_human_input: "Need Human Input".to_string(),
+            agent_review: "Agent Review".to_string(),
+            human_review: "Human Review".to_string(),
+            rework: "Rework".to_string(),
+            merging: "Merging".to_string(),
+            done: "Done".to_string(),
+        }
+    }
+
     fn input() -> IssueWorkflowInput {
         IssueWorkflowInput {
             workflow_id: "issue:shea-symphony:475:pulse:todo-to-work:20260709-175700Z:project"
@@ -826,6 +864,7 @@ mod tests {
         attempt_slot: u32,
     ) -> TrackerTransitionRequest {
         TrackerTransitionRequest::new(
+            &default_state_map(),
             workflow_id,
             Some("temporal-run-494".to_string()),
             TrackerTransitionIssueRef::new(
@@ -834,8 +873,8 @@ mod tests {
                 issue,
             )
             .unwrap(),
-            TrackerState::new(expected_from_state).unwrap(),
-            TrackerState::new(requested_to_state).unwrap(),
+            expected_from_state,
+            requested_to_state,
             TrackerTransitionKind::new(transition_kind).unwrap(),
             TrackerTransitionRequester::new("issue_workflow").unwrap(),
             TrackerTransitionReason::new(
@@ -878,8 +917,8 @@ mod tests {
                 "issue": "#494",
             })
         );
-        assert_eq!(value["expected_from_state"], "In Progress");
-        assert_eq!(value["requested_to_state"], "Agent Review");
+        assert_eq!(value["expected_from_state"], "in_progress");
+        assert_eq!(value["requested_to_state"], "agent_review");
         assert!(value["idempotency_key"]
             .as_str()
             .unwrap()
@@ -1054,27 +1093,52 @@ mod tests {
     }
 
     #[test]
-    fn transition_idempotency_key_length_prefixes_opaque_delimiters() {
-        let delimiter_in_requested_state = transition_request_with(
+    fn equivalent_configured_inputs_share_canonical_transition_states_and_idempotency() {
+        let display_inputs = transition_request_with(
             "workflow",
             "#494",
-            "Todo",
-            "In Progress:state",
+            "  TODO  ",
+            " agent review ",
             "handoff",
             0,
         );
-        let delimiter_in_expected_state = transition_request_with(
-            "workflow",
+        let canonical_inputs =
+            transition_request_with("workflow", "#494", "todo", "AGENT_REVIEW", "handoff", 0);
+
+        assert_eq!(display_inputs.expected_from_state.as_str(), "todo");
+        assert_eq!(display_inputs.requested_to_state.as_str(), "agent_review");
+        assert_eq!(display_inputs, canonical_inputs);
+    }
+
+    #[test]
+    fn transition_idempotency_key_length_prefixes_opaque_delimiters() {
+        let workflow_id = TrackerTransitionWorkflowId::new("workflow").unwrap();
+        let issue_ref = TrackerTransitionIssueRef::new(
+            "github_project_v2",
+            "github.com/Alive24/shea-symphony",
             "#494",
-            "Todo:In Progress",
-            "state",
-            "handoff",
+        )
+        .unwrap();
+        let transition_kind = TrackerTransitionKind::new("handoff").unwrap();
+        let delimiter_in_requested_state = TransitionIdempotencyKey::for_transition(
+            &workflow_id,
+            &issue_ref,
+            &TrackerState::new("Todo").unwrap(),
+            &TrackerState::new("In Progress:state").unwrap(),
+            &transition_kind,
+            0,
+        );
+        let delimiter_in_expected_state = TransitionIdempotencyKey::for_transition(
+            &workflow_id,
+            &issue_ref,
+            &TrackerState::new("Todo:In Progress").unwrap(),
+            &TrackerState::new("state").unwrap(),
+            &transition_kind,
             0,
         );
 
         assert_ne!(
-            delimiter_in_requested_state.idempotency_key,
-            delimiter_in_expected_state.idempotency_key,
+            delimiter_in_requested_state, delimiter_in_expected_state,
             "length prefixes prevent the collision a delimiter-only key would allow"
         );
     }
@@ -1085,6 +1149,9 @@ mod tests {
         assert_eq!(state.as_str(), "Provider Managed: Awaiting Review");
         assert!(TrackerState::new("\n").is_err());
         assert!(serde_json::from_str::<TrackerState>(r#""\n""#).is_err());
+
+        let legacy_state: TrackerState = serde_json::from_str(r#""Agent Review""#).unwrap();
+        assert_eq!(legacy_state.as_str(), "Agent Review");
 
         let too_many_refs = (0..=MAX_TRANSITION_EVIDENCE_REFS)
             .map(|index| format!("artifact://run/494/{index}"))

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -26,7 +26,10 @@ pub use github::GithubProjectReadMode;
 pub use linear::LinearAdapter;
 pub use memory::MemoryTracker;
 pub use project_field::ProjectFieldAssignment;
-pub use state::{claim_decision, ClaimDecision};
+pub use state::{
+    claim_decision, resolve_configured_tracker_state, ClaimDecision, ResolvedTrackerState,
+    TrackerStateResolutionError,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct IssueRelationshipRef {
@@ -93,7 +96,7 @@ use github::{
 use linear::{linear_graphql_error_message, linear_issues_from_response, linear_state_option_name};
 #[cfg(test)]
 use state::status_update_required;
-use state::{issue_matches_assignee_filter, status_is_mapped, tracker_state_key};
+use state::{configured_state_has_key, issue_matches_assignee_filter, status_is_mapped};
 #[cfg(test)]
 use workpad::duplicate_workpad_body;
 
@@ -388,9 +391,7 @@ fn github_issue_needs_native_blocker_prefetch(
     issue: &TrackerIssue,
     config: &RuntimeConfig,
 ) -> bool {
-    let state = tracker_state_key(&issue.state);
-    state == tracker_state_key(&config.tracker.state_map.todo)
-        || state == tracker_state_key(&config.tracker.state_map.rework)
+    configured_state_has_key(&config.tracker.state_map, &issue.state, &["todo", "rework"])
 }
 
 fn github_issue_needs_native_subissue_prefetch(
@@ -400,10 +401,11 @@ fn github_issue_needs_native_subissue_prefetch(
     if has_native_subissue_fields(issue) {
         return false;
     }
-    let state = tracker_state_key(&issue.state);
-    let main_lane_state = state == tracker_state_key(&config.tracker.state_map.todo)
-        || state == tracker_state_key(&config.tracker.state_map.rework)
-        || state == tracker_state_key(&config.tracker.state_map.in_progress);
+    let main_lane_state = configured_state_has_key(
+        &config.tracker.state_map,
+        &issue.state,
+        &["todo", "rework", "in_progress"],
+    );
     main_lane_state
         && issue
             .description

--- a/src/tracker/error.rs
+++ b/src/tracker/error.rs
@@ -1,7 +1,12 @@
 use thiserror::Error;
 
+use super::TrackerStateResolutionError;
+
 #[derive(Debug, Error)]
 pub enum TrackerError {
+    /// A requested tracker state was unknown or ambiguously declared by `state_map`.
+    #[error(transparent)]
+    StateResolution(#[from] TrackerStateResolutionError),
     #[error("tracker fixture failed: {0}")]
     Fixture(String),
     #[error("tracker payload failed: {0}")]
@@ -45,6 +50,7 @@ impl ProjectStateFailureKind {
 
 pub fn classify_project_state_error(error: &TrackerError) -> ProjectStateFailureKind {
     match error {
+        TrackerError::StateResolution(_) => ProjectStateFailureKind::Schema,
         TrackerError::Fixture(_) => ProjectStateFailureKind::Payload,
         TrackerError::Payload(message) => classify_project_state_failure_message(message),
         TrackerError::IntegrationUnavailable(message) => {

--- a/src/tracker/github/client.rs
+++ b/src/tracker/github/client.rs
@@ -25,8 +25,8 @@ use crate::tracker::follow_up::follow_up_issue_body;
 use crate::tracker::state::status_update_required;
 use crate::tracker::workpad::{duplicate_workpad_body, ensure_workpad_marker, merge_workpad_body};
 use crate::tracker::{
-    relationship_readback_from_issue, FollowUpIssueInput, IssueRelationshipReadback,
-    ProjectFieldAssignment, TrackerError,
+    relationship_readback_from_issue, resolve_configured_tracker_state, FollowUpIssueInput,
+    IssueRelationshipReadback, ProjectFieldAssignment, TrackerError,
 };
 
 #[derive(Debug, Clone)]
@@ -483,26 +483,12 @@ impl GithubProjectV2GhClient {
             })
     }
 
-    fn state_option_name(&self, normalized_state: &str) -> Result<String, TrackerError> {
-        let state_map = &self.config.tracker.state_map;
-        let option = match normalized_state {
-            "backlog" => &state_map.backlog,
-            "todo" => &state_map.todo,
-            "need_to_clarify" | "need to clarify" => &state_map.need_to_clarify,
-            "in_progress" | "in progress" => &state_map.in_progress,
-            "need_human_input" | "need human input" => &state_map.need_human_input,
-            "agent_review" | "agent review" => &state_map.agent_review,
-            "human_review" | "human review" => &state_map.human_review,
-            "rework" => &state_map.rework,
-            "merging" => &state_map.merging,
-            "done" => &state_map.done,
-            other => {
-                return Err(TrackerError::IntegrationUnavailable(format!(
-                    "unsupported normalized state {other:?}"
-                )))
-            }
-        };
-        Ok(option.clone())
+    fn state_option_name(&self, state_input: &str) -> Result<String, TrackerError> {
+        Ok(
+            resolve_configured_tracker_state(&self.config.tracker.state_map, state_input)?
+                .display_value()
+                .to_string(),
+        )
     }
 
     pub(in crate::tracker) fn link_pull_request(

--- a/src/tracker/linear.rs
+++ b/src/tracker/linear.rs
@@ -7,8 +7,9 @@ use crate::model::{normalize_state, BlockerRef, LinkedPullRequest, TrackerIssue}
 use super::follow_up::follow_up_issue_body;
 use super::workpad::ensure_workpad_marker;
 use super::{
-    issue_matches_assignee_filter, json_number_to_i64, load_fixture, string_nodes,
-    FollowUpIssueInput, MemoryTracker, TrackerAdapter, TrackerError,
+    issue_matches_assignee_filter, json_number_to_i64, load_fixture,
+    resolve_configured_tracker_state, string_nodes, FollowUpIssueInput, MemoryTracker,
+    TrackerAdapter, TrackerError,
 };
 
 #[derive(Debug, Clone)]
@@ -784,27 +785,13 @@ fn linear_blocker_refs(issue: &serde_json::Value) -> Vec<BlockerRef> {
 
 pub(super) fn linear_state_option_name(
     config: &RuntimeConfig,
-    normalized_state: &str,
+    state_input: &str,
 ) -> Result<String, TrackerError> {
-    let state_map = &config.tracker.state_map;
-    let option = match normalized_state {
-        "backlog" => &state_map.backlog,
-        "todo" => &state_map.todo,
-        "need_to_clarify" | "need to clarify" => &state_map.need_to_clarify,
-        "in_progress" | "in progress" => &state_map.in_progress,
-        "need_human_input" | "need human input" => &state_map.need_human_input,
-        "agent_review" | "agent review" => &state_map.agent_review,
-        "human_review" | "human review" => &state_map.human_review,
-        "rework" => &state_map.rework,
-        "merging" => &state_map.merging,
-        "done" => &state_map.done,
-        other => {
-            return Err(TrackerError::IntegrationUnavailable(format!(
-                "unsupported normalized Linear state {other:?}"
-            )))
-        }
-    };
-    Ok(option.clone())
+    Ok(
+        resolve_configured_tracker_state(&config.tracker.state_map, state_input)?
+            .display_value()
+            .to_string(),
+    )
 }
 
 fn expect_linear_success(

--- a/src/tracker/state.rs
+++ b/src/tracker/state.rs
@@ -1,5 +1,105 @@
-use crate::config::{AssigneeFilter, RuntimeConfig};
+use std::collections::BTreeSet;
+
+use thiserror::Error;
+
+use crate::config::{AssigneeFilter, RuntimeConfig, StateMap};
 use crate::model::{normalize_state, TrackerIssue};
+
+const CONFIGURED_STATE_KEYS: [&str; 10] = [
+    "backlog",
+    "todo",
+    "need_to_clarify",
+    "in_progress",
+    "need_human_input",
+    "agent_review",
+    "human_review",
+    "rework",
+    "merging",
+    "done",
+];
+
+/// A configured tracker state resolved to Symphony's canonical key and provider display value.
+///
+/// The canonical key is used for internal comparison and transition idempotency;
+/// the display value remains the provider-facing value configured in `state_map`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTrackerState {
+    canonical_key: &'static str,
+    display_value: String,
+}
+
+impl ResolvedTrackerState {
+    /// Returns the stable internal `state_map` key for this configured state.
+    pub fn canonical_key(&self) -> &'static str {
+        self.canonical_key
+    }
+
+    /// Returns the configured provider display value without canonicalizing it.
+    pub fn display_value(&self) -> &str {
+        &self.display_value
+    }
+}
+
+/// Typed diagnostic emitted when a value cannot identify exactly one configured tracker state.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum TrackerStateResolutionError {
+    /// The supplied value was neither a configured canonical key nor a configured display value.
+    #[error("unknown configured tracker state input {input:?}")]
+    UnknownInput {
+        /// The unsupported input exactly as supplied by the caller.
+        input: String,
+    },
+    /// Multiple configured states accept the same trim- and case-normalized input.
+    #[error(
+        "ambiguous configured tracker state input {input:?}; it resolves to {}",
+        canonical_keys.join(", ")
+    )]
+    AmbiguousConfiguration {
+        /// The input that matched more than one configured state.
+        input: String,
+        /// Canonical keys that collide for this input.
+        canonical_keys: Vec<String>,
+    },
+}
+
+/// Resolves an exact configured key or display value to one canonical internal tracker state.
+///
+/// Comparison trims only surrounding whitespace and folds case. It deliberately
+/// does not normalize punctuation, underscores, interior whitespace, aliases,
+/// or approximate spellings. A collision is rejected rather than depending on
+/// configuration field order.
+pub fn resolve_configured_tracker_state(
+    state_map: &StateMap,
+    input: &str,
+) -> Result<ResolvedTrackerState, TrackerStateResolutionError> {
+    let normalized_input = normalize_configured_state_input(input);
+    let matches = configured_states(state_map)
+        .into_iter()
+        .filter(|(canonical_key, display_value)| {
+            normalized_input == normalize_configured_state_input(canonical_key)
+                || normalized_input == normalize_configured_state_input(display_value)
+        })
+        .collect::<Vec<_>>();
+
+    match matches.as_slice() {
+        [] => Err(TrackerStateResolutionError::UnknownInput {
+            input: input.to_string(),
+        }),
+        [(canonical_key, display_value)] => Ok(ResolvedTrackerState {
+            canonical_key,
+            display_value: (*display_value).to_string(),
+        }),
+        _ => Err(TrackerStateResolutionError::AmbiguousConfiguration {
+            input: input.to_string(),
+            canonical_keys: matches
+                .iter()
+                .map(|(canonical_key, _)| (*canonical_key).to_string())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect(),
+        }),
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClaimDecision {
@@ -9,30 +109,21 @@ pub enum ClaimDecision {
 }
 
 pub fn claim_decision(issue: &TrackerIssue, config: &RuntimeConfig) -> ClaimDecision {
-    let state = tracker_state_key(&issue.state);
-    let state_map = &config.tracker.state_map;
-
-    if state == tracker_state_key(&state_map.in_progress) {
-        ClaimDecision::AlreadyInProgress
-    } else if state == tracker_state_key(&state_map.todo)
-        || state == tracker_state_key(&state_map.rework)
-    {
-        ClaimDecision::Claimable
-    } else {
-        ClaimDecision::StopAndReplan {
+    match resolve_configured_tracker_state(&config.tracker.state_map, &issue.state) {
+        Ok(state) if state.canonical_key() == "in_progress" => ClaimDecision::AlreadyInProgress,
+        Ok(state) if matches!(state.canonical_key(), "todo" | "rework") => ClaimDecision::Claimable,
+        Ok(_) | Err(_) => ClaimDecision::StopAndReplan {
             current_state: issue.state.clone(),
-        }
+        },
     }
 }
 
 pub(in crate::tracker) fn status_update_required(issue: &TrackerIssue, target_state: &str) -> bool {
-    tracker_state_key(&issue.state) != tracker_state_key(target_state)
+    normalize_configured_state_input(&issue.state) != normalize_configured_state_input(target_state)
 }
 
 pub(in crate::tracker) fn status_is_mapped(status: &str, config: &RuntimeConfig) -> bool {
-    mapped_status_names(config)
-        .iter()
-        .any(|mapped| tracker_state_key(mapped) == tracker_state_key(status))
+    resolve_configured_tracker_state(&config.tracker.state_map, status).is_ok()
 }
 
 pub(in crate::tracker) fn issue_matches_assignee_filter(
@@ -56,26 +147,111 @@ pub(in crate::tracker) fn issue_matches_assignee_filter(
         .any(|assignee| allowed.contains(&normalize_state(assignee)))
 }
 
-pub(in crate::tracker) fn tracker_state_key(state: &str) -> String {
-    normalize_state(state)
-        .replace('_', " ")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+pub(in crate::tracker) fn configured_state_has_key(
+    state_map: &StateMap,
+    input: &str,
+    canonical_keys: &[&str],
+) -> bool {
+    resolve_configured_tracker_state(state_map, input)
+        .map(|state| canonical_keys.contains(&state.canonical_key()))
+        .unwrap_or(false)
 }
 
-fn mapped_status_names(config: &RuntimeConfig) -> Vec<&str> {
-    let state_map = &config.tracker.state_map;
-    vec![
-        state_map.backlog.as_str(),
-        state_map.todo.as_str(),
-        state_map.need_to_clarify.as_str(),
-        state_map.in_progress.as_str(),
-        state_map.need_human_input.as_str(),
-        state_map.agent_review.as_str(),
-        state_map.human_review.as_str(),
-        state_map.rework.as_str(),
-        state_map.merging.as_str(),
-        state_map.done.as_str(),
+fn normalize_configured_state_input(input: &str) -> String {
+    input.trim().to_lowercase()
+}
+
+fn configured_states(state_map: &StateMap) -> [(&'static str, &str); 10] {
+    [
+        (CONFIGURED_STATE_KEYS[0], &state_map.backlog),
+        (CONFIGURED_STATE_KEYS[1], &state_map.todo),
+        (CONFIGURED_STATE_KEYS[2], &state_map.need_to_clarify),
+        (CONFIGURED_STATE_KEYS[3], &state_map.in_progress),
+        (CONFIGURED_STATE_KEYS[4], &state_map.need_human_input),
+        (CONFIGURED_STATE_KEYS[5], &state_map.agent_review),
+        (CONFIGURED_STATE_KEYS[6], &state_map.human_review),
+        (CONFIGURED_STATE_KEYS[7], &state_map.rework),
+        (CONFIGURED_STATE_KEYS[8], &state_map.merging),
+        (CONFIGURED_STATE_KEYS[9], &state_map.done),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_state_map() -> StateMap {
+        StateMap {
+            backlog: "Backlog".to_string(),
+            todo: "Todo".to_string(),
+            need_to_clarify: "Need to Clarify".to_string(),
+            in_progress: "In Progress".to_string(),
+            need_human_input: "Need Human Input".to_string(),
+            agent_review: "Agent Review".to_string(),
+            human_review: "Human Review".to_string(),
+            rework: "Rework".to_string(),
+            merging: "Merging".to_string(),
+            done: "Done".to_string(),
+        }
+    }
+
+    #[test]
+    fn resolves_every_configured_key_and_display_value() {
+        let state_map = default_state_map();
+        for (key, display) in configured_states(&state_map) {
+            assert_eq!(
+                resolve_configured_tracker_state(&state_map, key)
+                    .unwrap()
+                    .canonical_key(),
+                key
+            );
+            let resolved = resolve_configured_tracker_state(&state_map, display).unwrap();
+            assert_eq!(resolved.canonical_key(), key);
+            assert_eq!(resolved.display_value(), display);
+        }
+    }
+
+    #[test]
+    fn resolves_custom_displays_with_case_and_surrounding_whitespace() {
+        let mut state_map = default_state_map();
+        state_map.need_to_clarify = "Triage Needed".to_string();
+
+        let resolved = resolve_configured_tracker_state(&state_map, "  tRiAgE nEeDeD  ").unwrap();
+
+        assert_eq!(resolved.canonical_key(), "need_to_clarify");
+        assert_eq!(resolved.display_value(), "Triage Needed");
+    }
+
+    #[test]
+    fn rejects_unknown_aliases_and_punctuation_variants() {
+        let state_map = default_state_map();
+        for input in [
+            "in-progress",
+            "need-human-input",
+            "need__human__input",
+            "review",
+        ] {
+            assert_eq!(
+                resolve_configured_tracker_state(&state_map, input),
+                Err(TrackerStateResolutionError::UnknownInput {
+                    input: input.to_string(),
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_configuration_collisions_without_selecting_a_state() {
+        let mut state_map = default_state_map();
+        state_map.todo = "Review".to_string();
+        state_map.rework = "review".to_string();
+
+        assert_eq!(
+            resolve_configured_tracker_state(&state_map, " REVIEW "),
+            Err(TrackerStateResolutionError::AmbiguousConfiguration {
+                input: " REVIEW ".to_string(),
+                canonical_keys: vec!["rework".to_string(), "todo".to_string()],
+            })
+        );
+    }
 }

--- a/src/tracker/tests.rs
+++ b/src/tracker/tests.rs
@@ -1488,7 +1488,7 @@ Prompt
 fn status_update_required_skips_same_mapped_state() {
     assert!(!status_update_required(
         &issue("In Progress"),
-        "in_progress"
+        " in progress "
     ));
     assert!(!status_update_required(
         &issue("Agent Review"),
@@ -1573,7 +1573,7 @@ tracker:
   fixture_path: issues.json
   state_map:
     in_progress: Started
-    agent_review: Agent Review
+    agent_review: Verification Queue
 ---
 Prompt
 "#,
@@ -1584,8 +1584,8 @@ Prompt
         "Started"
     );
     assert_eq!(
-        linear_state_option_name(&config, "agent review").unwrap(),
-        "Agent Review"
+        linear_state_option_name(&config, " verification queue ").unwrap(),
+        "Verification Queue"
     );
     assert!(linear_state_option_name(&config, "unknown").is_err());
 }


### PR DESCRIPTION
## Summary
- Implements #485: T2607-04: normalize configured tracker state inputs at the typed transition boundary.

## Branch Target Evidence
- Branch target role: `SingleIssue`
- PR base branch: `main`

## Verification
- cargo test
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings

## Handoff
Main implementation work stops at Agent Review. Human Review remains reserved for an independent Review Agent after passing evidence is recorded.

Closes #485
