### PR TITLE
Deduplicate autopilot plan reads and share rate-limit cooldown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,7 @@ dependencies = [
  "signal-hook",
  "tempfile",
  "thiserror",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1"
 serde_yaml = "0.9"
 signal-hook = "0.3"
 thiserror = "1"
+time = { version = "0.3", features = ["parsing"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -75,14 +75,27 @@ Merge lane work; use `--no-recover` only for focused debugging. Per-lane
 capacity uses `--main-max-concurrent`, `--review-max-concurrent`, and
 `--merge-max-concurrent`.
 
-Lane throughput is independent inside each foreground supervisor iteration. The
-supervisor checks Main, Review, and Merge in that order, refreshes the plan
-between lanes, and records one lane work-unit result for each lane. A slow,
-blocked, idle, or busy lane remains visible in the status and result output, but
-it is not a shared global iteration gate when another lane has ready work. A
-global readiness blocker such as an unsafe canonical checkout, Doctor blocker,
-or non-recoverable runtime ambiguity still blocks write-mode Autoloop before
-lane mutation.
+Lane throughput is independent inside each foreground supervisor iteration.
+Concurrently enabled Main, Review, and Merge workers consume one immutable,
+process-local selection snapshot generation instead of rebuilding the same
+Doctor-hydrated Project plan per lane. A write-capable selected lane invalidates
+that generation after its tick, so the next selection cycle performs one new
+single-flight refresh. The snapshot only selects candidates: each lane keeps
+its targeted live issue/PR read and refuses changed state immediately before a
+claim, review transition, merge, or other mutation. A slow, blocked, idle, or
+busy lane remains visible in status and result output without becoming a global
+throughput gate. A global readiness blocker such as an unsafe canonical
+checkout, Doctor blocker, or non-recoverable runtime ambiguity still blocks
+write-mode Autoloop before lane mutation.
+
+GitHub GraphQL reads emit secret-free `github_graphql_budget` evidence with the
+operation, initiating Autopilot/lane action, provider-reported cost and
+remaining budget, and reset time when available. Exhaustion establishes one
+process-local `github_graphql_cooldown` decision shared by all lane threads.
+Shea waits until the provider reset deadline; missing or malformed reset
+evidence uses a bounded conservative fallback, and cancellation interrupts the
+wait. The scope is deliberately one Shea process/runtime profile—there is no
+durable cache, cross-process lock, or cross-repository quota coordinator.
 
 The iteration budget controls the supervisor lifetime, not the total number of
 Main, Review, or Merge items that may complete. Lane-specific worker limits

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -85,6 +85,26 @@ Supervisor cycles remain visible as lifecycle evidence through
 `supervisor_cycle`; lane events and result events carry `completed_work_units`
 and per-lane counters so operators can see which lane actually completed work.
 
+Within one Autoloop process, enabled lanes share an immutable selection-plan
+generation. `selection_snapshot_generation=... source=shared_snapshot` evidence
+identifies reuse; the one lane that performs a later single-flight refresh uses
+`source=shared_refresh`. Write-capable selected ticks invalidate their consumed
+generation, while a stale finishing lane cannot invalidate a newer generation.
+This saves repeated global Project/Doctor hydration without authorizing work
+from stale data: Main, Review, and Merge still perform their existing targeted
+live issue/PR reads immediately before mutations and stop when status, claim,
+handoff, or PR evidence changed after selection.
+
+Tracker stderr/logs expose GraphQL budget state as
+`github_graphql_budget operation=... action=... cost=... remaining=...
+reset_at=...`. If the provider reports exhaustion, all lane threads observe one
+`github_graphql_cooldown scope=process decision=wait_until_reset` deadline.
+Provider reset evidence is preferred; unavailable or malformed reset evidence
+falls back to a bounded delay, and Ctrl-C cancels the wait. This is per-process
+coordination only. Separate Shea Symphony, Shea Halo, and FailureReport
+processes report and manage their own budgets; operators should compare their
+evidence rather than expect a cross-repository lock.
+
 For a more scannable operator view, keep the same dry-run boundary and opt into
 the terminal panel:
 

--- a/src/commands/autopilot.rs
+++ b/src/commands/autopilot.rs
@@ -5,7 +5,9 @@ use shea_symphony::config::RuntimeConfig;
 use shea_symphony::doctor::ProjectAuditReport;
 use shea_symphony::model::{normalize_state, TrackerIssue};
 use shea_symphony::runtime_state::load_runtime_states;
-use shea_symphony::tracker::{adapter_from_config, TrackerAdapter};
+use shea_symphony::tracker::{
+    adapter_from_config, with_github_graphql_request_context, TrackerAdapter,
+};
 use shea_symphony::workflow::WorkflowDefinition;
 
 use crate::commands::doctor::hydrate_issues_for_doctor;
@@ -33,7 +35,10 @@ pub(crate) fn autopilot_plan(
     workflow_path: PathBuf,
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let snapshot = build_autopilot_plan(&workflow_path)?;
+    let snapshot =
+        with_github_graphql_request_context("autopilot.plan.selection_refresh", None, || {
+            build_autopilot_plan(&workflow_path)
+        })?;
     if json {
         println!("{}", serde_json::to_string_pretty(&snapshot)?);
     } else {

--- a/src/commands/autopilot/looping.rs
+++ b/src/commands/autopilot/looping.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    mpsc, Arc,
+    mpsc, Arc, Condvar, Mutex,
 };
 use std::thread;
 use std::time::Duration;
@@ -14,6 +14,7 @@ use serde_json::{json, Value};
 use shea_symphony::config::RuntimeConfig;
 use shea_symphony::model::PollingSnapshot;
 use shea_symphony::orchestrator::Orchestrator;
+use shea_symphony::tracker::with_github_graphql_request_context;
 use shea_symphony::workflow::WorkflowDefinition;
 
 use crate::cli::DisplayMode;
@@ -256,7 +257,11 @@ fn autopilot_loop_with_cancellation(
         let settings = AutopilotLoopSettings::from_config(&config, &options);
         let tick_settings = AutopilotLoopTickSettings::from_options(&config, &options);
 
-        let plan = match build_autopilot_plan(&options.workflow_path) {
+        let plan = match with_github_graphql_request_context(
+            "autopilot.supervisor.selection_refresh",
+            Some(Arc::clone(&cancellation)),
+            || build_autopilot_plan(&options.workflow_path),
+        ) {
             Ok(plan) => plan,
             Err(error) => {
                 let error_text = error.to_string();
@@ -458,6 +463,7 @@ fn autopilot_loop_with_cancellation(
             &options,
             settings,
             tick_settings,
+            plan,
             work_unit_limit,
             &mut completed_work_units,
             &cancellation,
@@ -563,6 +569,151 @@ struct AutopilotLaneWorkerFinished {
 }
 
 #[derive(Debug)]
+struct SharedPlanRead<T> {
+    generation: u64,
+    snapshot: Option<Arc<T>>,
+    error: Option<String>,
+    refreshed: bool,
+}
+
+#[derive(Debug)]
+struct SharedPlanCacheState<T> {
+    generation: u64,
+    snapshot: Option<Arc<T>>,
+    error: Option<String>,
+    retry_after_ms: u64,
+    refresh_in_flight: bool,
+}
+
+#[derive(Debug)]
+struct SharedPlanCache<T> {
+    state: Mutex<SharedPlanCacheState<T>>,
+    ready: Condvar,
+}
+
+impl<T> SharedPlanCache<T> {
+    fn seeded(snapshot: T) -> Self {
+        Self {
+            state: Mutex::new(SharedPlanCacheState {
+                generation: 1,
+                snapshot: Some(Arc::new(snapshot)),
+                error: None,
+                retry_after_ms: 0,
+                refresh_in_flight: false,
+            }),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn read_or_refresh(
+        &self,
+        cancellation: &Arc<AtomicBool>,
+        refresh: impl FnOnce() -> Result<T, String>,
+    ) -> SharedPlanRead<T> {
+        let mut refresh = Some(refresh);
+        loop {
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            if let Some(snapshot) = &state.snapshot {
+                return SharedPlanRead {
+                    generation: state.generation,
+                    snapshot: Some(Arc::clone(snapshot)),
+                    error: None,
+                    refreshed: false,
+                };
+            }
+            let now_ms = current_time_ms();
+            if let Some(error) = &state.error {
+                if now_ms < state.retry_after_ms {
+                    return SharedPlanRead {
+                        generation: state.generation,
+                        snapshot: None,
+                        error: Some(error.clone()),
+                        refreshed: false,
+                    };
+                }
+            }
+            if state.refresh_in_flight {
+                if cancellation.load(Ordering::SeqCst) {
+                    return SharedPlanRead {
+                        generation: state.generation,
+                        snapshot: None,
+                        error: Some("shared selection refresh cancelled".into()),
+                        refreshed: false,
+                    };
+                }
+                let (next_state, _) = self
+                    .ready
+                    .wait_timeout(state, Duration::from_millis(250))
+                    .unwrap_or_else(|poison| poison.into_inner());
+                drop(next_state);
+                continue;
+            }
+
+            state.refresh_in_flight = true;
+            state.error = None;
+            let generation = state.generation.saturating_add(1);
+            drop(state);
+
+            let result = refresh
+                .take()
+                .expect("shared plan refresh closure is consumed once")();
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            state.generation = generation;
+            state.refresh_in_flight = false;
+            let read = match result {
+                Ok(snapshot) => {
+                    let snapshot = Arc::new(snapshot);
+                    state.snapshot = Some(Arc::clone(&snapshot));
+                    state.error = None;
+                    state.retry_after_ms = 0;
+                    SharedPlanRead {
+                        generation,
+                        snapshot: Some(snapshot),
+                        error: None,
+                        refreshed: true,
+                    }
+                }
+                Err(error) => {
+                    state.snapshot = None;
+                    state.error = Some(error.clone());
+                    state.retry_after_ms = current_time_ms().saturating_add(1_000);
+                    SharedPlanRead {
+                        generation,
+                        snapshot: None,
+                        error: Some(error),
+                        refreshed: true,
+                    }
+                }
+            };
+            self.ready.notify_all();
+            return read;
+        }
+    }
+
+    fn invalidate(&self, generation: u64) -> bool {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if state.generation != generation || state.snapshot.is_none() {
+            return false;
+        }
+        state.snapshot = None;
+        state.error = None;
+        state.retry_after_ms = 0;
+        true
+    }
+}
+
+type SharedAutopilotPlan = SharedPlanCache<AutopilotPlanSnapshot>;
+
+#[derive(Debug)]
 enum AutopilotLaneWorkerMessage {
     Running {
         lane: AutopilotLaneKind,
@@ -587,6 +738,7 @@ fn run_independent_autopilot_lane_supervisor(
     options: &AutopilotLoopOptions,
     settings: AutopilotLoopSettings,
     tick_settings: AutopilotLoopTickSettings,
+    initial_plan: AutopilotPlanSnapshot,
     work_unit_limit: Option<usize>,
     completed_work_units: &mut AutopilotWorkUnitCounters,
     cancellation: &Arc<AtomicBool>,
@@ -632,20 +784,25 @@ fn run_independent_autopilot_lane_supervisor(
         }),
     )?;
 
+    let shared_plan = Arc::new(SharedAutopilotPlan::seeded(initial_plan));
     let (sender, receiver) = mpsc::channel();
     let mut handles = Vec::new();
     for lane in lanes {
         let sender = sender.clone();
         let options = options.clone();
         let cancellation = Arc::clone(cancellation);
+        let shared_plan = Arc::clone(&shared_plan);
         let handle = thread::spawn(move || {
             run_autopilot_lane_worker(
                 lane,
                 options,
-                settings,
-                tick_settings,
-                work_unit_limit,
+                AutopilotLaneWorkerSettings {
+                    loop_settings: settings,
+                    tick_settings,
+                    max_iterations: work_unit_limit,
+                },
                 cancellation,
+                shared_plan,
                 sender,
             );
         });
@@ -783,19 +940,28 @@ fn run_independent_autopilot_lane_supervisor(
     })
 }
 
+#[derive(Debug, Clone, Copy)]
+struct AutopilotLaneWorkerSettings {
+    loop_settings: AutopilotLoopSettings,
+    tick_settings: AutopilotLoopTickSettings,
+    max_iterations: Option<usize>,
+}
+
 fn run_autopilot_lane_worker(
     lane: AutopilotLaneKind,
     options: AutopilotLoopOptions,
-    settings: AutopilotLoopSettings,
-    tick_settings: AutopilotLoopTickSettings,
-    max_iterations: Option<usize>,
+    settings: AutopilotLaneWorkerSettings,
     cancellation: Arc<AtomicBool>,
+    shared_plan: Arc<SharedAutopilotPlan>,
     sender: mpsc::Sender<AutopilotLaneWorkerMessage>,
 ) {
     let mut iteration = 1usize;
     let mut error_attempt = 0u32;
     loop {
-        if max_iterations.is_some_and(|limit| iteration > limit) {
+        if settings
+            .max_iterations
+            .is_some_and(|limit| iteration > limit)
+        {
             let _ = sender.send(AutopilotLaneWorkerMessage::Stopped {
                 lane,
                 reason: "max_iterations".into(),
@@ -812,11 +978,14 @@ fn run_autopilot_lane_worker(
             break;
         }
 
-        let (plan, plan_error) = match build_autopilot_plan(&options.workflow_path) {
-            Ok(plan) => (Some(plan), None),
-            Err(error) => (None, Some(error.to_string())),
-        };
-        let lane_plan = autopilot_plan_lane(plan.as_ref(), lane.name()).cloned();
+        let plan_read = shared_plan.read_or_refresh(&cancellation, || {
+            with_github_graphql_request_context(
+                format!("autopilot.{}.selection_refresh", lane.name()),
+                Some(Arc::clone(&cancellation)),
+                || build_autopilot_plan(&options.workflow_path).map_err(|error| error.to_string()),
+            )
+        });
+        let lane_plan = autopilot_plan_lane(plan_read.snapshot.as_deref(), lane.name()).cloned();
         if sender
             .send(AutopilotLaneWorkerMessage::Running {
                 lane,
@@ -828,11 +997,43 @@ fn run_autopilot_lane_worker(
             break;
         }
 
-        let mut result = lane.tick(&options, &tick_settings, plan.as_ref());
-        if let Some(error) = plan_error {
+        let mut result = with_github_graphql_request_context(
+            format!("autopilot.{}.targeted_tick", lane.name()),
+            Some(Arc::clone(&cancellation)),
+            || {
+                lane.tick(
+                    &options,
+                    &settings.tick_settings,
+                    plan_read.snapshot.as_deref(),
+                )
+            },
+        );
+        result.evidence.push(format!(
+            "selection_snapshot_generation={} source={} scope=process",
+            plan_read.generation,
+            if plan_read.refreshed {
+                "shared_refresh"
+            } else {
+                "shared_snapshot"
+            }
+        ));
+        if let Some(error) = plan_read.error {
             result
                 .evidence
                 .push(format!("plan_snapshot_error={}", compact_evidence(&error)));
+        }
+        let snapshot_invalidated = options.write
+            && lane_plan
+                .as_ref()
+                .and_then(|plan| plan.selected_issue.as_ref())
+                .is_some()
+            && shared_plan.invalidate(plan_read.generation);
+        if snapshot_invalidated {
+            result.evidence.push(format!(
+                "selection_snapshot_invalidated generation={} lane={} reason=write_capable_tick",
+                plan_read.generation,
+                lane.name()
+            ));
         }
         let had_error = result.status == "error";
         if had_error {
@@ -840,8 +1041,9 @@ fn run_autopilot_lane_worker(
         } else {
             error_attempt = 0;
         }
-        let parked_queues = plan
-            .map(|snapshot| snapshot.parked_queues)
+        let parked_queues = plan_read
+            .snapshot
+            .map(|snapshot| snapshot.parked_queues.clone())
             .unwrap_or_default();
         if sender
             .send(AutopilotLaneWorkerMessage::Finished(
@@ -857,14 +1059,14 @@ fn run_autopilot_lane_worker(
             break;
         }
 
-        if !autopilot_should_continue(iteration, max_iterations) {
+        if !autopilot_should_continue(iteration, settings.max_iterations) {
             iteration = iteration.saturating_add(1);
             continue;
         }
         let delay_ms = if had_error {
-            autopilot_lane_error_backoff_ms(settings.poll_interval_ms, error_attempt)
+            autopilot_lane_error_backoff_ms(settings.loop_settings.poll_interval_ms, error_attempt)
         } else {
-            settings.poll_interval_ms
+            settings.loop_settings.poll_interval_ms
         };
         if autopilot_sleep_or_cancel(delay_ms, &cancellation) {
             let _ = sender.send(AutopilotLaneWorkerMessage::Stopped {
@@ -2228,6 +2430,8 @@ fn print_autopilot_stopped(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::Barrier;
 
     #[test]
     fn autopilot_lane_tick_requires_ready_selected_issue() {
@@ -2654,6 +2858,89 @@ mod tests {
         assert!(quiet.is_empty());
         assert!(verbose.contains("autopilot_loop_result supervisor_cycle=3"));
         assert!(verbose.contains("autopilot_loop_lane lane=merge status=completed"));
+    }
+
+    #[test]
+    fn shared_plan_refresh_is_single_flight_for_three_lanes() {
+        let cache = Arc::new(SharedPlanCache::seeded(1usize));
+        assert!(cache.invalidate(1));
+        let refreshes = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(3));
+
+        let handles = (0..3)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let refreshes = Arc::clone(&refreshes);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    let cancellation = Arc::new(AtomicBool::new(false));
+                    barrier.wait();
+                    cache.read_or_refresh(&cancellation, || {
+                        refreshes.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(25));
+                        Ok(2usize)
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let reads = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+        assert_eq!(reads.iter().filter(|read| read.refreshed).count(), 1);
+        assert!(reads.iter().all(|read| read.generation == 2));
+        assert!(reads
+            .iter()
+            .all(|read| read.snapshot.as_deref() == Some(&2usize)));
+    }
+
+    #[test]
+    fn stale_generation_cannot_invalidate_a_newer_snapshot() {
+        let cache = SharedPlanCache::seeded(1usize);
+        assert!(cache.invalidate(1));
+        let cancellation = Arc::new(AtomicBool::new(false));
+        let refreshed = cache.read_or_refresh(&cancellation, || Ok(2usize));
+        assert_eq!(refreshed.generation, 2);
+        assert!(!cache.invalidate(1));
+
+        let cached = cache.read_or_refresh(&cancellation, || -> Result<usize, String> {
+            panic!("newer shared snapshot should not refresh")
+        });
+        assert_eq!(cached.generation, 2);
+        assert_eq!(cached.snapshot.as_deref(), Some(&2usize));
+    }
+
+    #[test]
+    fn shared_plan_waiter_can_cancel_while_refresh_is_in_flight() {
+        let cache = Arc::new(SharedPlanCache::seeded(1usize));
+        assert!(cache.invalidate(1));
+        let refresh_started = Arc::new(Barrier::new(2));
+        let cache_for_refresh = Arc::clone(&cache);
+        let started_for_refresh = Arc::clone(&refresh_started);
+        let refresh_handle = thread::spawn(move || {
+            let cancellation = Arc::new(AtomicBool::new(false));
+            cache_for_refresh.read_or_refresh(&cancellation, || {
+                started_for_refresh.wait();
+                thread::sleep(Duration::from_millis(100));
+                Ok(2usize)
+            })
+        });
+
+        refresh_started.wait();
+        let cancellation = Arc::new(AtomicBool::new(true));
+        let cancelled = cache.read_or_refresh(&cancellation, || Ok(3usize));
+        assert_eq!(cancelled.snapshot, None);
+        assert!(cancelled
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("cancelled")));
+        assert_eq!(
+            refresh_handle.join().unwrap().snapshot.as_deref(),
+            Some(&2usize)
+        );
     }
 }
 

--- a/src/main/tests/main_loop.rs
+++ b/src/main/tests/main_loop.rs
@@ -329,6 +329,24 @@ fn run_loop_claim_action_uses_tracker_claim_decision() {
 }
 
 #[test]
+fn targeted_claim_revalidation_refuses_state_changed_after_cached_selection() {
+    let config = test_config();
+    let selected_from_snapshot = tracker_issue("Todo");
+    let targeted_live_read = tracker_issue("Agent Review");
+
+    assert_eq!(
+        run_loop_claim_action(&selected_from_snapshot, &config),
+        RunLoopClaimAction::Claim
+    );
+    assert_eq!(
+        run_loop_claim_action(&targeted_live_read, &config),
+        RunLoopClaimAction::StopAndReplan {
+            current_state: "Agent Review".into()
+        }
+    );
+}
+
+#[test]
 fn live_gate_blocks_missing_assignee_without_override() {
     let config = live_github_config();
     let issue = tracker_issue("Todo");

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -22,7 +22,7 @@ pub use error::{
     TrackerError,
 };
 pub use follow_up::FollowUpIssueInput;
-pub use github::GithubProjectReadMode;
+pub use github::{with_github_graphql_request_context, GithubProjectReadMode};
 pub use linear::LinearAdapter;
 pub use memory::MemoryTracker;
 pub use project_field::ProjectFieldAssignment;

--- a/src/tracker/github/cli.rs
+++ b/src/tracker/github/cli.rs
@@ -1,7 +1,15 @@
+use std::cell::RefCell;
 use std::fs;
 use std::process::{Command, Output, Stdio};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex, OnceLock,
+};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
 
 use crate::config::RuntimeConfig;
 
@@ -22,6 +30,249 @@ pub(in crate::tracker) fn gh_available() -> bool {
 enum GithubCliApi {
     Graphql,
     RestJson,
+}
+
+#[derive(Clone, Default)]
+struct GithubGraphqlRequestContext {
+    action: String,
+    cancellation: Option<Arc<AtomicBool>>,
+}
+
+thread_local! {
+    static GITHUB_GRAPHQL_REQUEST_CONTEXT: RefCell<GithubGraphqlRequestContext> =
+        RefCell::new(GithubGraphqlRequestContext::default());
+}
+
+struct GithubGraphqlRequestContextGuard(Option<GithubGraphqlRequestContext>);
+
+impl Drop for GithubGraphqlRequestContextGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = self.0.take() {
+            GITHUB_GRAPHQL_REQUEST_CONTEXT.with(|context| {
+                context.replace(previous);
+            });
+        }
+    }
+}
+
+/// Runs a tracker operation with bounded, secret-free GitHub GraphQL action
+/// evidence and optional cancellation for a shared rate-limit cooldown.
+///
+/// The context is thread-local while the cooldown is process-local, matching
+/// one workflow/runtime profile per Shea process without creating durable or
+/// cross-repository coordination.
+pub fn with_github_graphql_request_context<T>(
+    action: impl Into<String>,
+    cancellation: Option<Arc<AtomicBool>>,
+    operation: impl FnOnce() -> T,
+) -> T {
+    let previous = GITHUB_GRAPHQL_REQUEST_CONTEXT.with(|context| {
+        context.replace(GithubGraphqlRequestContext {
+            action: action.into(),
+            cancellation,
+        })
+    });
+    let _guard = GithubGraphqlRequestContextGuard(Some(previous));
+    operation()
+}
+
+fn github_graphql_request_context() -> GithubGraphqlRequestContext {
+    GITHUB_GRAPHQL_REQUEST_CONTEXT.with(|context| context.borrow().clone())
+}
+
+const GITHUB_GRAPHQL_COOLDOWN_FALLBACK_MS: u64 = 1_000;
+const GITHUB_GRAPHQL_COOLDOWN_MAX_MS: u64 = 3_600_000;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GithubGraphqlBudgetEvidence {
+    operation: String,
+    action: String,
+    cost: Option<i64>,
+    remaining: Option<i64>,
+    reset_at: Option<String>,
+    reset_at_ms: Option<u64>,
+}
+
+impl GithubGraphqlBudgetEvidence {
+    fn from_response(args: &[String], response: &serde_json::Value) -> Self {
+        let reset_at = response
+            .pointer("/data/rateLimit/resetAt")
+            .and_then(serde_json::Value::as_str)
+            .map(ToOwned::to_owned);
+        Self {
+            operation: github_graphql_operation(args),
+            action: github_graphql_action(),
+            cost: response
+                .pointer("/data/rateLimit/cost")
+                .and_then(serde_json::Value::as_i64),
+            remaining: response
+                .pointer("/data/rateLimit/remaining")
+                .and_then(serde_json::Value::as_i64),
+            reset_at_ms: reset_at
+                .as_deref()
+                .and_then(parse_github_graphql_reset_at_ms),
+            reset_at,
+        }
+    }
+
+    fn without_response(args: &[String]) -> Self {
+        Self {
+            operation: github_graphql_operation(args),
+            action: github_graphql_action(),
+            cost: None,
+            remaining: None,
+            reset_at: None,
+            reset_at_ms: None,
+        }
+    }
+
+    fn compact(&self) -> String {
+        format!(
+            "operation={} action={} cost={} remaining={} reset_at={}",
+            self.operation,
+            self.action,
+            self.cost
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unavailable".into()),
+            self.remaining
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "unavailable".into()),
+            self.reset_at.as_deref().unwrap_or("unavailable")
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+struct GithubGraphqlCooldownState {
+    until_ms: u64,
+    reset_at: Option<String>,
+    decision_id: u64,
+    announced_decision_id: u64,
+}
+
+#[derive(Debug, Default)]
+struct GithubGraphqlCooldown {
+    state: Mutex<GithubGraphqlCooldownState>,
+}
+
+impl GithubGraphqlCooldown {
+    fn schedule(&self, evidence: &GithubGraphqlBudgetEvidence, now_ms: u64) -> bool {
+        let provider_deadline = evidence.reset_at_ms.filter(|deadline| *deadline > now_ms);
+        let until_ms = provider_deadline
+            .unwrap_or_else(|| now_ms.saturating_add(GITHUB_GRAPHQL_COOLDOWN_FALLBACK_MS))
+            .min(now_ms.saturating_add(GITHUB_GRAPHQL_COOLDOWN_MAX_MS));
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if state.until_ms >= until_ms && state.until_ms > now_ms {
+            return false;
+        }
+        state.until_ms = until_ms;
+        state.reset_at = evidence.reset_at.clone();
+        state.decision_id = state.decision_id.saturating_add(1);
+        eprintln!(
+            "github_graphql_cooldown scope=process decision=wait_until_reset decision_id={} delay_ms={} {}",
+            state.decision_id,
+            until_ms.saturating_sub(now_ms),
+            evidence.compact()
+        );
+        true
+    }
+
+    fn wait(&self) -> Result<(), TrackerError> {
+        loop {
+            let now_ms = unix_time_ms();
+            let (until_ms, decision_id, reset_at, announce) = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .unwrap_or_else(|poison| poison.into_inner());
+                if state.until_ms <= now_ms {
+                    state.until_ms = 0;
+                    state.reset_at = None;
+                    return Ok(());
+                }
+                let announce = state.announced_decision_id != state.decision_id;
+                if announce {
+                    state.announced_decision_id = state.decision_id;
+                }
+                (
+                    state.until_ms,
+                    state.decision_id,
+                    state.reset_at.clone(),
+                    announce,
+                )
+            };
+            if announce {
+                eprintln!(
+                    "github_graphql_cooldown scope=process status=waiting decision_id={} due_in_ms={} reset_at={}",
+                    decision_id,
+                    until_ms.saturating_sub(now_ms),
+                    reset_at.as_deref().unwrap_or("unavailable")
+                );
+            }
+            if github_graphql_request_context()
+                .cancellation
+                .is_some_and(|cancellation| cancellation.load(Ordering::SeqCst))
+            {
+                return Err(TrackerError::IntegrationUnavailable(
+                    "GitHub GraphQL shared rate-limit cooldown cancelled".into(),
+                ));
+            }
+            thread::sleep(Duration::from_millis(
+                until_ms.saturating_sub(now_ms).min(250),
+            ));
+        }
+    }
+}
+
+fn github_graphql_cooldown() -> &'static GithubGraphqlCooldown {
+    static COOLDOWN: OnceLock<GithubGraphqlCooldown> = OnceLock::new();
+    COOLDOWN.get_or_init(GithubGraphqlCooldown::default)
+}
+
+fn github_graphql_action() -> String {
+    let action = github_graphql_request_context().action;
+    if action.trim().is_empty() {
+        "tracker.unspecified".into()
+    } else {
+        action
+    }
+}
+
+fn github_graphql_operation(args: &[String]) -> String {
+    let query = args
+        .iter()
+        .find_map(|arg| arg.strip_prefix("query="))
+        .unwrap_or_default();
+    let mut tokens = query.split_whitespace();
+    while let Some(token) = tokens.next() {
+        if matches!(token, "query" | "mutation") {
+            return tokens
+                .next()
+                .unwrap_or("anonymous")
+                .split(['(', '{'])
+                .next()
+                .unwrap_or("anonymous")
+                .to_string();
+        }
+    }
+    "anonymous".into()
+}
+
+fn parse_github_graphql_reset_at_ms(value: &str) -> Option<u64> {
+    let timestamp = OffsetDateTime::parse(value, &Rfc3339).ok()?;
+    u64::try_from(timestamp.unix_timestamp_nanos() / 1_000_000).ok()
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 impl GithubCliApi {
@@ -64,7 +315,12 @@ impl GithubCliAccess {
                 Err(error) if project_state_error_is_retryable(&error) => {
                     last_error = Some(error);
                     if attempt < Self::MAX_ATTEMPTS {
-                        thread::sleep(project_state_retry_delay(attempt));
+                        if !last_error.as_ref().is_some_and(|error| {
+                            classify_project_state_error(error)
+                                == ProjectStateFailureKind::RateLimit
+                        }) {
+                            thread::sleep(project_state_retry_delay(attempt));
+                        }
                     } else {
                         break;
                     }
@@ -107,11 +363,25 @@ impl GithubCliAccess {
         api: GithubCliApi,
         args: &[String],
     ) -> Result<serde_json::Value, TrackerError> {
+        if api == GithubCliApi::Graphql {
+            github_graphql_cooldown().wait()?;
+        }
         let output = run_gh_command(args, api.operation_label())?;
 
         if !output.status.success() {
             let message = String::from_utf8_lossy(&output.stderr).trim().to_string();
             let kind = classify_project_state_failure_message(&message);
+            if api == GithubCliApi::Graphql && kind == ProjectStateFailureKind::RateLimit {
+                let evidence = GithubGraphqlBudgetEvidence::without_response(args);
+                github_graphql_cooldown().schedule(&evidence, unix_time_ms());
+                return Err(TrackerError::IntegrationUnavailable(format!(
+                    "{} failed kind={}: {}; github_graphql_budget {}",
+                    api.operation_label(),
+                    kind.as_str(),
+                    message,
+                    evidence.compact()
+                )));
+            }
             return Err(TrackerError::IntegrationUnavailable(format!(
                 "{} failed kind={}: {message}",
                 api.operation_label(),
@@ -123,7 +393,24 @@ impl GithubCliAccess {
             serde_json::from_slice(&output.stdout).map_err(|error| {
                 TrackerError::Payload(format!("{}: {error}", api.invalid_json_label()))
             })?;
-        api.validate_response(&response)?;
+        if api == GithubCliApi::Graphql {
+            let evidence = GithubGraphqlBudgetEvidence::from_response(args, &response);
+            eprintln!("github_graphql_budget {}", evidence.compact());
+            if evidence.remaining == Some(0) {
+                github_graphql_cooldown().schedule(&evidence, unix_time_ms());
+            }
+            if let Err(error) = api.validate_response(&response) {
+                if classify_project_state_error(&error) == ProjectStateFailureKind::RateLimit {
+                    github_graphql_cooldown().schedule(&evidence, unix_time_ms());
+                }
+                return Err(TrackerError::IntegrationUnavailable(format!(
+                    "{error}; github_graphql_budget {}",
+                    evidence.compact()
+                )));
+            }
+        } else {
+            api.validate_response(&response)?;
+        }
         Ok(response)
     }
 }
@@ -317,4 +604,108 @@ fn project_state_retry_delay(attempt: usize) -> Duration {
         2 => 1_000,
         _ => 2_000,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graphql_args(operation: &str) -> Vec<String> {
+        vec![
+            "api".into(),
+            "graphql".into(),
+            "-f".into(),
+            format!("query=query {operation} {{ rateLimit {{ cost remaining resetAt }} }}"),
+        ]
+    }
+
+    #[test]
+    fn graphql_budget_evidence_parses_operation_and_provider_reset() {
+        let response = serde_json::json!({
+            "data": {
+                "rateLimit": {
+                    "cost": 7,
+                    "remaining": 42,
+                    "resetAt": "2026-08-07T20:30:00Z"
+                }
+            }
+        });
+
+        let evidence =
+            with_github_graphql_request_context("autopilot.main.selection_refresh", None, || {
+                GithubGraphqlBudgetEvidence::from_response(&graphql_args("FixturePlan"), &response)
+            });
+
+        assert_eq!(evidence.operation, "FixturePlan");
+        assert_eq!(evidence.action, "autopilot.main.selection_refresh");
+        assert_eq!(evidence.cost, Some(7));
+        assert_eq!(evidence.remaining, Some(42));
+        assert!(evidence.reset_at_ms.is_some());
+        assert!(!evidence.compact().contains("token"));
+    }
+
+    #[test]
+    fn graphql_reset_parser_rejects_missing_or_malformed_evidence() {
+        assert!(parse_github_graphql_reset_at_ms("2026-08-07T20:30:00Z").is_some());
+        assert_eq!(parse_github_graphql_reset_at_ms("soon"), None);
+        assert_eq!(parse_github_graphql_reset_at_ms(""), None);
+    }
+
+    #[test]
+    fn shared_cooldown_deduplicates_equivalent_lane_decisions() {
+        let cooldown = GithubGraphqlCooldown::default();
+        let now_ms = 1_000;
+        let evidence = GithubGraphqlBudgetEvidence {
+            operation: "FixturePlan".into(),
+            action: "autopilot.main.selection_refresh".into(),
+            cost: Some(1),
+            remaining: Some(0),
+            reset_at: Some("1970-01-01T00:00:03Z".into()),
+            reset_at_ms: Some(3_000),
+        };
+
+        assert!(cooldown.schedule(&evidence, now_ms));
+        assert!(!cooldown.schedule(&evidence, now_ms));
+        assert!(!cooldown.schedule(&evidence, now_ms));
+
+        let state = cooldown
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        assert_eq!(state.decision_id, 1);
+        assert_eq!(state.until_ms, 3_000);
+    }
+
+    #[test]
+    fn shared_cooldown_uses_bounded_fallback_and_honors_cancellation() {
+        let cooldown = GithubGraphqlCooldown::default();
+        let now_ms = unix_time_ms();
+        let evidence = GithubGraphqlBudgetEvidence {
+            operation: "FixturePlan".into(),
+            action: "autopilot.review.selection_refresh".into(),
+            cost: None,
+            remaining: None,
+            reset_at: Some("malformed".into()),
+            reset_at_ms: None,
+        };
+        assert!(cooldown.schedule(&evidence, now_ms));
+        {
+            let state = cooldown
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            assert_eq!(
+                state.until_ms,
+                now_ms.saturating_add(GITHUB_GRAPHQL_COOLDOWN_FALLBACK_MS)
+            );
+        }
+
+        let cancellation = Arc::new(AtomicBool::new(true));
+        let error = with_github_graphql_request_context(
+            "autopilot.review.selection_refresh",
+            Some(cancellation),
+            || cooldown.wait().unwrap_err(),
+        );
+        assert!(error.to_string().contains("cooldown cancelled"));
+    }
 }

--- a/src/tracker/github/mod.rs
+++ b/src/tracker/github/mod.rs
@@ -5,6 +5,7 @@ mod project_v2;
 mod queries;
 mod topology;
 
+pub use cli::with_github_graphql_request_context;
 pub use queries::GithubProjectReadMode;
 
 pub(in crate::tracker) use cli::{

--- a/src/tracker/github/queries.rs
+++ b/src/tracker/github/queries.rs
@@ -26,6 +26,11 @@ pub(in crate::tracker) fn github_project_query(
     format!(
         r#"
 query SheaSymphonyProject($owner: String!, $number: Int!, $cursor: String) {{
+  rateLimit {{
+    cost
+    remaining
+    resetAt
+  }}
   {owner_field}(login: $owner) {{
     projectV2(number: $number) {{
       items(first: {GITHUB_PROJECT_ITEM_PAGE_SIZE}, after: $cursor) {{
@@ -143,6 +148,11 @@ pub(in crate::tracker) fn github_issue_evidence_query() -> String {
     format!(
         r#"
 query SheaSymphonyIssueEvidence($owner: String!, $repo: String!, $number: Int!) {{
+  rateLimit {{
+    cost
+    remaining
+    resetAt
+  }}
   repository(owner: $owner, name: $repo) {{
     issue(number: $number) {{
       id
@@ -191,6 +201,11 @@ pub(in crate::tracker) fn github_issue_project_item_query() -> String {
     format!(
         r#"
 query SheaSymphonyIssueProjectItem($owner: String!, $repo: String!, $number: Int!) {{
+  rateLimit {{
+    cost
+    remaining
+    resetAt
+  }}
   repository(owner: $owner, name: $repo) {{
     issue(number: $number) {{
       __typename
@@ -296,6 +311,11 @@ pub(in crate::tracker) fn github_project_metadata_query(owner_field: &str) -> St
     format!(
         r#"
 query SheaSymphonyProjectMetadata($owner: String!, $number: Int!) {{
+  rateLimit {{
+    cost
+    remaining
+    resetAt
+  }}
   {owner_field}(login: $owner) {{
     projectV2(number: $number) {{
       id
@@ -371,6 +391,11 @@ pub(in crate::tracker) fn github_issue_comments_query() -> String {
     format!(
         r#"
 query SheaSymphonyIssueComments($issueId: ID!) {{
+  rateLimit {{
+    cost
+    remaining
+    resetAt
+  }}
   node(id: $issueId) {{
     ... on Issue {{
       comments(first: {GITHUB_WORKPAD_COMMENT_PAGE_SIZE}) {{
@@ -421,6 +446,11 @@ mutation SheaSymphonyCloseIssue($issueId: ID!) {
 
 pub(in crate::tracker) const GITHUB_REPOSITORY_ID_QUERY: &str = r#"
 query SheaSymphonyRepositoryId($owner: String!, $repo: String!) {
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
   repository(owner: $owner, name: $repo) {
     id
   }
@@ -448,3 +478,33 @@ mutation SheaSymphonyAddProjectItem($projectId: ID!, $contentId: ID!) {
   }
 }
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn graphql_read_queries_request_rate_limit_evidence() {
+        let queries = [
+            github_project_query("user", GithubProjectReadMode::QueueScan),
+            github_issue_evidence_query(),
+            github_issue_project_item_query(),
+            github_project_metadata_query("user"),
+            github_issue_comments_query(),
+            GITHUB_REPOSITORY_ID_QUERY.to_string(),
+        ];
+
+        for query in queries {
+            assert!(
+                query.contains("rateLimit"),
+                "query omitted rateLimit: {query}"
+            );
+            assert!(query.contains("cost"), "query omitted cost: {query}");
+            assert!(
+                query.contains("remaining"),
+                "query omitted remaining: {query}"
+            );
+            assert!(query.contains("resetAt"), "query omitted resetAt: {query}");
+        }
+    }
+}

--- a/src/tracker/state.rs
+++ b/src/tracker/state.rs
@@ -47,7 +47,7 @@ pub(in crate::tracker) fn issue_matches_assignee_filter(
     let allowed: Vec<String> = current_login
         .into_iter()
         .chain(filter.additional_assignees.iter().map(String::as_str))
-        .map(|assignee| normalize_state(assignee))
+        .map(normalize_state)
         .collect();
 
     issue


### PR DESCRIPTION
## Summary

- share one immutable, single-flight Autopilot selection-plan generation across concurrently enabled Main, Review, and Merge workers
- invalidate consumed generations after write-capable selected ticks while preserving targeted live issue/PR reads before every mutation
- emit secret-free GitHub GraphQL operation/cost/remaining/reset evidence and coordinate one cancellation-aware, reset-based cooldown per Shea process
- cover three-lane request de-duplication, generation safety, reset parsing/fallback, cooldown sharing, cancellation, query shape, and stale-state refusal
- document the selection-snapshot versus mutation-freshness boundary and process-local scope

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (825 tests across all repository test targets)
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
- `cargo build --release`
- release binary SHA-256: `465d436dec7411105fe00d36938506a13663e2e0908606d023db870c328cb91f`
- targeted live issue read through the changed binary: `SheaSymphonyIssueProjectItem`, cost `1`, remaining `3811`, provider reset `2026-08-07T18:32:40Z`

## Boundaries

- targets protected `2606-MVP`; no 2607/`main` Temporal forward-port
- no credential, GitHub App, cross-process, or cross-repository coordination changes
- downstream binary replacement/restart and three-repository UAT remain explicit operator-controlled review work

Closes #488
