### PR TITLE
#515: Backport Claude stream-json transport to 2606-MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "crossterm",
+ "libc",
  "liquid",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.28"
+libc = "0.2"
 liquid = "0.26.11"
 ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }

--- a/docs/bootstrap-parity-audit.md
+++ b/docs/bootstrap-parity-audit.md
@@ -48,7 +48,7 @@ must not be edited by Shea Symphony implementation work.
 | Issue Quality Gate | Landed | `src/quality_gate.rs`, `docs/bootstrap/ISSUE_QUALITY_GATE_TEMPLATE.md` | Semantic/LLM-assisted checks remain optional and conservative. |
 | Issue Forge | Partial | `src/issue_forge.rs`, README command docs | Tracker creation exists; richer field setup and conversational UI remain follow-ups. |
 | Workspace lifecycle | Partial | `src/workspace.rs`, `src/handoff.rs`, `src/git_handoff.rs`, `clean plan` command | Terminal cleanup planning exists; automatic runtime cleanup and remote/SSH parity are not complete. |
-| Agent backend abstraction | Partial | `src/agent.rs`, Codex/Claude subprocess workflows | Full Codex app-server and Claude Code protocol parity are deferred. |
+| Agent backend abstraction | Implemented | `src/agent.rs`, Codex app-server transport, Claude Code stream-json workflow | Codex and Claude expose the same normalized lane lifecycle through their native structured transports. |
 | Run loop/orchestrator | Partial | `src/orchestrator.rs`, `src/main.rs`, `src/runtime_state.rs`, `autopilot plan`, `autopilot loop` | Bounded foreground all-lane supervision exists; unbounded daemon/background operation, richer reconciliation, and fully autonomous operation are not complete. |
 | Agent Review boundary | Partial | `src/review.rs`, `review loop`, review job ledger docs | Bounded `review loop` and durable review evidence exist; persistent background reviewer supervision is still incomplete. |
 | Merging lane | Partial | `src/merge_lane.rs`, `merge once`, `merge loop` command | Guarded one-shot and bounded pool landing exist; unbounded continuous merge polling and richer reconciliation are not complete. |
@@ -74,7 +74,7 @@ These items remain blockers for claiming broad self-running parity:
 
 1. Full Codex app-server protocol parity with session, turn, usage, and
    rate-limit accounting.
-2. Full Claude Code protocol parity beyond conservative subprocess execution.
+2. Richer optional dynamic-tool integration beyond the current structured lane transports.
 3. Persistent or unbounded worker supervision with retry, continuation, stall
    recovery, and terminal workspace cleanup wired into reconciliation. Bounded
    foreground Autoloop is not a daemon and does not close this obligation

--- a/docs/claude-code-stream-json.md
+++ b/docs/claude-code-stream-json.md
@@ -1,0 +1,81 @@
+# Claude Code stream-json transport
+
+Shea Symphony uses Claude Code's non-interactive `stream-json` protocol for
+Main execution and semantic Merge-agent repair. This is lane-level lifecycle
+parity with the Codex backend; it is not a Claude implementation of the Codex
+app-server protocol. Review remains a separate backend and is not supported by
+this transport.
+
+## Configuration boundary
+
+```yaml
+main_lane:
+  backend: claude-code
+merge_lane:
+  agent_backend: claude-code
+claude:
+  command: claude
+  turn_timeout_ms: 3600000
+```
+
+`claude.command` is an executable, executable plus base arguments, or an
+operator wrapper. Shea appends `-p --input-format stream-json --output-format
+stream-json --verbose` and, for a validated recovery, `--resume <session-id>`.
+The configured command owns model choice, authentication, gateway routing,
+environment, and permission arguments. Prefer an executable wrapper or a base
+command such as `env PROFILE=shea claude`; do not add shell pipelines or
+redirections because Shea executes the final command with `exec` for reliable
+process cleanup.
+
+Shea writes one JSONL user message to stdin and requires an initialization
+event followed by an explicit terminal result. Assistant text, tool use, tool
+results, usage, errors, and terminal state are normalized into the existing
+lane event contract. Raw protocol, stderr, normalized events, prompt, process
+ID, Shea run ID, and Claude session ID are stored below the configured artifact
+roots. Environment values are passed to the worker but are not copied into
+event messages.
+
+A zero exit code without a successful result is not success. Malformed or
+truncated JSONL, session-ID changes, error results, timeout, cancellation, and
+nonzero exit all fail closed. Timeout cleanup signals the entire Unix child
+process group before force-killing its leader.
+
+Resume is Main-lane recovery only. Shea passes `--resume` only when the session
+registry record matches the issue ID and identifier, `main` lane, run ID,
+worktree path, Claude backend/source, and recorded session ID. Merge repair
+starts a fresh session and retains its own prompt and routing authority. Clean
+mechanical merge handling never launches Claude.
+
+See the official [Claude Code CLI reference](https://code.claude.com/docs/en/cli-usage)
+for the underlying flags and session contract.
+
+## Deterministic fixture
+
+```bash
+cargo test agent::tests::claude_code_backend
+```
+
+Protocol fixtures under `examples/fixtures/claude-stream-json-*.jsonl` cover
+initialization, assistant and tool progress, usage, success, error,
+cancellation, malformed JSON, truncation, resume arguments, timeout cleanup,
+and process exit. `examples/claude-stream-json-workflow.md` shows a
+credential-free wrapper configuration.
+
+## Local-worktree-only UAT
+
+The ignored test creates disposable `main` and `merge` directories, asks the
+configured Claude command to modify one small file in each, validates the
+result, checks structured session/artifact evidence, and deletes the temporary
+directories when the test exits:
+
+```bash
+SHEA_CLAUDE_UAT_COMMAND='claude' \
+  cargo test claude_code_live_local_worktree_uat -- --ignored --nocapture
+```
+
+An operator wrapper can be supplied instead, including its own model, gateway,
+authentication, environment, and permission flags. The UAT calls the backend
+directly: it does not read or mutate GitHub Project state, push a branch, create
+a PR, or invoke the Main/Merge tracker controllers. Inspect the printed failure
+or the temporary artifact path before rerunning if the command cannot
+authenticate or its permission policy prevents the requested local edits.

--- a/docs/cli-command-reference.md
+++ b/docs/cli-command-reference.md
@@ -345,7 +345,14 @@ the current local app-server approval-policy schema. `autopilot loop` itself is
 neither backend; it is the foreground CLI supervisor that invokes Main, Review,
 and Merge lane commands. `main loop --write` records prompt, protocol, stderr,
 normalized-event, runtime-state, and session-registry evidence for that
-app-server turn before any `Agent Review` handoff. If `main_lane.backend: tmux`
+app-server turn before any `Agent Review` handoff. Selecting
+`main_lane.backend: claude-code` or `merge_lane.agent_backend: claude-code`
+uses the same lane result contract through Claude Code's non-interactive
+stream-json CLI. Shea appends the protocol and resume flags to
+`claude.command`, persists raw and normalized evidence, and fails closed unless
+an initialized session produces an explicit successful result. The command or
+wrapper retains model, authentication, gateway, environment, and permission
+ownership; see `docs/claude-code-stream-json.md`. If `main_lane.backend: tmux`
 is selected as explicit fallback/debug, the tmux path records its session name,
 log path, workspace, branch, attach command, prompt artifact, actor, lane,
 attempt, and running status in the durable session registry under the configured
@@ -376,7 +383,8 @@ starts the configured lane runtime with the lane-specific prompt only after
 confirming that the Project claim field already matches the issue, lane, and
 run. Manual claim evidence is truthful non-runtime registry evidence; `session
 start` never writes claim fields. Main and Merge-agent sessions default to Codex
-app-server in the canonical workflow, while Review session start remains the
+app-server in the canonical workflow and may both select the shared Claude
+stream-json backend, while Review session start remains the
 supervised tmux fallback; set `main_lane.backend: tmux` or
 `merge_lane.agent_backend: tmux` only for explicit fallback/debug. Clean
 `merge once` / `merge loop` does not use this agent-session backend and remains

--- a/docs/dogfood-readiness.md
+++ b/docs/dogfood-readiness.md
@@ -22,7 +22,7 @@ Shea Symphony is not a daemon or unattended background service yet.
 | Orchestrator | Deterministic dispatch planning and a CLI `main loop` skeleton with bounded modes, idle polling, claim-helper use, dependency preflight for `Todo` / `Rework`, parent execution gating that skips or rejects native parent issues until every native subissue has Project status `Done`, runtime-state persistence, tracker-visible advisory ownership markers, resume preflight, retry backoff records, stall detection, `main loop --write` default recover-first restart for interrupted Main runtime slots, live PR handoff plus tracker PR link recording in non-fixture GitHub mode, ready/non-draft PR enforcement before Agent Review handoff, parent/subissue branch target selection for native subissues and parent final PRs, guarded `merge once` and bounded `merge loop` lanes for `Merging` issues, `merge loop --write` default tracker-first recovery for interrupted structured merge-loop/goal claims, read-only `autopilot plan` that composes Main/Review/Merge lane preflight and parked operator queues without launching workers, bounded foreground Autoloop (`autopilot loop`) that runs Main, Review, and Merge ticks in order with explicit `--write`, per-lane concurrency flags, recover-first Main/Merge handling, status/backoff/cancellation reporting, `--max-concurrent` selection guarded by `Main Agent` / `Merging Agent` Project fields, multi-entry Main runtime slot persistence with backwards-compatible single-state loading, per-issue Main runtime preflight, read-only `debug` readiness reporting, and a bounded operator launcher script exist. Remaining gaps: no daemon/background Autoloop, no persistent app-server service mode, no unbounded merge idle polling, and full state reconciliation is still evolving. |
 | Workspace | Local path sanitization, creation, timeout-aware hooks, stdout/stderr capture, `before_remove`, safe cleanup helpers, grouped read-only `clean plan` / `clean audit` cleanup and persistence classification, guarded terminal cleanup planning, repository-local git identity application, workspace/branch/PR handoff planning with explicit branch target evidence, live git worktree/branch creation, issue-level `workspace list` / `workspace show` / `workspace adopt` discovery across registry, workpad, PR, and local git worktree evidence, reuse-first `workspace ensure` preparation for Review/Merge inspection under the configured workspace root with durable Workspace Evidence, dirty/no-op guards before branch push, optional configured verification commands before PR handoff, branch push, PR create-or-reuse, tracker PR link recording, main loop handoff evidence, profile-scoped workspace keys, parsed-but-unused SSH worker host config, a namespaced artifact layout, and dry-run cleanup planning exist. Automatic runtime cleanup, write-mode artifact cleanup, and live SSH execution are not wired yet. |
 | Execution profiles | First-slice profile discovery exists. Workflow config can point to a cockpit-tools Codex `codex_instances.json` file, and Shea Symphony treats each instance `name` as a profile/worker identity while ignoring account binding fields. If the cockpit-tools file is missing, explicit `profiles.entries` are used. This is not a full account manager. |
-| Agent backends | Dry-run backend plus Codex app-server, tmux fallback, and conservative Claude Code subprocess backends exist. The canonical Main runtime now defaults to Codex app-server through `main_lane.backend: codex` and `codex.command: codex app-server -c 'service_tier="fast"'`; `main loop --write` records prompt, raw protocol, stderr, normalized event, exit-status, runtime-state, and session-registry evidence for app-server turns before normal PR/handoff reconciliation. Autoloop (`autopilot loop`) is not an app-server, tmux session, or backend process by itself. It invokes the configured lane commands and preserves each lane runtime boundary. A local `tmux` backend remains available as explicit fallback/debug with attachable lane sessions and backend-aware status evidence. Manual break-glass recovery still claims with `main claim`, `review claim`, or `merge claim`, which records truthful registry evidence, before optional `session start --run <RUN_ID>`. Main and Merge-agent sessions default to Codex app-server, while clean `merge once` / `merge loop` remains direct CLI behavior and does not launch an agent runtime. Dynamic-tool execution and Claude Code protocol parity remain follow-ups. |
+| Agent backends | Dry-run, Codex app-server, Claude Code stream-json, and tmux fallback backends exist. The canonical Main runtime defaults to Codex app-server; operators may select `claude-code` for Main and semantic Merge-agent repair through one structured transport. Both structured backends record prompt, raw protocol, stderr, normalized events, exit status, runtime state, and session-registry evidence; Claude recovery additionally validates issue, lane, run, worktree, and session identity before `--resume`. Model, authentication, gateway, environment, and permission policy remain in the configured `claude.command` or wrapper. Autoloop is the foreground controller rather than a backend. Clean merge remains direct CLI behavior and never launches Claude. Review has its own backend abstraction and no Claude support here. Dynamic-tool execution remains a follow-up. |
 | Prompt rendering | Strict prompt rendering supports `issue.*`, `attempt`, and basic `{% if %}` / `{% else %}` blocks. The supported subset is documented in `docs/prompt-template-contract.md`; full Liquid compatibility remains a parity gap. |
 | Dynamic tools | A first-slice dynamic-tool registry can describe planned backend-specific tools such as Codex `linear_graphql` without coupling them to the orchestrator. Tool execution and Codex app-server dynamic-tool protocol wiring are not implemented yet. |
 | Agent Review | Finding classes, fake reviewer lifecycle, headless `agy` CLI review support with print prompt transport, configured model and timeout args, legacy Gemini CLI fallback support, role-bound transition decisions, evidence-first Rework diagnostics for confirmed findings and completed-but-inconclusive automatic reviews, invalid-handoff evidence when Agent Review receives a draft PR, parent/subissue-aware pass routing where routine native subissue PASS goes to `Merging` and parent/ordinary PASS goes to `Human Review`, `review freshness` evidence for Merging conflict repair, bounded `review loop` worker selection/reconciliation with one issue per worker slot, Project `Review Agent` claim markers before backend launch, health-aware review backend failure classification, recoverable wait/backoff retry while preserving `Agent Review`, non-recovering config/policy routing to `Need Human Input`, compact repeated-failure evidence, terminal manual review claim preservation, durable review job ledger records, and workpad/status evidence helpers exist. Persistent background review worker supervision is not implemented yet. |
@@ -239,8 +239,8 @@ Project v2 issues:
      boundary, and stop conditions.
    - Keep the prompt aligned with `docs/bootstrap/SHEA_WORKFLOW.md` as the
      bootstrap contract evolves.
-   - Harden the Codex and Claude Code subprocess backends, then implement full
-     protocol transports.
+   - Keep ordinary Codex subprocess compatibility separate from the dedicated
+     Codex app-server and Claude Code stream-json transports.
    - Route configured `codex app-server` commands through the dedicated stdio
      JSON-RPC transport and keep ordinary Codex commands on the subprocess path.
    - Use the app-server event normalizer as the protocol boundary for Codex
@@ -422,18 +422,18 @@ Acceptance:
 - handles failures without stalling the orchestrator.
 - keeps live tests credential/tool gated.
 
-### 2b. Implement Full Claude Code Protocol Backend
+### 2b. Claude Code stream-json protocol backend (implemented)
 
-Goal: evolve the conservative Claude Code subprocess path into the configured
-Claude Code protocol flow while preserving the normalized backend interface.
+Claude Code now uses the configured command or wrapper plus Shea-owned
+stream-json invocation, parsing, artifacts, timeout cleanup, and safe resume
+while preserving the normalized backend interface.
 
 Acceptance:
 
 - launches configured Claude Code command in workspace cwd.
-- starts a session or equivalent turn.
-- emits normalized backend events.
-- handles failures without stalling the orchestrator.
-- keeps live tests credential/tool gated.
+- records Claude and Shea session identity for Main and semantic Merge repair.
+- rejects malformed, truncated, cancelled, timed-out, and unexpected-exit runs.
+- keeps the local live UAT ignored and credential/operator-command gated.
 
 ### 3. Harden Workspace Hooks And Cleanup
 

--- a/docs/operator-dogfood.md
+++ b/docs/operator-dogfood.md
@@ -47,6 +47,14 @@ Fixture workflows can still use inline prompt bodies. If the canonical workflow
 declares lane prompts, all three lane paths must exist before agent
 initialization continues.
 
+Main and semantic Merge-agent repair may instead select the shared Claude Code
+stream-json transport with `main_lane.backend: claude-code` and/or
+`merge_lane.agent_backend: claude-code`. Shea owns the protocol flags, JSONL
+input, parsing, artifacts, timeout cleanup, and safe resume; the configured
+`claude.command` or wrapper owns model, gateway, authentication, environment,
+and permission policy. See `docs/claude-code-stream-json.md` for configuration,
+failure semantics, and the no-remote-write local UAT.
+
 After preflight, dry-run mode executes the all-lane foreground preview:
 
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,7 @@ memory-backed. They do not mutate live GitHub Project v2 state.
 | Workflow | Purpose | Notes |
 | --- | --- | --- |
 | `codex-subprocess-workflow.md` | Conservative Codex subprocess backend fixture. | Runs the configured command in the prepared workspace. |
-| `claude-subprocess-workflow.md` | Conservative Claude Code subprocess backend fixture. | Separate backend path from Codex; not full protocol parity. |
+| `claude-stream-json-workflow.md` | Claude Code stream-json backend fixture shared by Main and Merge-agent selection. | Credential-free structured protocol evidence; live command policy remains operator-owned. |
 | `cockpit-profiles-workflow.md` | Execution profile discovery from a cockpit-tools-style fixture. | Reads `fixtures/cockpit-tools-codex-instances.json`; no secrets are used. |
 
 ## Review And Quality Gate Fixtures
@@ -55,7 +55,8 @@ memory-backed. They do not mutate live GitHub Project v2 state.
 
 | Fixture | Used by |
 | --- | --- |
-| `fixtures/dry-run-issues.json` | `dry-run-workflow.md`, `codex-subprocess-workflow.md`, `claude-subprocess-workflow.md`, `review-fake-workflow.md`, `cockpit-profiles-workflow.md` |
+| `fixtures/dry-run-issues.json` | `dry-run-workflow.md`, `codex-subprocess-workflow.md`, `claude-stream-json-workflow.md`, `review-fake-workflow.md`, `cockpit-profiles-workflow.md` |
+| `fixtures/claude-stream-json-*.jsonl` | Claude structured success, error, cancellation, malformed, and truncated transport tests |
 | `fixtures/source-alignment-issues.json` | `source-alignment-workflow.md` |
 | `fixtures/usage-limit-issues.json` | `usage-limit-workflow.md` |
 | `fixtures/git-identity-issues.json` | `git-identity-workflow.md` |

--- a/examples/claude-stream-json-workflow.md
+++ b/examples/claude-stream-json-workflow.md
@@ -17,19 +17,23 @@ tracker:
   terminal_states:
     - Done
 workspace:
-  root: /tmp/shea-symphony-claude-subprocess-workspaces
+  root: /tmp/shea-symphony-claude-stream-json-workspaces
 main_lane:
   backend: claude-code
   max_concurrent_agents: 1
   max_turns: 1
   max_retry_backoff_ms: 300000
+merge_lane:
+  agent_backend: claude-code
+  max_concurrent_workers: 1
 claude:
-  command: "cat > claude-subprocess-output.md"
+  # Shea appends -p, stream-json input/output, --verbose, and --resume when needed.
+  command: sh examples/fixtures/claude-stream-json-wrapper.sh
   turn_timeout_ms: 1000
 observability:
   logs_root: log
 ---
 
-You are running a safe Claude Code fixture task for {{ issue.identifier }}.
+You are running a deterministic Claude Code stream-json fixture for {{ issue.identifier }}.
 
 Title: {{ issue.title }}

--- a/examples/fixtures/claude-stream-json-cancelled.jsonl
+++ b/examples/fixtures/claude-stream-json-cancelled.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","session_id":"claude-session-cancelled"}
+{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"claude-session-cancelled","result":"Claude Code process was cancelled"}

--- a/examples/fixtures/claude-stream-json-error.jsonl
+++ b/examples/fixtures/claude-stream-json-error.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","session_id":"claude-session-error"}
+{"type":"result","subtype":"error_during_execution","is_error":true,"session_id":"claude-session-error","result":"tool permission was denied"}

--- a/examples/fixtures/claude-stream-json-malformed.jsonl
+++ b/examples/fixtures/claude-stream-json-malformed.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","session_id":"claude-session-malformed"}
+{"type":"assistant","session_id":"claude-session-malformed","message":

--- a/examples/fixtures/claude-stream-json-success.jsonl
+++ b/examples/fixtures/claude-stream-json-success.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","session_id":"claude-session-510","cwd":"/fixture/worktree","tools":["Read","Edit","Bash"]}
+{"type":"assistant","session_id":"claude-session-510","message":{"role":"assistant","content":[{"type":"text","text":"Inspecting the issue worktree."},{"type":"tool_use","id":"tool-1","name":"Read","input":{"file_path":"README.md"}}],"usage":{"input_tokens":12,"output_tokens":7}}}
+{"type":"user","session_id":"claude-session-510","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"fixture","is_error":false}]}}
+{"type":"result","subtype":"success","is_error":false,"session_id":"claude-session-510","result":"Claude completed the fixture task.","duration_ms":25,"num_turns":1}

--- a/examples/fixtures/claude-stream-json-truncated.jsonl
+++ b/examples/fixtures/claude-stream-json-truncated.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","session_id":"claude-session-truncated"}
+{"type":"assistant","session_id":"claude-session-truncated","message":{"role":"assistant","content":[{"type":"text","text":"Work began but no result followed."}],"usage":{"input_tokens":3,"output_tokens":2}}}

--- a/examples/fixtures/claude-stream-json-wrapper.sh
+++ b/examples/fixtures/claude-stream-json-wrapper.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+# Deterministic protocol fixture: accepts Shea's official stream-json flags and input.
+cat >/dev/null
+cat "$(dirname "$0")/claude-stream-json-success.jsonl"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -303,12 +303,12 @@ impl AgentBackend for ClaudeCodeBackend {
             run_id: None,
             attempt: 1,
             branch_name: None,
-            session_registry_path: None,
+            session_registry_path: Some(session_registry_path(config)),
         })
     }
 
     fn run(&self, prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
-        run_subprocess_backend(prepared, "claude-code-subprocess", "Claude Code subprocess")
+        run_claude_stream_json_backend(prepared)
     }
 
     fn stop(&self, _reason: &str) -> Result<(), AgentError> {
@@ -539,6 +539,712 @@ fn run_subprocess_backend(
 
         thread::sleep(Duration::from_millis(10));
     }
+}
+
+const CLAUDE_STREAM_JSON_SOURCE: &str = "claude-code-stream-json";
+const CLAUDE_RESUME_SESSION_ENV: &str = "SHEA_SYMPHONY_CLAUDE_RESUME_SESSION_ID";
+
+#[derive(Debug, Clone)]
+struct ClaudeArtifactPaths {
+    protocol_path: PathBuf,
+    stderr_path: PathBuf,
+    events_path: PathBuf,
+}
+
+#[derive(Default)]
+struct ClaudeProtocolState {
+    session_id: Option<String>,
+    initialized: bool,
+    terminal: bool,
+}
+
+fn run_claude_stream_json_backend(prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
+    let mut events = Vec::new();
+    if !prepared.workspace.is_dir() {
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend,
+            error: format!("workspace does not exist: {}", prepared.workspace.display()),
+        });
+        return Ok(events);
+    }
+    let Some(base_command) = prepared.command.as_deref() else {
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend,
+            error: "missing Claude Code command".into(),
+        });
+        return Ok(events);
+    };
+
+    let prompt_artifact_path = persist_prompt_artifact(&prepared)?;
+    let artifacts = claude_artifact_paths(&prepared, &prompt_artifact_path);
+    if let Some(parent) = artifacts.protocol_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let invocation = claude_stream_json_command(
+        base_command,
+        prepared
+            .env
+            .get(CLAUDE_RESUME_SESSION_ENV)
+            .map(String::as_str),
+    );
+    let mut command = Command::new("sh");
+    command
+        .arg("-lc")
+        .arg(&invocation)
+        .current_dir(&prepared.workspace)
+        .env("SHEA_SYMPHONY_PROMPT_PATH", &prompt_artifact_path)
+        .envs(prepared.env.iter())
+        .env(
+            "SHEA_SYMPHONY_ACTOR_ROLE",
+            prepared.actor_role.as_deref().unwrap_or_default(),
+        )
+        .env(
+            "SHEA_SYMPHONY_ACTOR_LABEL",
+            prepared.actor_label.as_deref().unwrap_or_default(),
+        )
+        .env(
+            "SHEA_SYMPHONY_GIT_AUTHOR",
+            prepared.git_author.as_deref().unwrap_or_default(),
+        )
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    configure_child_process_group(&mut command);
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            fs::write(&artifacts.protocol_path, "")?;
+            fs::write(&artifacts.stderr_path, error.to_string())?;
+            events.push(AgentEvent::Failed {
+                backend: prepared.backend.clone(),
+                error: format!("Claude Code startup failed: {error}"),
+            });
+            finish_claude_artifacts(
+                &prepared,
+                &prompt_artifact_path,
+                &artifacts,
+                &mut events,
+                None,
+            )?;
+            return Ok(events);
+        }
+    };
+
+    let process_id = child.id();
+    let Some(mut stdin) = child.stdin.take() else {
+        terminate_child_process_group(&mut child);
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend.clone(),
+            error: "Claude Code stdin was unavailable".into(),
+        });
+        finish_claude_artifacts(
+            &prepared,
+            &prompt_artifact_path,
+            &artifacts,
+            &mut events,
+            None,
+        )?;
+        return Ok(events);
+    };
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| AgentError::Unavailable("Claude Code stdout was unavailable".into()))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| AgentError::Unavailable("Claude Code stderr was unavailable".into()))?;
+    let stdout_rx = spawn_app_server_stdout_reader(stdout);
+    let (stderr_tx, stderr_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut stderr_text = String::new();
+        let _ = BufReader::new(stderr).read_to_string(&mut stderr_text);
+        let _ = stderr_tx.send(stderr_text);
+    });
+
+    let input = serde_json::json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": prepared.prompt}]
+        },
+        "parent_tool_use_id": null
+    });
+    let input_line = serde_json::to_string(&input)
+        .map_err(|error| AgentError::Unavailable(error.to_string()))?;
+    let mut protocol_log = String::new();
+    append_protocol_record(&mut protocol_log, "stdin", &input_line);
+    if let Err(error) = writeln!(stdin, "{input_line}").and_then(|_| stdin.flush()) {
+        terminate_child_process_group(&mut child);
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend.clone(),
+            error: format!("Claude Code input write failed: {error}"),
+        });
+    }
+    drop(stdin);
+
+    let deadline = Instant::now() + Duration::from_millis(prepared.timeout_ms.max(1));
+    let mut state = ClaudeProtocolState::default();
+    let mut force_stop = events
+        .iter()
+        .any(|event| matches!(event, AgentEvent::Failed { .. }));
+    while !force_stop {
+        match next_claude_stdout_line(&mut child, &stdout_rx, deadline) {
+            Ok(Some(line)) => {
+                append_protocol_record(&mut protocol_log, "stdout", &line);
+                if let Err(error) = normalize_claude_stream_line(
+                    &prepared,
+                    &artifacts,
+                    &prompt_artifact_path,
+                    process_id,
+                    &line,
+                    &mut state,
+                    &mut events,
+                ) {
+                    events.push(AgentEvent::Failed {
+                        backend: prepared.backend.clone(),
+                        error,
+                    });
+                    force_stop = true;
+                }
+            }
+            Ok(None) => break,
+            Err(error) => {
+                events.push(AgentEvent::Failed {
+                    backend: prepared.backend.clone(),
+                    error,
+                });
+                force_stop = true;
+            }
+        }
+    }
+
+    let exit_status = if force_stop {
+        terminate_child_process_group(&mut child)
+    } else {
+        child.wait().ok()
+    };
+    if !state.terminal
+        && !events
+            .iter()
+            .any(|event| matches!(event, AgentEvent::Failed { .. }))
+    {
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend.clone(),
+            error: if !state.initialized
+                && exit_status.as_ref().is_some_and(|status| !status.success())
+            {
+                format!(
+                    "Claude Code startup failed with status {} before initialization",
+                    display_exit_status(exit_status.as_ref())
+                )
+            } else {
+                "Claude Code stream ended before a terminal result event".into()
+            },
+        });
+    }
+    if exit_status.as_ref().is_some_and(|status| !status.success())
+        && !events.iter().any(|event| {
+            matches!(event, AgentEvent::Failed { error, .. } if error.contains("timed out"))
+        })
+    {
+        events.push(AgentEvent::Failed {
+            backend: prepared.backend.clone(),
+            error: format!(
+                "Claude Code exited with status {}",
+                display_exit_status(exit_status.as_ref())
+            ),
+        });
+    }
+
+    fs::write(&artifacts.protocol_path, &protocol_log)?;
+    let stderr_text = stderr_rx
+        .recv_timeout(Duration::from_millis(500))
+        .unwrap_or_default();
+    fs::write(&artifacts.stderr_path, &stderr_text)?;
+    if !stderr_text.trim().is_empty() {
+        events.push(AgentEvent::Message {
+            backend: prepared.backend.clone(),
+            session_id: state.session_id.clone(),
+            text: stderr_text,
+        });
+    }
+    if let Some(session_id) = state.session_id.as_deref() {
+        update_claude_session_status(
+            prepared.session_registry_path.as_deref(),
+            session_id,
+            if events
+                .iter()
+                .any(|event| matches!(event, AgentEvent::Completed { .. }))
+                && !events
+                    .iter()
+                    .any(|event| matches!(event, AgentEvent::Failed { .. }))
+            {
+                SessionStatus::Completed
+            } else if usage_limit_pause_from_events(&events).is_some() {
+                SessionStatus::UsageLimited
+            } else {
+                SessionStatus::Failed
+            },
+        )?;
+    }
+    finish_claude_artifacts(
+        &prepared,
+        &prompt_artifact_path,
+        &artifacts,
+        &mut events,
+        exit_status.as_ref(),
+    )?;
+    Ok(events)
+}
+
+fn claude_stream_json_command(base_command: &str, resume_session_id: Option<&str>) -> String {
+    let mut command = format!(
+        "exec {} -p --input-format stream-json --output-format stream-json --verbose",
+        base_command.trim()
+    );
+    if let Some(session_id) = resume_session_id.filter(|value| !value.trim().is_empty()) {
+        command.push_str(" --resume ");
+        command.push_str(&shell_quote_str(session_id));
+    }
+    command
+}
+
+fn configure_child_process_group(command: &mut Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+}
+
+fn terminate_child_process_group(child: &mut Child) -> Option<ExitStatus> {
+    if let Ok(Some(status)) = child.try_wait() {
+        return Some(status);
+    }
+    #[cfg(unix)]
+    {
+        // The child is its process-group leader, so a negative PID reaches wrappers and
+        // descendants together. A stale descendant must never outlive a failed lane run.
+        unsafe {
+            libc::kill(-(child.id() as i32), libc::SIGTERM);
+        }
+        for _ in 0..10 {
+            if let Ok(Some(status)) = child.try_wait() {
+                return Some(status);
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+    let _ = child.kill();
+    child.wait().ok()
+}
+
+fn next_claude_stdout_line(
+    child: &mut Child,
+    stdout_rx: &Receiver<Result<String, String>>,
+    deadline: Instant,
+) -> Result<Option<String>, String> {
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            terminate_child_process_group(child);
+            return Err("Claude Code timed out waiting for a terminal result event".into());
+        }
+        match stdout_rx.recv_timeout(
+            deadline
+                .saturating_duration_since(now)
+                .min(Duration::from_millis(50)),
+        ) {
+            Ok(Ok(line)) => return Ok(Some(line)),
+            Ok(Err(error)) => return Err(format!("Claude Code stdout read failed: {error}")),
+            Err(RecvTimeoutError::Timeout) => {
+                if child
+                    .try_wait()
+                    .map_err(|error| error.to_string())?
+                    .is_some()
+                {
+                    return Ok(None);
+                }
+            }
+            Err(RecvTimeoutError::Disconnected) => return Ok(None),
+        }
+    }
+}
+
+fn normalize_claude_stream_line(
+    prepared: &PreparedRun,
+    artifacts: &ClaudeArtifactPaths,
+    prompt_artifact_path: &Path,
+    process_id: u32,
+    line: &str,
+    state: &mut ClaudeProtocolState,
+    events: &mut Vec<AgentEvent>,
+) -> Result<(), String> {
+    // Claude may add progress event kinds over time. Preserve unknown non-terminal
+    // kinds as evidence, but accept success only from the explicit final result.
+    if state.terminal {
+        return Err("Claude Code emitted data after its terminal result event".into());
+    }
+    let value: serde_json::Value = serde_json::from_str(line.trim())
+        .map_err(|error| format!("Claude Code emitted malformed stream-json: {error}"))?;
+    let event_type = value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            "Claude Code stream-json event is missing string field `type`".to_string()
+        })?;
+    validate_claude_event_session(state, &value)?;
+
+    match event_type {
+        "system" if value.get("subtype").and_then(serde_json::Value::as_str) == Some("init") => {
+            if state.initialized {
+                return Err("Claude Code emitted more than one initialization event".into());
+            }
+            let session_id = value
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| "Claude Code initialization is missing session_id".to_string())?
+                .to_string();
+            state.initialized = true;
+            state.session_id = Some(session_id.clone());
+            events.push(AgentEvent::SessionStarted {
+                backend: prepared.backend.clone(),
+                session_id: session_id.clone(),
+            });
+            save_claude_session_record(
+                prepared,
+                artifacts,
+                prompt_artifact_path,
+                &session_id,
+                process_id,
+            )
+            .map_err(|error| error.to_string())?;
+            events.push(AgentEvent::Message {
+                backend: prepared.backend.clone(),
+                session_id: Some(session_id),
+                text: "claude_event type=system subtype=init".into(),
+            });
+        }
+        "assistant" => {
+            require_claude_initialization(state, event_type)?;
+            normalize_claude_assistant(prepared, &value, state, events);
+        }
+        "user" => {
+            require_claude_initialization(state, event_type)?;
+            normalize_claude_tool_results(prepared, &value, state, events);
+        }
+        "result" => {
+            require_claude_initialization(state, event_type)?;
+            state.terminal = true;
+            let subtype = value
+                .get("subtype")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("unknown");
+            let is_error = value
+                .get("is_error")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(subtype != "success");
+            if is_error || subtype != "success" {
+                let detail = value
+                    .get("result")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or(subtype);
+                events.push(AgentEvent::Failed {
+                    backend: prepared.backend.clone(),
+                    error: format!("Claude Code result failed ({subtype}): {detail}"),
+                });
+            } else {
+                let summary = value
+                    .get("result")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or("Claude Code completed successfully.")
+                    .to_string();
+                events.push(AgentEvent::Completed {
+                    backend: prepared.backend.clone(),
+                    session_id: state.session_id.clone(),
+                    summary,
+                });
+            }
+        }
+        "error" => {
+            state.terminal = true;
+            events.push(AgentEvent::Failed {
+                backend: prepared.backend.clone(),
+                error: format!(
+                    "Claude Code error event: {}",
+                    value
+                        .get("error")
+                        .and_then(serde_json::Value::as_str)
+                        .or_else(|| value.get("message").and_then(serde_json::Value::as_str))
+                        .unwrap_or("unspecified error")
+                ),
+            });
+        }
+        _ => {
+            events.push(AgentEvent::Message {
+                backend: prepared.backend.clone(),
+                session_id: state.session_id.clone(),
+                text: format!(
+                    "claude_event type={event_type} subtype={}",
+                    value
+                        .get("subtype")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("n/a")
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_claude_event_session(
+    state: &ClaudeProtocolState,
+    value: &serde_json::Value,
+) -> Result<(), String> {
+    let Some(actual) = value
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Ok(());
+    };
+    if let Some(expected) = state.session_id.as_deref() {
+        if actual != expected {
+            return Err(format!(
+                "Claude Code session changed within one stream: expected {expected}, got {actual}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn require_claude_initialization(
+    state: &ClaudeProtocolState,
+    event_type: &str,
+) -> Result<(), String> {
+    if state.initialized {
+        Ok(())
+    } else {
+        Err(format!(
+            "Claude Code emitted {event_type} before initialization"
+        ))
+    }
+}
+
+fn normalize_claude_assistant(
+    prepared: &PreparedRun,
+    value: &serde_json::Value,
+    state: &ClaudeProtocolState,
+    events: &mut Vec<AgentEvent>,
+) {
+    if let Some(content) = value
+        .pointer("/message/content")
+        .and_then(serde_json::Value::as_array)
+    {
+        for block in content {
+            match block.get("type").and_then(serde_json::Value::as_str) {
+                Some("text") => {
+                    if let Some(text) = block.get("text").and_then(serde_json::Value::as_str) {
+                        events.push(AgentEvent::Message {
+                            backend: prepared.backend.clone(),
+                            session_id: state.session_id.clone(),
+                            text: text.to_string(),
+                        });
+                    }
+                }
+                Some("tool_use") => events.push(AgentEvent::Message {
+                    backend: prepared.backend.clone(),
+                    session_id: state.session_id.clone(),
+                    text: format!(
+                        "claude_tool_use name={} id={}",
+                        block
+                            .get("name")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("unknown"),
+                        block
+                            .get("id")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("unknown")
+                    ),
+                }),
+                Some(kind) => events.push(AgentEvent::Message {
+                    backend: prepared.backend.clone(),
+                    session_id: state.session_id.clone(),
+                    text: format!("claude_assistant_block type={kind}"),
+                }),
+                None => {}
+            }
+        }
+    }
+    if let Some(usage) = value.pointer("/message/usage") {
+        let input_tokens = json_u64(usage.get("input_tokens"));
+        let output_tokens = json_u64(usage.get("output_tokens"));
+        if input_tokens > 0 || output_tokens > 0 {
+            events.push(AgentEvent::TokenUsage {
+                backend: prepared.backend.clone(),
+                input_tokens,
+                output_tokens,
+                total_tokens: input_tokens.saturating_add(output_tokens),
+            });
+        }
+    }
+}
+
+fn normalize_claude_tool_results(
+    prepared: &PreparedRun,
+    value: &serde_json::Value,
+    state: &ClaudeProtocolState,
+    events: &mut Vec<AgentEvent>,
+) {
+    let Some(content) = value
+        .pointer("/message/content")
+        .and_then(serde_json::Value::as_array)
+    else {
+        return;
+    };
+    for block in content {
+        if block.get("type").and_then(serde_json::Value::as_str) == Some("tool_result") {
+            events.push(AgentEvent::Message {
+                backend: prepared.backend.clone(),
+                session_id: state.session_id.clone(),
+                text: format!(
+                    "claude_tool_result tool_use_id={} is_error={}",
+                    block
+                        .get("tool_use_id")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("unknown"),
+                    block
+                        .get("is_error")
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false)
+                ),
+            });
+        }
+    }
+}
+
+fn json_u64(value: Option<&serde_json::Value>) -> u64 {
+    value
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or_default()
+}
+
+fn claude_artifact_paths(
+    prepared: &PreparedRun,
+    prompt_artifact_path: &Path,
+) -> ClaudeArtifactPaths {
+    let artifact_dir = prompt_artifact_path
+        .parent()
+        .and_then(Path::parent)
+        .unwrap_or_else(|| Path::new("/tmp"))
+        .join("claude-stream-json");
+    let base = format!(
+        "{}-{}",
+        safe_path_component(prepared.issue_identifier.as_deref()),
+        current_time_ms()
+    );
+    ClaudeArtifactPaths {
+        protocol_path: artifact_dir.join(format!("{base}.protocol.jsonl")),
+        stderr_path: artifact_dir.join(format!("{base}.stderr.log")),
+        events_path: artifact_dir.join(format!("{base}.events.json")),
+    }
+}
+
+fn save_claude_session_record(
+    prepared: &PreparedRun,
+    artifacts: &ClaudeArtifactPaths,
+    prompt_artifact_path: &Path,
+    session_id: &str,
+    process_id: u32,
+) -> Result<(), AgentError> {
+    let Some(registry_path) = prepared.session_registry_path.as_deref() else {
+        return Ok(());
+    };
+    let now_ms = unix_timestamp_ms();
+    save_session_record(
+        registry_path,
+        AgentSessionRecord {
+            issue_id: prepared.issue_id.clone(),
+            issue_identifier: prepared.issue_identifier.clone(),
+            issue_title: prepared.issue_title.clone(),
+            lane: prepared.lane.clone().unwrap_or_else(|| "main".into()),
+            run_id: prepared.run_id.clone(),
+            thread: Some(session_id.to_string()),
+            session_source: Some(CLAUDE_STREAM_JSON_SOURCE.into()),
+            claim_value: prepared.env.get("SHEA_SYMPHONY_CLAIM").cloned(),
+            actor_role: prepared.actor_role.clone(),
+            actor_label: prepared.actor_label.clone(),
+            git_author: prepared.git_author.clone(),
+            profile_id: prepared.profile_id.clone(),
+            instance_name: prepared.instance_name.clone(),
+            worktree: prepared.workspace.clone(),
+            branch: prepared.branch_name.clone(),
+            backend: prepared.backend.clone(),
+            session_name: session_id.to_string(),
+            process_id: Some(process_id),
+            pane_target: String::new(),
+            prompt_artifact_path: prompt_artifact_path.to_path_buf(),
+            log_path: artifacts.events_path.clone(),
+            attach_command: format!(
+                "not an interactive session; inspect Claude artifacts: protocol={} stderr={} events={}",
+                artifacts.protocol_path.display(),
+                artifacts.stderr_path.display(),
+                artifacts.events_path.display()
+            ),
+            attempt: prepared.attempt.max(1),
+            status: SessionStatus::Running,
+            started_at_ms: now_ms,
+            updated_at_ms: now_ms,
+        },
+    )
+    .map_err(|error| AgentError::Unavailable(format!("Claude session registry failed: {error}")))
+}
+
+fn update_claude_session_status(
+    registry_path: Option<&Path>,
+    session_id: &str,
+    status: SessionStatus,
+) -> Result<(), AgentError> {
+    let Some(registry_path) = registry_path else {
+        return Ok(());
+    };
+    update_session_record_status(registry_path, session_id, status, unix_timestamp_ms()).map_err(
+        |error| AgentError::Unavailable(format!("Claude session registry failed: {error}")),
+    )
+}
+
+fn finish_claude_artifacts(
+    prepared: &PreparedRun,
+    prompt_artifact_path: &Path,
+    artifacts: &ClaudeArtifactPaths,
+    events: &mut Vec<AgentEvent>,
+    exit_status: Option<&ExitStatus>,
+) -> Result<(), AgentError> {
+    events.push(AgentEvent::Message {
+        backend: prepared.backend.clone(),
+        session_id: events.iter().find_map(|event| match event {
+            AgentEvent::SessionStarted { session_id, .. } => Some(session_id.clone()),
+            _ => None,
+        }),
+        text: format!(
+            "claude_stream_json_artifacts prompt_artifact={} protocol_artifact={} stderr_artifact={} normalized_events_artifact={} exit_status={}",
+            prompt_artifact_path.display(),
+            artifacts.protocol_path.display(),
+            artifacts.stderr_path.display(),
+            artifacts.events_path.display(),
+            display_exit_status(exit_status)
+        ),
+    });
+    fs::write(
+        &artifacts.events_path,
+        serde_json::to_string_pretty(events)
+            .map_err(|error| AgentError::Unavailable(error.to_string()))?,
+    )?;
+    Ok(())
 }
 
 fn run_codex_app_server_backend(prepared: PreparedRun) -> Result<Vec<AgentEvent>, AgentError> {
@@ -2788,6 +3494,51 @@ exit 0
         RuntimeConfig::from_workflow(&workflow, std::path::Path::new("/tmp/WORKFLOW.md")).unwrap()
     }
 
+    #[cfg(unix)]
+    fn fake_claude_stream_json(root: &Path) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = root.join("fake-claude");
+        fs::write(
+            &script,
+            r#"#!/bin/sh
+trace="${FAKE_CLAUDE_TRACE:?}"
+mode="${FAKE_CLAUDE_MODE:-fixture}"
+mkdir -p "$trace"
+pwd > "$trace/cwd"
+printf 'ARG=%s\n' "$@" > "$trace/args"
+if [ "$mode" = timeout ]; then
+  sleep 5 &
+  child=$!
+  printf '%s' "$child" > "$trace/child-pid"
+  wait "$child"
+  exit 0
+fi
+cat > "$trace/input.jsonl"
+case "$mode" in
+  fixture)
+    cat "${FAKE_CLAUDE_FIXTURE:?}"
+    ;;
+  startup_failure)
+    printf '%s\n' 'fake Claude startup failed' >&2
+    exit 23
+    ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&script).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script, permissions).unwrap();
+        script
+    }
+
+    fn claude_fixture(name: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("examples/fixtures")
+            .join(name)
+    }
+
     fn codex_config_with_profile(command: &str) -> RuntimeConfig {
         let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("examples/fixtures/cockpit-tools-codex-instances.json");
@@ -3334,60 +4085,291 @@ done
         assert!(summary.message.contains("timed out"));
     }
 
+    #[cfg(unix)]
     #[test]
-    fn claude_code_backend_runs_subprocess_in_workspace() {
+    fn claude_code_backend_runs_stream_json_and_records_session_evidence() {
         let temp = tempfile::tempdir().unwrap();
-        let config = claude_config("cat > claude-subprocess-output.md", 5_000);
+        let claude = fake_claude_stream_json(temp.path());
+        let config = claude_config(&claude.display().to_string(), 5_000);
         let backend = ClaudeCodeBackend;
-        let prepared = backend
-            .prepare(temp.path().to_path_buf(), "hello claude".into(), &config)
+        let workspace = temp.path().join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let trace = temp.path().join("trace");
+        let registry_path = temp.path().join("sessions/session-registry.json");
+        let mut prepared = backend
+            .prepare(workspace.clone(), "hello claude".into(), &config)
             .unwrap();
+        prepared.prompt_artifact_path = Some(temp.path().join("logs/prompts/claude.prompt.md"));
+        prepared.session_registry_path = Some(registry_path.clone());
+        prepared.issue_id = Some("issue-510".into());
+        prepared.issue_identifier = Some("#510".into());
+        prepared.issue_title = Some("Run Claude Code stream-json sessions".into());
+        prepared.lane = Some("main".into());
+        prepared.run_id = Some("run-510".into());
+        prepared.branch_name = Some("feature/issue-510".into());
+        prepared
+            .env
+            .insert("FAKE_CLAUDE_TRACE".into(), trace.display().to_string());
+        prepared.env.insert(
+            "FAKE_CLAUDE_FIXTURE".into(),
+            claude_fixture("claude-stream-json-success.jsonl")
+                .display()
+                .to_string(),
+        );
         let events = backend.run(prepared).unwrap();
         let summary = backend.summarize(&events);
 
         assert!(summary.success);
         assert_eq!(summary.backend, "claude-code");
+        assert_eq!(summary.session_id.as_deref(), Some("claude-session-510"));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Message { text, .. } if text.contains("claude_tool_use name=Read")
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Message { text, .. } if text.contains("claude_tool_result")
+        )));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::TokenUsage {
+                input_tokens: 12,
+                output_tokens: 7,
+                total_tokens: 19,
+                ..
+            }
+        )));
+        let args = fs::read_to_string(trace.join("args")).unwrap();
+        for argument in [
+            "ARG=-p",
+            "ARG=--input-format",
+            "ARG=stream-json",
+            "ARG=--output-format",
+            "ARG=--verbose",
+        ] {
+            assert!(args.contains(argument), "{args}");
+        }
         assert_eq!(
-            summary.session_id.as_deref(),
-            Some("claude-code-subprocess")
+            fs::canonicalize(fs::read_to_string(trace.join("cwd")).unwrap().trim()).unwrap(),
+            fs::canonicalize(&workspace).unwrap()
+        );
+        let input: serde_json::Value = serde_json::from_str(
+            fs::read_to_string(trace.join("input.jsonl"))
+                .unwrap()
+                .trim(),
+        )
+        .unwrap();
+        assert_eq!(
+            input.pointer("/type").and_then(serde_json::Value::as_str),
+            Some("user")
         );
         assert_eq!(
-            std::fs::read_to_string(temp.path().join("claude-subprocess-output.md")).unwrap(),
-            "hello claude"
+            input
+                .pointer("/message/content/0/text")
+                .and_then(serde_json::Value::as_str),
+            Some("hello claude")
         );
+
+        let registry = crate::session_registry::load_session_registry(&registry_path).unwrap();
+        let record = registry.sessions.first().unwrap();
+        assert_eq!(record.session_name, "claude-session-510");
+        assert_eq!(record.thread.as_deref(), Some("claude-session-510"));
+        assert_eq!(
+            record.session_source.as_deref(),
+            Some(CLAUDE_STREAM_JSON_SOURCE)
+        );
+        assert_eq!(record.issue_identifier.as_deref(), Some("#510"));
+        assert_eq!(record.run_id.as_deref(), Some("run-510"));
+        assert_eq!(record.worktree, workspace);
+        assert_eq!(record.status, SessionStatus::Completed);
+        let protocol_path = message_field(&events, "protocol_artifact=").unwrap();
+        assert!(fs::read_to_string(protocol_path)
+            .unwrap()
+            .contains("claude-session-510"));
     }
 
+    #[cfg(unix)]
     #[test]
-    fn claude_code_backend_reports_subprocess_failure() {
+    fn claude_code_backend_resumes_recorded_session_through_cli_contract() {
         let temp = tempfile::tempdir().unwrap();
-        let config = claude_config("echo claude-nope >&2; exit 9", 5_000);
+        let claude = fake_claude_stream_json(temp.path());
+        let config = claude_config(&claude.display().to_string(), 5_000);
         let backend = ClaudeCodeBackend;
-        let prepared = backend
-            .prepare(temp.path().to_path_buf(), "prompt".into(), &config)
+        let workspace = temp.path().join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let trace = temp.path().join("trace");
+        let mut prepared = backend
+            .prepare(workspace, "Continue".into(), &config)
             .unwrap();
+        prepared.session_registry_path = Some(temp.path().join("sessions/session-registry.json"));
+        prepared.env.insert(
+            CLAUDE_RESUME_SESSION_ENV.into(),
+            "claude-session-510".into(),
+        );
+        prepared
+            .env
+            .insert("FAKE_CLAUDE_TRACE".into(), trace.display().to_string());
+        prepared.env.insert(
+            "FAKE_CLAUDE_FIXTURE".into(),
+            claude_fixture("claude-stream-json-success.jsonl")
+                .display()
+                .to_string(),
+        );
         let events = backend.run(prepared).unwrap();
         let summary = backend.summarize(&events);
 
-        assert!(!summary.success);
-        assert!(summary.message.contains("status 9"));
-        assert!(events.iter().any(|event| matches!(
-            event,
-            AgentEvent::Message { text, .. } if text.contains("claude-nope")
-        )));
+        assert!(summary.success);
+        let args = fs::read_to_string(trace.join("args")).unwrap();
+        assert!(args.contains("ARG=--resume"), "{args}");
+        assert!(args.contains("ARG=claude-session-510"), "{args}");
     }
 
+    #[cfg(unix)]
     #[test]
-    fn claude_code_backend_reports_timeout() {
+    fn claude_code_backend_fails_closed_for_protocol_and_process_failures() {
+        for (mode, fixture, expected) in [
+            (
+                "fixture",
+                "claude-stream-json-error.jsonl",
+                "permission was denied",
+            ),
+            ("fixture", "claude-stream-json-cancelled.jsonl", "cancelled"),
+            ("fixture", "claude-stream-json-malformed.jsonl", "malformed"),
+            (
+                "fixture",
+                "claude-stream-json-truncated.jsonl",
+                "before a terminal result",
+            ),
+            (
+                "startup_failure",
+                "claude-stream-json-success.jsonl",
+                "startup failed with status 23",
+            ),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            let claude = fake_claude_stream_json(temp.path());
+            let config = claude_config(&claude.display().to_string(), 5_000);
+            let workspace = temp.path().join("workspace");
+            fs::create_dir_all(&workspace).unwrap();
+            let trace = temp.path().join("trace");
+            let backend = ClaudeCodeBackend;
+            let mut prepared = backend
+                .prepare(workspace, "prompt".into(), &config)
+                .unwrap();
+            prepared.session_registry_path =
+                Some(temp.path().join("sessions/session-registry.json"));
+            prepared
+                .env
+                .insert("FAKE_CLAUDE_TRACE".into(), trace.display().to_string());
+            prepared.env.insert("FAKE_CLAUDE_MODE".into(), mode.into());
+            prepared.env.insert(
+                "FAKE_CLAUDE_FIXTURE".into(),
+                claude_fixture(fixture).display().to_string(),
+            );
+
+            let events = backend.run(prepared).unwrap();
+            let summary = backend.summarize(&events);
+
+            assert!(!summary.success, "{mode} {fixture}: {summary:?}");
+            assert!(
+                summary.message.contains(expected),
+                "{mode} {fixture}: {summary:?}"
+            );
+            assert!(message_field(&events, "protocol_artifact=").is_some());
+            assert!(message_field(&events, "normalized_events_artifact=").is_some());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn claude_code_backend_times_out_and_terminates_process_group() {
         let temp = tempfile::tempdir().unwrap();
-        let config = claude_config("sleep 1", 10);
+        let claude = fake_claude_stream_json(temp.path());
+        let config = claude_config(&claude.display().to_string(), 1_000);
+        let workspace = temp.path().join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let trace = temp.path().join("trace");
         let backend = ClaudeCodeBackend;
-        let prepared = backend
-            .prepare(temp.path().to_path_buf(), "prompt".into(), &config)
+        let mut prepared = backend
+            .prepare(workspace, "prompt".into(), &config)
             .unwrap();
+        prepared.session_registry_path = Some(temp.path().join("sessions/session-registry.json"));
+        prepared
+            .env
+            .insert("FAKE_CLAUDE_TRACE".into(), trace.display().to_string());
+        prepared
+            .env
+            .insert("FAKE_CLAUDE_MODE".into(), "timeout".into());
+
         let events = backend.run(prepared).unwrap();
         let summary = backend.summarize(&events);
 
         assert!(!summary.success);
         assert!(summary.message.contains("timed out"));
+        let child_pid = fs::read_to_string(trace.join("child-pid"))
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+        let mut process_exists = true;
+        for _ in 0..20 {
+            // Signal 0 performs a read-only existence check for the former descendant.
+            process_exists = unsafe { libc::kill(child_pid, 0) == 0 };
+            if !process_exists {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !process_exists,
+            "timed-out descendant {child_pid} is still alive"
+        );
+    }
+
+    #[ignore = "requires an operator-configured local Claude Code command"]
+    #[test]
+    fn claude_code_live_local_worktree_uat() {
+        let command = std::env::var("SHEA_CLAUDE_UAT_COMMAND")
+            .expect("set SHEA_CLAUDE_UAT_COMMAND to a local Claude executable or wrapper");
+        let temp = tempfile::tempdir().unwrap();
+        let config = claude_config(&command, 600_000);
+        let backend = ClaudeCodeBackend;
+
+        for (lane, initial, expected, prompt) in [
+            (
+                "main",
+                "before\n",
+                "main stream-json uat\n",
+                "Replace uat.txt with exactly `main stream-json uat` followed by a newline, then verify it with a shell command.",
+            ),
+            (
+                "merge",
+                "<<<<<<< HEAD\napproved\n=======\nstale\n>>>>>>> origin/main\n",
+                "approved\n",
+                "Resolve the conflict markers in uat.txt by preserving `approved`, then verify that no conflict markers remain.",
+            ),
+        ] {
+            let workspace = temp.path().join(lane);
+            fs::create_dir_all(&workspace).unwrap();
+            fs::write(workspace.join("uat.txt"), initial).unwrap();
+            let mut prepared = backend
+                .prepare(workspace.clone(), prompt.into(), &config)
+                .unwrap();
+            prepared.prompt_artifact_path =
+                Some(temp.path().join(format!("logs/prompts/{lane}.prompt.md")));
+            prepared.session_registry_path =
+                Some(temp.path().join("sessions/session-registry.json"));
+            prepared.issue_id = Some(format!("local-{lane}-uat"));
+            prepared.issue_identifier = Some(format!("local-{lane}-uat"));
+            prepared.lane = Some(lane.into());
+            prepared.run_id = Some(format!("local-{lane}-uat"));
+
+            let events = backend.run(prepared).unwrap();
+            let summary = backend.summarize(&events);
+
+            assert!(summary.success, "{lane}: {summary:?}");
+            assert_eq!(fs::read_to_string(workspace.join("uat.txt")).unwrap(), expected);
+            assert!(summary.session_id.is_some(), "{lane}: {summary:?}");
+            assert!(summary.log_path.as_ref().is_some_and(|path| path.is_file()));
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -475,6 +475,13 @@ impl RuntimeConfig {
                 "tmux.agent_command must not be empty".into(),
             ));
         }
+        if (self.backend.kind == "claude-code" || self.merge_lane.agent_backend == "claude-code")
+            && self.claude.command.trim().is_empty()
+        {
+            return Err(ConfigError::Invalid(
+                "claude.command must not be empty when a lane selects claude-code".into(),
+            ));
+        }
         match self.review.backend.as_str() {
             "fake" | "gemini-cli" | "agy-cli" => {}
             other => return Err(ConfigError::UnsupportedBackend(other.to_string())),
@@ -514,6 +521,7 @@ impl RuntimeConfig {
             self.agent.max_retry_backoff_ms,
         )?;
         require_positive("review_lane.timeout_ms", self.review.timeout_ms)?;
+        require_positive("claude.turn_timeout_ms", self.claude.turn_timeout_ms)?;
         require_positive(
             "review_lane.max_concurrent_workers",
             self.review.max_concurrent_workers as u64,
@@ -1140,6 +1148,43 @@ mod tests {
 
         assert_eq!(config.merge_lane.agent_backend, "tmux");
         assert_eq!(config.merge_lane.max_concurrent_workers, 2);
+    }
+
+    #[test]
+    fn parses_claude_wrapper_for_main_and_merge_lanes() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nmain_lane:\n  backend: claude-code\nmerge_lane:\n  agent_backend: claude-code\nclaude:\n  command: /opt/bin/claude-wrapper --profile shea\n  turn_timeout_ms: 9000\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert_eq!(config.backend.kind, "claude-code");
+        assert_eq!(config.merge_lane.agent_backend, "claude-code");
+        assert_eq!(
+            config.claude.command,
+            "/opt/bin/claude-wrapper --profile shea"
+        );
+        assert_eq!(config.claude.turn_timeout_ms, 9_000);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn selected_claude_lane_rejects_empty_command() {
+        let workflow = WorkflowDefinition::parse(
+            "/tmp/WORKFLOW.md",
+            "---\ntracker:\n  kind: memory\nmain_lane:\n  backend: claude-code\nclaude:\n  command: '   '\n---\nPrompt",
+        )
+        .unwrap();
+        let config =
+            RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+        assert!(config
+            .validate()
+            .unwrap_err()
+            .to_string()
+            .contains("claude.command must not be empty"));
     }
 
     #[test]

--- a/src/lanes/main_loop/execution.rs
+++ b/src/lanes/main_loop/execution.rs
@@ -49,6 +49,7 @@ pub(crate) struct IssueExecutionResult {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct IssueExecutionOptions {
     pub(crate) app_server_resume_thread_id: Option<String>,
+    pub(crate) claude_resume_session_id: Option<String>,
     pub(crate) prompt_override: Option<String>,
 }
 
@@ -130,9 +131,17 @@ fn execute_issue_once_in_workspace(
     if options.app_server_resume_thread_id.is_some() {
         prompt = CODEX_APP_SERVER_CONTINUE_PROMPT.into();
     }
+    if options.claude_resume_session_id.is_some() {
+        prompt = "Continue".into();
+    }
     let backend = backend_from_config(config);
     let mut prepared = backend.prepare(workspace.path.clone(), prompt, config)?;
     prepared.app_server_resume_thread_id = options.app_server_resume_thread_id.clone();
+    if let Some(session_id) = options.claude_resume_session_id.clone() {
+        prepared
+            .env
+            .insert("SHEA_SYMPHONY_CLAUDE_RESUME_SESSION_ID".into(), session_id);
+    }
     prepared.prompt_artifact_path = Some(rendered_prompt_artifact_path(
         config,
         issue,

--- a/src/lanes/main_loop/runtime/recovery.rs
+++ b/src/lanes/main_loop/runtime/recovery.rs
@@ -97,7 +97,7 @@ pub(super) fn recover_registered_main_sessions(
                     continue;
                 };
                 let termination = if matches!(probe.status, SessionStatus::Stale) {
-                    terminate_stale_codex_app_server_session(config, record)?
+                    terminate_stale_structured_agent_session(config, record)?
                 } else {
                     None
                 };
@@ -156,11 +156,14 @@ pub(super) fn recover_registered_main_sessions(
     Ok(())
 }
 
-fn terminate_stale_codex_app_server_session(
+fn terminate_stale_structured_agent_session(
     config: &RuntimeConfig,
     record: &AgentSessionRecord,
 ) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    if record.session_source.as_deref() != Some(codex_app_server::BACKEND_NAME) {
+    if !matches!(
+        record.session_source.as_deref(),
+        Some(codex_app_server::BACKEND_NAME | "claude-code-stream-json")
+    ) {
         return Ok(None);
     }
     let Some(process_id) = record.process_id else {

--- a/src/lanes/main_loop/session.rs
+++ b/src/lanes/main_loop/session.rs
@@ -52,6 +52,7 @@ impl MainRecoveryMode {
 pub(crate) struct MainRecoveryPlan {
     pub(crate) mode: MainRecoveryMode,
     pub(crate) app_server_resume_thread_id: Option<String>,
+    pub(crate) claude_resume_session_id: Option<String>,
     pub(crate) prompt_override: Option<String>,
     pub(crate) evidence: String,
 }
@@ -106,8 +107,19 @@ pub(crate) fn main_recovery_plan(
         return Ok(MainRecoveryPlan {
             mode: MainRecoveryMode::NativeThread,
             app_server_resume_thread_id: Some(thread_id.clone()),
+            claude_resume_session_id: None,
             prompt_override: None,
             evidence: format!("thread={thread_id}"),
+        });
+    }
+
+    if let Some(session_id) = claude_resume_session_for_state(config, issue, state)? {
+        return Ok(MainRecoveryPlan {
+            mode: MainRecoveryMode::NativeThread,
+            app_server_resume_thread_id: None,
+            claude_resume_session_id: Some(session_id.clone()),
+            prompt_override: None,
+            evidence: format!("claude_session={session_id}"),
         });
     }
 
@@ -116,6 +128,7 @@ pub(crate) fn main_recovery_plan(
         return Ok(MainRecoveryPlan {
             mode: MainRecoveryMode::TranscriptReplay,
             app_server_resume_thread_id: None,
+            claude_resume_session_id: None,
             prompt_override: Some(prompt),
             evidence: "local_conversation_artifacts=present".into(),
         });
@@ -124,9 +137,55 @@ pub(crate) fn main_recovery_plan(
     Ok(MainRecoveryPlan {
         mode: MainRecoveryMode::WorktreeOnly,
         app_server_resume_thread_id: None,
+        claude_resume_session_id: None,
         prompt_override: Some(worktree_only_recovery_prompt(issue, state)?),
         evidence: "local_conversation_artifacts=missing".into(),
     })
+}
+
+fn claude_resume_session_for_state(
+    config: &RuntimeConfig,
+    issue: &TrackerIssue,
+    state: &RuntimeState,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    if state.backend != "claude-code" {
+        return Ok(None);
+    }
+    let Some(worktree) = state.workspace_path.as_deref() else {
+        return Ok(None);
+    };
+    let Some(run_id) = state
+        .run_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+    let registry = load_session_registry(&session_registry_path(config))?;
+    // Native resume is safe only inside the original durable ownership tuple;
+    // any mismatch falls back to transcript/worktree recovery instead.
+    let matches_boundary = |record: &&AgentSessionRecord| {
+        record.session_source.as_deref() == Some("claude-code-stream-json")
+            && record.backend == "claude-code"
+            && record.lane.eq_ignore_ascii_case("main")
+            && record.issue_id.as_deref() == Some(issue.id.as_str())
+            && record.issue_identifier.as_deref() == Some(issue.identifier.as_str())
+            && record.run_id.as_deref() == Some(run_id)
+            && record.worktree == worktree
+            && !record.session_name.trim().is_empty()
+    };
+    let record = state
+        .backend_session_id
+        .as_deref()
+        .and_then(|session_id| {
+            registry
+                .sessions
+                .iter()
+                .rev()
+                .find(|record| record.session_name == session_id && matches_boundary(record))
+        })
+        .or_else(|| registry.sessions.iter().rev().find(matches_boundary));
+    Ok(record.map(|record| record.session_name.clone()))
 }
 
 fn codex_app_server_session_record_for_state(

--- a/src/lanes/main_loop/write_candidate.rs
+++ b/src/lanes/main_loop/write_candidate.rs
@@ -468,8 +468,9 @@ pub(crate) fn run_loop_dispatch_write_candidate(
         Some(MainSessionReconciliation::Active { .. }) => unreachable!(),
         None => {
             let recovery_plan = if recover
-                && runtime_state.backend == "codex"
-                && config.codex.command.contains("app-server")
+                && ((runtime_state.backend == "codex"
+                    && config.codex.command.contains("app-server"))
+                    || runtime_state.backend == "claude-code")
                 && main_recovery_plan_applicable(&runtime_state)
             {
                 Some(main_recovery_plan(config, &latest, &runtime_state)?)
@@ -513,6 +514,25 @@ pub(crate) fn run_loop_dispatch_write_candidate(
                         ),
                     )?;
                 }
+                if let Some(session_id) = recovery_plan.claude_resume_session_id.as_deref() {
+                    println!(
+                        "run_loop_action=claude_resume issue={} session={} mode={} input=Continue",
+                        latest.identifier,
+                        session_id,
+                        recovery_plan.mode.as_str()
+                    );
+                    append_runtime_supervision_event(
+                        config,
+                        Some(&runtime_state),
+                        "ClaudeStreamJsonResume",
+                        &format!(
+                            "issue={} session={} mode={} input=Continue",
+                            latest.identifier,
+                            session_id,
+                            recovery_plan.mode.as_str()
+                        ),
+                    )?;
+                }
             }
             execute_issue_once_with_options(
                 workflow,
@@ -525,6 +545,9 @@ pub(crate) fn run_loop_dispatch_write_candidate(
                     app_server_resume_thread_id: recovery_plan
                         .as_ref()
                         .and_then(|plan| plan.app_server_resume_thread_id.clone()),
+                    claude_resume_session_id: recovery_plan
+                        .as_ref()
+                        .and_then(|plan| plan.claude_resume_session_id.clone()),
                     prompt_override: recovery_plan
                         .as_ref()
                         .and_then(|plan| plan.prompt_override.clone()),

--- a/src/main/tests/main_loop/runtime.rs
+++ b/src/main/tests/main_loop/runtime.rs
@@ -191,6 +191,50 @@ fn main_recovery_plan_prefers_native_thread() {
 }
 
 #[test]
+fn main_recovery_plan_resumes_claude_only_at_matching_run_and_worktree_boundary() {
+    let temp = tempfile::tempdir().unwrap();
+    let config = runtime_reconcile_test_config(temp.path());
+    let issue = tracker_issue("In Progress");
+    let workspace = temp.path().join("issue-29");
+    std::fs::create_dir_all(&workspace).unwrap();
+    init_clean_git_workspace(&workspace);
+    let mut state = active_runtime_state("#29");
+    state.backend = "claude-code".into();
+    state.backend_session_id = Some("claude-session-29".into());
+    state.workspace_path = Some(workspace.clone());
+    state.run_id = Some("run-29".into());
+    let mut record = main_tmux_session_record("#29", SessionStatus::Failed);
+    record.issue_id = Some(issue.id.clone());
+    record.backend = "claude-code".into();
+    record.session_source = Some("claude-code-stream-json".into());
+    record.session_name = "claude-session-29".into();
+    record.thread = Some("claude-session-29".into());
+    record.run_id = Some("run-29".into());
+    record.worktree = workspace;
+    save_session_registry(
+        &session_registry_path(&config),
+        &shea_symphony::session_registry::SessionRegistry {
+            sessions: vec![record],
+        },
+    )
+    .unwrap();
+
+    let plan = main_recovery_plan(&config, &issue, &state).unwrap();
+
+    assert_eq!(plan.mode, MainRecoveryMode::NativeThread);
+    assert_eq!(
+        plan.claude_resume_session_id.as_deref(),
+        Some("claude-session-29")
+    );
+    assert_eq!(plan.app_server_resume_thread_id, None);
+    assert_eq!(plan.prompt_override, None);
+
+    state.run_id = Some("different-run".into());
+    let mismatched = main_recovery_plan(&config, &issue, &state).unwrap();
+    assert_eq!(mismatched.claude_resume_session_id, None);
+}
+
+#[test]
 fn main_recovery_plan_applicable_rejects_fresh_claim_state() {
     let mut state = active_runtime_state("#29");
     state.backend = "codex".into();

--- a/src/main/tests/merge.rs
+++ b/src/main/tests/merge.rs
@@ -31,6 +31,27 @@ fn merge_session_keeps_tmux_as_explicit_fallback() {
 }
 
 #[test]
+fn main_and_merge_sessions_share_configured_claude_backend() {
+    let workflow = WorkflowDefinition::parse(
+        "/tmp/WORKFLOW.md",
+        "---\ntracker:\n  kind: memory\nmain_lane:\n  backend: claude-code\nmerge_lane:\n  agent_backend: claude-code\nclaude:\n  command: /opt/bin/company-claude-wrapper --profile shea\n---\nPrompt",
+    )
+    .unwrap();
+    let config = RuntimeConfig::from_workflow(&workflow, Path::new("/tmp/WORKFLOW.md")).unwrap();
+
+    let main = agent_session_backend_spec(&config, AgentSessionLaneArg::Main).unwrap();
+    let merge = agent_session_backend_spec(&config, AgentSessionLaneArg::Merge).unwrap();
+
+    assert_eq!(main.backend, "claude-code");
+    assert_eq!(merge.backend, "claude-code");
+    assert_eq!(main.command, merge.command);
+    assert_eq!(
+        main.command,
+        "/opt/bin/company-claude-wrapper --profile shea"
+    );
+}
+
+#[test]
 fn clean_merge_tick_does_not_require_merge_agent_backend() {
     let temp = tempfile::tempdir().unwrap();
     let workflow_path = temp.path().join("WORKFLOW.md");

--- a/src/tracker/state.rs
+++ b/src/tracker/state.rs
@@ -47,7 +47,7 @@ pub(in crate::tracker) fn issue_matches_assignee_filter(
     let allowed: Vec<String> = current_login
         .into_iter()
         .chain(filter.additional_assignees.iter().map(String::as_str))
-        .map(|assignee| normalize_state(assignee))
+        .map(normalize_state)
         .collect();
 
     issue


### PR DESCRIPTION
## Summary

- backport the merged #510 Claude Code `stream-json` transport from source commit `12aab077` / PR #521 onto the protected 2606 runtime starting at `7214093a`
- connect the shared structured transport to the legacy 2606 Main and semantic Merge-agent paths, including fail-closed parsing, evidence, bounded resume, timeout, cancellation, and process-group cleanup
- carry the deterministic fixtures, configuration validation, focused regression coverage, operator docs, and local-worktree-only UAT harness
- preserve the 2606 dependency graph by adding only the already-transitive `libc` dependency; no Temporal runtime ownership or vendored App/CLI binaries are included

## 2606 compatibility notes

- The #510 Rust/lane patch applied cleanly to the legacy APIs.
- `Cargo.toml` and `Cargo.lock` were adapted deliberately instead of copied from `main`, avoiding the 2607 Temporal/SQLite dependency graph.
- A semantics-preserving `redundant_closure` cleanup in `src/tracker/state.rs` keeps strict clippy green with the current Rust toolchain.
- Existing Codex, dry-run, tracker, worktree, clean mechanical merge, and semantic merge regressions remain covered by the full suite.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
- `cargo test claude_code -- --nocapture`
- `cargo test merge -- --nocapture`
- `cargo test github_assignee_filter_allows_current_login_and_additional_assignees -- --nocapture`
- `SHEA_CLAUDE_UAT_COMMAND='claude --permission-mode acceptEdits --allowedTools Read,Edit,Write,Bash' cargo test claude_code_live_local_worktree_uat -- --ignored --nocapture` (passed disposable Main edit and semantic Merge conflict repair)
- `cargo tree --depth 1` confirms the legacy 2606 direct dependency graph plus `libc`, with no Temporal/SQLite stack
- vendored `.shea/bin/shea-symphony` and `.shea/app/shea-symphony-app` diff: none

Closes #515
