### PR TITLE
Bundle a versioned Legacy compatibility CLI with the App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ app/dist/
 app/.npm-cache/
 app/src-tauri/target/
 app/src-tauri/gen/
+app/src-tauri/binaries/
 .playwright-mcp
 .shea-symphony
 *storybook.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 description = "Rust implementation of an OpenAI Symphony-style orchestration harness with Shea Symphony extensions"
 license = "Apache-2.0"
+default-run = "shea-symphony"
+
+[[bin]]
+name = "shea-symphony-legacy"
+path = "src/legacy.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/app/README.md
+++ b/app/README.md
@@ -9,6 +9,10 @@ Symphony. The runnable surface is the first-screen Operator Desk: Human Todo and
 Lane Board. Tauri owns the local Autoloop process, launched through `autopilot loop`, and uses allowlisted
 Shea Symphony CLI commands for readback; there is no runtime Node bridge.
 
+During the 2607 transition, those legacy operator commands come from the
+`shea-symphony-legacy` sidecar built from the same `main` revision as the App.
+The default `shea-symphony` executable remains the Temporal worker.
+
 ## Run
 
 ```sh
@@ -26,11 +30,27 @@ npm run dev
 
 Open the Vite URL printed by the command.
 
+## Bundle The Legacy Sidecar
+
+Release bundles must stage a target-specific Legacy executable before Tauri
+builds the App:
+
+```sh
+cd app
+npm run bundle:legacy
+```
+
+The staging script builds `shea-symphony-legacy` for the active Rust target,
+checks its machine-readable role and source revision, and places it under
+`src-tauri/binaries/` using Tauri's sidecar naming convention. The command
+builds the supported local Tauri App bundle (without invoking an installer or
+signing flow). It fails clearly when the staged artifact is missing.
+
 ## Live CLI Bridge
 
 The desktop bridge uses:
 
-`workflows/shea-symphony.md`
+`.shea/workflows/shea-symphony.md`
 
 Tauri commands are intentionally allowlisted:
 
@@ -43,6 +63,23 @@ Tauri commands are intentionally allowlisted:
 
 The read surfaces call the Shea Symphony CLI directly from Rust. Tauri does not
 perform direct `git` or `gh` state reads for the Operator Desk.
+
+CLI resolution is deterministic:
+
+1. an explicit workspace `cli_path`;
+2. the validated installed Legacy runtime discovery record;
+3. in debug builds only, `cargo run --bin shea-symphony-legacy` from the engine
+   checkout.
+
+An explicit path may select an unmarked protected-2606 binary as a temporary
+operator escape hatch. Automatic discovery never accepts an unmarked binary or
+the `temporal_worker` role. On startup, a packaged App validates its bundled
+sidecar and atomically publishes a credential-free discovery record at
+`~/.shea-symphony/runtime-discovery.json` (or
+`SHEA_SYMPHONY_RUNTIME_DISCOVERY_PATH`). The record includes the executable
+path, SHA-256 digest, role, compatibility contract, version, revision, target,
+platform, and architecture. This integrity check detects stale or mismatched
+local artifacts; it is not publisher signing.
 
 Browser preview returns live-shaped fixture data. Use it for visual QA when the
 desktop shell is not running.

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --host 127.0.0.1",
     "dev:tauri": "vite --host 127.0.0.1 --port 1420 --strictPort",
     "build": "vite build",
+    "bundle:legacy": "../scripts/stage-legacy-sidecar.sh && SHEA_SYMPHONY_REQUIRE_LEGACY_SIDECAR=1 tauri build --bundles app",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "preview": "vite preview --host 127.0.0.1",
     "tauri": "tauri",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4289,6 +4289,7 @@ dependencies = [
  "crossterm",
  "futures",
  "futures-util",
+ "libc",
  "liquid",
  "ratatui",
  "rusqlite",
@@ -4313,8 +4314,10 @@ dependencies = [
 name = "shea-symphony-app"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "serde",
  "serde_json",
+ "sha2",
  "shea-symphony",
  "tauri",
  "tauri-build",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2021"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
+hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 shea-symphony = { path = "../.." }
 tauri = { version = "2", features = [] }
 tokio = { version = "1", features = ["time"] }

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -1,3 +1,20 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=SHEA_SYMPHONY_REQUIRE_LEGACY_SIDECAR");
+    if std::env::var_os("SHEA_SYMPHONY_REQUIRE_LEGACY_SIDECAR").is_some() {
+        let target = std::env::var("TARGET").expect("Cargo TARGET is unavailable");
+        let suffix = if target.contains("windows") {
+            ".exe"
+        } else {
+            ""
+        };
+        let sidecar = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join("binaries")
+            .join(format!("shea-symphony-legacy-{target}{suffix}"));
+        assert!(
+            sidecar.is_file(),
+            "missing required target-specific Legacy sidecar: {}",
+            sidecar.display()
+        );
+    }
     tauri_build::build();
 }

--- a/app/src-tauri/src/autoloop.rs
+++ b/app/src-tauri/src/autoloop.rs
@@ -126,9 +126,9 @@ pub fn start_autoloop(
     let mut command = shea_command_for_workspace(
         &args.iter().map(String::as_str).collect::<Vec<_>>(),
         &workspace_profile,
-    );
+    )?;
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let command_for_event = command_preview_for_workspace(&args, &workspace_profile);
+    let command_for_event = command_preview_for_workspace(&args, &workspace_profile)?;
     let mut child = match command.spawn() {
         Ok(child) => child,
         Err(error) => {

--- a/app/src-tauri/src/cli.rs
+++ b/app/src-tauri/src/cli.rs
@@ -7,6 +7,7 @@ use std::{
 use serde::Serialize;
 use serde_json::{json, Value};
 
+use crate::runtime;
 use crate::workspace::WorkspaceProfile;
 
 pub const DEFAULT_WORKFLOW_PATH: &str = ".shea/workflows/shea-symphony.md";
@@ -33,7 +34,10 @@ pub struct CommandRun {
 pub fn run_shea_read_for_workspace(args: &[String], workspace: &WorkspaceProfile) -> CommandRun {
     let started_at = Instant::now();
     let string_args = args.iter().map(String::as_str).collect::<Vec<_>>();
-    let mut command = shea_command_for_workspace(&string_args, workspace);
+    let mut command = match shea_command_for_workspace(&string_args, workspace) {
+        Ok(command) => command,
+        Err(error) => return command_run_from_error(args, started_at, error),
+    };
     match command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -80,8 +84,11 @@ pub fn now_ms() -> u128 {
         .unwrap_or(0)
 }
 
-pub fn shea_command_for_workspace(args: &[&str], workspace: &WorkspaceProfile) -> Command {
-    command_from_spec(shea_command_spec(args, workspace))
+pub fn shea_command_for_workspace(
+    args: &[&str],
+    workspace: &WorkspaceProfile,
+) -> Result<Command, String> {
+    Ok(command_from_spec(shea_command_spec(args, workspace)?))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -91,7 +98,18 @@ pub struct SheaCommandSpec {
     pub current_dir: PathBuf,
 }
 
-pub fn shea_command_spec(args: &[&str], workspace: &WorkspaceProfile) -> SheaCommandSpec {
+pub fn shea_command_spec(
+    args: &[&str],
+    workspace: &WorkspaceProfile,
+) -> Result<SheaCommandSpec, String> {
+    shea_command_spec_with_discovery(args, workspace, &runtime::default_discovery_path())
+}
+
+fn shea_command_spec_with_discovery(
+    args: &[&str],
+    workspace: &WorkspaceProfile,
+    discovery_path: &Path,
+) -> Result<SheaCommandSpec, String> {
     let engine_root = workspace.engine_path();
     let target_root = workspace.target_path();
     if let Some(cli_path) = workspace
@@ -101,63 +119,64 @@ pub fn shea_command_spec(args: &[&str], workspace: &WorkspaceProfile) -> SheaCom
         .filter(|value| !value.is_empty())
     {
         let path = PathBuf::from(cli_path);
-        return SheaCommandSpec {
-            program: if path.is_absolute() {
-                path
-            } else {
-                target_root.join(path)
-            },
+        let program = if path.is_absolute() {
+            path
+        } else {
+            target_root.join(path)
+        };
+        runtime::validate_explicit_runtime(&program)?;
+        return Ok(SheaCommandSpec {
+            program,
             args: args.iter().map(|arg| (*arg).to_string()).collect(),
             current_dir: target_root,
-        };
+        });
     }
-    if should_use_cargo_runner_for_engine(&engine_root) {
+    if let Some(program) = runtime::resolve_installed_runtime(discovery_path)? {
+        return Ok(SheaCommandSpec {
+            program,
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            current_dir: target_root,
+        });
+    }
+    if cfg!(debug_assertions) {
         let mut command_args = vec![
             "run".into(),
             "--quiet".into(),
+            "--bin".into(),
+            "shea-symphony-legacy".into(),
             "--manifest-path".into(),
             engine_root.join("Cargo.toml").display().to_string(),
             "--".into(),
         ];
         command_args.extend(args.iter().map(|arg| (*arg).to_string()));
-        SheaCommandSpec {
+        Ok(SheaCommandSpec {
             program: PathBuf::from("cargo"),
             args: command_args,
             current_dir: target_root,
-        }
+        })
     } else {
-        SheaCommandSpec {
-            program: engine_root
-                .join("target")
-                .join("debug")
-                .join("shea-symphony"),
-            args: args.iter().map(|arg| (*arg).to_string()).collect(),
-            current_dir: target_root,
-        }
+        Err(format!(
+            "no validated installed Legacy runtime was found at {}; configure explicit cli_path or reinstall the App bundle",
+            discovery_path.display()
+        ))
     }
 }
 
-pub fn command_preview_for_workspace(args: &[String], workspace: &WorkspaceProfile) -> Vec<String> {
+pub fn command_preview_for_workspace(
+    args: &[String],
+    workspace: &WorkspaceProfile,
+) -> Result<Vec<String>, String> {
     let string_args = args.iter().map(String::as_str).collect::<Vec<_>>();
-    let spec = shea_command_spec(&string_args, workspace);
+    let spec = shea_command_spec(&string_args, workspace)?;
     let mut preview = vec![spec.program.display().to_string()];
     preview.extend(spec.args);
-    preview
+    Ok(preview)
 }
 
 fn command_from_spec(spec: SheaCommandSpec) -> Command {
     let mut command = Command::new(spec.program);
     command.args(spec.args).current_dir(spec.current_dir);
     command
-}
-
-fn should_use_cargo_runner_for_engine(engine_root: &Path) -> bool {
-    cfg!(debug_assertions)
-        || !engine_root
-            .join("target")
-            .join("debug")
-            .join("shea-symphony")
-            .exists()
 }
 
 fn command_run_from_output(
@@ -254,9 +273,10 @@ fn parse_canonical_main_worktree(text: &str) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_canonical_main_worktree, shea_command_spec};
+    use super::{parse_canonical_main_worktree, shea_command_spec_with_discovery};
     use crate::workspace::WorkspaceProfile;
     use std::path::PathBuf;
+    use tempfile::TempDir;
 
     #[test]
     fn parses_main_worktree_from_git_porcelain_output() {
@@ -289,10 +309,13 @@ branch refs/heads/main
             error: None,
         };
 
-        let spec = shea_command_spec(
+        let temp = TempDir::new().unwrap();
+        let spec = shea_command_spec_with_discovery(
             &["autopilot", "plan", ".shea/workflows/shea-symphony.md"],
             &profile,
-        );
+            &temp.path().join("missing-discovery.json"),
+        )
+        .unwrap();
 
         assert_eq!(spec.program, PathBuf::from("cargo"));
         assert_eq!(spec.current_dir, target_root);
@@ -301,6 +324,8 @@ branch refs/heads/main
             vec![
                 "run",
                 "--quiet",
+                "--bin",
+                "shea-symphony-legacy",
                 "--manifest-path",
                 "/engine/shea-symphony/Cargo.toml",
                 "--",
@@ -313,6 +338,9 @@ branch refs/heads/main
 
     #[test]
     fn command_spec_uses_profile_cli_path_relative_to_target() {
+        let temp = TempDir::new().unwrap();
+        let invalid_discovery = temp.path().join("invalid-discovery.json");
+        std::fs::write(&invalid_discovery, "not json").unwrap();
         let target_root = PathBuf::from("/target/repo");
         let profile = WorkspaceProfile {
             engine_root: "/engine/shea-symphony".into(),
@@ -323,7 +351,12 @@ branch refs/heads/main
             error: None,
         };
 
-        let spec = shea_command_spec(&["doctor", ".shea/workflows/shea-symphony.md"], &profile);
+        let spec = shea_command_spec_with_discovery(
+            &["doctor", ".shea/workflows/shea-symphony.md"],
+            &profile,
+            &invalid_discovery,
+        )
+        .unwrap();
 
         assert_eq!(spec.program, target_root.join(".shea/bin/shea-symphony"));
         assert_eq!(spec.current_dir, target_root);

--- a/app/src-tauri/src/main.rs
+++ b/app/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod external_links;
 mod github;
 mod handoff_prompts;
 mod read_surfaces;
+mod runtime;
 mod target_context;
 mod target_runtime;
 mod temporal_health;
@@ -15,6 +16,8 @@ use autoloop_state::LoopManager;
 use workspace::{default_profile_path, initial_workspace_profile, WorkspaceManager};
 
 fn main() {
+    runtime::publish_installed_discovery_if_available()
+        .expect("failed to prepare the bundled Shea Symphony Legacy runtime");
     let engine_root = cli::repo_root();
     let profile_path = default_profile_path();
     let args = std::env::args_os().collect::<Vec<_>>();

--- a/app/src-tauri/src/read_surfaces.rs
+++ b/app/src-tauri/src/read_surfaces.rs
@@ -42,6 +42,7 @@ pub async fn get_runtime_snapshot(
             ],
             &workspace_profile,
         )
+        .map_err(|error| format!("failed to resolve Shea runtime: {error}"))?
         .output()
         .map_err(|error| format!("failed to run status snapshot: {error}"))?;
         if !output.status.success() {
@@ -1159,6 +1160,7 @@ fn project_issue_readback(issue: &str, workspace: &WorkspaceProfile) -> Option<V
         ],
         workspace,
     )
+    .ok()?
     .output()
     .ok()?;
     let stderr = String::from_utf8_lossy(&output.stderr);

--- a/app/src-tauri/src/runtime.rs
+++ b/app/src-tauri/src/runtime.rs
@@ -1,0 +1,443 @@
+use std::{
+    env, fs,
+    fs::OpenOptions,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use shea_symphony::runtime_identity::{
+    RuntimeIdentity, RuntimeRole, RUNTIME_IDENTITY_SCHEMA_VERSION, RUNTIME_INFO_FLAG,
+};
+
+const DISCOVERY_SCHEMA_VERSION: u32 = 1;
+const LEGACY_COMPATIBILITY: &str = "shea-legacy-cli-v1";
+const DISCOVERY_FILE_NAME: &str = "runtime-discovery.json";
+const SIDECAR_FILE_NAME: &str = "shea-symphony-legacy";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeDiscovery {
+    pub schema_version: u32,
+    pub binary_role: RuntimeRole,
+    pub cli_version: String,
+    pub app_version: String,
+    pub source_revision: String,
+    pub target: String,
+    pub platform: String,
+    pub architecture: String,
+    pub compatibility: String,
+    pub executable_path: String,
+    pub sha256: String,
+}
+
+pub fn default_discovery_path() -> PathBuf {
+    if let Some(path) = env::var_os("SHEA_SYMPHONY_RUNTIME_DISCOVERY_PATH") {
+        return PathBuf::from(path);
+    }
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".shea-symphony")
+        .join(DISCOVERY_FILE_NAME)
+}
+
+pub fn validate_explicit_runtime(path: &Path) -> Result<(), String> {
+    let Some(identity) = probe_runtime(path)? else {
+        // Compatibility exception: an operator may explicitly select an
+        // unmarked 2606 binary, but it is never eligible for discovery.
+        return Ok(());
+    };
+    validate_legacy_identity(&identity, false)
+}
+
+pub fn resolve_installed_runtime(discovery_path: &Path) -> Result<Option<PathBuf>, String> {
+    if !discovery_path.is_file() {
+        return Ok(None);
+    }
+    let text = fs::read_to_string(discovery_path).map_err(|error| {
+        format!(
+            "installed Legacy runtime discovery is unreadable at {}: {error}",
+            discovery_path.display()
+        )
+    })?;
+    let discovery: RuntimeDiscovery = serde_json::from_str(&text).map_err(|error| {
+        format!(
+            "installed Legacy runtime discovery is invalid at {}: {error}",
+            discovery_path.display()
+        )
+    })?;
+    validate_discovery(&discovery)?;
+    let executable = PathBuf::from(&discovery.executable_path);
+    let actual_digest = sha256_file(&executable)?;
+    if actual_digest != discovery.sha256 {
+        return Err(format!(
+            "installed Legacy runtime digest mismatch for {}",
+            executable.display()
+        ));
+    }
+    let identity = probe_runtime(&executable)?.ok_or_else(|| {
+        format!(
+            "automatically discovered runtime is unmarked: {}",
+            executable.display()
+        )
+    })?;
+    validate_legacy_identity(&identity, true)?;
+    validate_discovery_identity(&discovery, &identity)?;
+    Ok(Some(executable))
+}
+
+pub fn publish_installed_discovery_if_available() -> Result<Option<PathBuf>, String> {
+    let executable = installed_sidecar_path()?;
+    if !executable.is_file() {
+        if cfg!(debug_assertions) && env::var_os("SHEA_SYMPHONY_BUNDLED_CLI_PATH").is_none() {
+            return Ok(None);
+        }
+        return Err(format!(
+            "bundled Legacy runtime is missing: {}",
+            executable.display()
+        ));
+    }
+    let discovery_path = default_discovery_path();
+    publish_discovery(&executable, &discovery_path)?;
+    Ok(Some(discovery_path))
+}
+
+fn publish_discovery(executable: &Path, discovery_path: &Path) -> Result<(), String> {
+    let executable = fs::canonicalize(executable).map_err(|error| {
+        format!(
+            "bundled Legacy runtime path is unavailable at {}: {error}",
+            executable.display()
+        )
+    })?;
+    let identity = probe_runtime(&executable)?.ok_or_else(|| {
+        format!(
+            "bundled Legacy runtime does not expose {RUNTIME_INFO_FLAG}: {}",
+            executable.display()
+        )
+    })?;
+    validate_legacy_identity(&identity, true)?;
+    let discovery = RuntimeDiscovery {
+        schema_version: DISCOVERY_SCHEMA_VERSION,
+        binary_role: identity.binary_role,
+        cli_version: identity.cli_version.clone(),
+        app_version: env!("CARGO_PKG_VERSION").into(),
+        source_revision: identity.source_revision.clone(),
+        target: identity.target.clone(),
+        platform: identity.platform.clone(),
+        architecture: identity.architecture.clone(),
+        compatibility: identity.compatibility.clone(),
+        executable_path: executable.display().to_string(),
+        sha256: sha256_file(&executable)?,
+    };
+    validate_discovery(&discovery)?;
+
+    let parent = discovery_path.parent().ok_or_else(|| {
+        format!(
+            "runtime discovery path has no parent: {}",
+            discovery_path.display()
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "could not create runtime discovery directory {}: {error}",
+            parent.display()
+        )
+    })?;
+    let temporary_path = discovery_path.with_extension(format!("tmp-{}", std::process::id()));
+    match fs::remove_file(&temporary_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error.to_string()),
+    }
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary_path)
+        .map_err(|error| error.to_string())?;
+    file.write_all(
+        serde_json::to_string_pretty(&discovery)
+            .map_err(|error| error.to_string())?
+            .as_bytes(),
+    )
+    .map_err(|error| error.to_string())?;
+    file.write_all(b"\n").map_err(|error| error.to_string())?;
+    file.sync_all().map_err(|error| error.to_string())?;
+    fs::rename(&temporary_path, discovery_path).map_err(|error| {
+        format!(
+            "could not atomically publish runtime discovery {}: {error}",
+            discovery_path.display()
+        )
+    })?;
+
+    resolve_installed_runtime(discovery_path)?.ok_or_else(|| {
+        format!(
+            "runtime discovery readback failed at {}",
+            discovery_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn installed_sidecar_path() -> Result<PathBuf, String> {
+    if let Some(path) = env::var_os("SHEA_SYMPHONY_BUNDLED_CLI_PATH") {
+        return Ok(PathBuf::from(path));
+    }
+    let executable = env::current_exe()
+        .map_err(|error| format!("could not resolve App executable path: {error}"))?;
+    let directory = executable
+        .parent()
+        .ok_or_else(|| "App executable path has no parent".to_string())?;
+    let suffix = if cfg!(windows) { ".exe" } else { "" };
+    Ok(directory.join(format!("{SIDECAR_FILE_NAME}{suffix}")))
+}
+
+fn probe_runtime(path: &Path) -> Result<Option<RuntimeIdentity>, String> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let output = Command::new(path)
+        .arg(RUNTIME_INFO_FLAG)
+        .output()
+        .map_err(|error| format!("could not inspect runtime {}: {error}", path.display()))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim())
+        .map(Some)
+        .map_err(|error| {
+            format!(
+                "runtime identity from {} is invalid: {error}",
+                path.display()
+            )
+        })
+}
+
+fn validate_legacy_identity(
+    identity: &RuntimeIdentity,
+    require_same_build: bool,
+) -> Result<(), String> {
+    if identity.schema_version != RUNTIME_IDENTITY_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported runtime identity schema {}",
+            identity.schema_version
+        ));
+    }
+    if identity.binary_role == RuntimeRole::TemporalWorker {
+        return Err(
+            "selected binary has role temporal_worker; the App requires legacy_cli semantics"
+                .into(),
+        );
+    }
+    if identity.binary_role != RuntimeRole::LegacyCli
+        || identity.compatibility != LEGACY_COMPATIBILITY
+    {
+        return Err("selected binary does not implement shea-legacy-cli-v1".into());
+    }
+    if require_same_build {
+        let expected = RuntimeIdentity::for_role(RuntimeRole::LegacyCli);
+        if identity.cli_version != expected.cli_version
+            || identity.source_revision != expected.source_revision
+            || identity.target != expected.target
+            || identity.platform != expected.platform
+            || identity.architecture != expected.architecture
+        {
+            return Err("bundled Legacy runtime does not match the App build identity".into());
+        }
+    }
+    Ok(())
+}
+
+fn validate_discovery(discovery: &RuntimeDiscovery) -> Result<(), String> {
+    if discovery.schema_version != DISCOVERY_SCHEMA_VERSION {
+        return Err(format!(
+            "unsupported runtime discovery schema {}",
+            discovery.schema_version
+        ));
+    }
+    if discovery.app_version != env!("CARGO_PKG_VERSION") {
+        return Err("runtime discovery belongs to a different App version".into());
+    }
+    if discovery.binary_role != RuntimeRole::LegacyCli
+        || discovery.compatibility != LEGACY_COMPATIBILITY
+    {
+        return Err("runtime discovery does not describe a compatible Legacy CLI".into());
+    }
+    if !Path::new(&discovery.executable_path).is_absolute() {
+        return Err("runtime discovery executable_path must be absolute".into());
+    }
+    if discovery.sha256.len() != 64
+        || !discovery
+            .sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("runtime discovery sha256 is invalid".into());
+    }
+    Ok(())
+}
+
+fn validate_discovery_identity(
+    discovery: &RuntimeDiscovery,
+    identity: &RuntimeIdentity,
+) -> Result<(), String> {
+    if discovery.binary_role != identity.binary_role
+        || discovery.cli_version != identity.cli_version
+        || discovery.source_revision != identity.source_revision
+        || discovery.target != identity.target
+        || discovery.platform != identity.platform
+        || discovery.architecture != identity.architecture
+        || discovery.compatibility != identity.compatibility
+    {
+        return Err("runtime discovery metadata is stale or incompatible".into());
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    let mut file = fs::File::open(path)
+        .map_err(|error| format!("could not hash runtime {}: {error}", path.display()))?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|error| error.to_string())?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(hex::encode(digest.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_known_temporal_binary_before_launch() {
+        let temp = TempDir::new().unwrap();
+        let binary = fake_runtime(temp.path(), RuntimeRole::TemporalWorker);
+
+        let error = validate_explicit_runtime(&binary).unwrap_err();
+
+        assert!(error.contains("temporal_worker"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn publishes_and_validates_atomic_legacy_discovery() {
+        let temp = TempDir::new().unwrap();
+        let binary = fake_runtime(temp.path(), RuntimeRole::LegacyCli);
+        let discovery = temp.path().join("state/runtime.json");
+
+        publish_discovery(&binary, &discovery).unwrap();
+
+        assert_eq!(
+            resolve_installed_runtime(&discovery).unwrap(),
+            Some(fs::canonicalize(binary).unwrap())
+        );
+        assert!(!discovery
+            .with_extension(format!("tmp-{}", std::process::id()))
+            .exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_tampered_runtime_after_discovery() {
+        let temp = TempDir::new().unwrap();
+        let binary = fake_runtime(temp.path(), RuntimeRole::LegacyCli);
+        let discovery = temp.path().join("runtime.json");
+        publish_discovery(&binary, &discovery).unwrap();
+
+        fs::write(&binary, "tampered").unwrap();
+        let error = resolve_installed_runtime(&discovery).unwrap_err();
+
+        assert!(error.contains("digest mismatch"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_stale_discovery_metadata() {
+        let temp = TempDir::new().unwrap();
+        let binary = fake_runtime(temp.path(), RuntimeRole::LegacyCli);
+        let discovery_path = temp.path().join("runtime.json");
+        publish_discovery(&binary, &discovery_path).unwrap();
+        let mut discovery: RuntimeDiscovery =
+            serde_json::from_str(&fs::read_to_string(&discovery_path).unwrap()).unwrap();
+        discovery.source_revision = "stale-revision".into();
+        fs::write(
+            &discovery_path,
+            serde_json::to_string_pretty(&discovery).unwrap(),
+        )
+        .unwrap();
+
+        let error = resolve_installed_runtime(&discovery_path).unwrap_err();
+
+        assert!(error.contains("stale or incompatible"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unmarked_runtime_is_allowed_only_as_an_explicit_override() {
+        let temp = TempDir::new().unwrap();
+        let binary = temp.path().join("unmarked-2606");
+        fs::write(&binary, "#!/bin/sh\nexit 2\n").unwrap();
+        let mut permissions = fs::metadata(&binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&binary, permissions).unwrap();
+
+        validate_explicit_runtime(&binary).unwrap();
+
+        let identity = RuntimeIdentity::for_role(RuntimeRole::LegacyCli);
+        let discovery = RuntimeDiscovery {
+            schema_version: DISCOVERY_SCHEMA_VERSION,
+            binary_role: RuntimeRole::LegacyCli,
+            cli_version: identity.cli_version,
+            app_version: env!("CARGO_PKG_VERSION").into(),
+            source_revision: identity.source_revision,
+            target: identity.target,
+            platform: identity.platform,
+            architecture: identity.architecture,
+            compatibility: identity.compatibility,
+            executable_path: fs::canonicalize(&binary).unwrap().display().to_string(),
+            sha256: sha256_file(&binary).unwrap(),
+        };
+        let discovery_path = temp.path().join("runtime.json");
+        fs::write(
+            &discovery_path,
+            serde_json::to_string_pretty(&discovery).unwrap(),
+        )
+        .unwrap();
+
+        let error = resolve_installed_runtime(&discovery_path).unwrap_err();
+        assert!(error.contains("automatically discovered runtime is unmarked"));
+    }
+
+    #[cfg(unix)]
+    fn fake_runtime(root: &Path, role: RuntimeRole) -> PathBuf {
+        let path = root.join(match role {
+            RuntimeRole::TemporalWorker => "temporal-runtime",
+            RuntimeRole::LegacyCli => "legacy-runtime",
+        });
+        let identity = RuntimeIdentity::for_role(role);
+        fs::write(
+            &path,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' '{}'\n",
+                serde_json::to_string(&identity).unwrap()
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).unwrap();
+        path
+    }
+}

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -24,8 +24,11 @@
     }
   },
   "bundle": {
-    "active": false,
+    "active": true,
     "targets": "all",
-    "icon": []
+    "icon": [],
+    "externalBin": [
+      "binaries/shea-symphony-legacy"
+    ]
   }
 }

--- a/app/test/legacy-sidecar.test.mjs
+++ b/app/test/legacy-sidecar.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const configUrl = new URL('../src-tauri/tauri.conf.json', import.meta.url);
+const packageUrl = new URL('../package.json', import.meta.url);
+const stageScript = new URL('../../scripts/stage-legacy-sidecar.sh', import.meta.url);
+
+test('Tauri bundle declares the versioned Legacy sidecar', () => {
+  const config = JSON.parse(readFileSync(configUrl, 'utf8'));
+
+  assert.equal(config.bundle.active, true);
+  assert.deepEqual(config.bundle.externalBin, ['binaries/shea-symphony-legacy']);
+});
+
+test('local bundle script stages Legacy before building the App bundle', () => {
+  const packageJson = JSON.parse(readFileSync(packageUrl, 'utf8'));
+
+  assert.match(packageJson.scripts['bundle:legacy'], /stage-legacy-sidecar\.sh/);
+  assert.match(packageJson.scripts['bundle:legacy'], /tauri build --bundles app/);
+});
+
+test('packaging preflight fails clearly when the target artifact is absent', () => {
+  const result = spawnSync(stageScript.pathname, ['--check'], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      SHEA_LEGACY_SIDECAR_TARGET: 'missing-artifact-test-target'
+    }
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /missing target-specific Legacy sidecar/);
+  assert.match(result.stderr, /missing-artifact-test-target/);
+});

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,36 @@
+use std::{env, process::Command};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=SHEA_SOURCE_REVISION");
+    track_git_head();
+
+    let source_revision = env::var("SHEA_SOURCE_REVISION")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| git_stdout(&["rev-parse", "HEAD"]))
+        .unwrap_or_else(|| "unknown".into());
+    let target = env::var("TARGET").unwrap_or_else(|_| "unknown".into());
+
+    println!("cargo:rustc-env=SHEA_SOURCE_REVISION={source_revision}");
+    println!("cargo:rustc-env=SHEA_TARGET_TRIPLE={target}");
+}
+
+fn track_git_head() {
+    if let Some(head_path) = git_stdout(&["rev-parse", "--git-path", "HEAD"]) {
+        println!("cargo:rerun-if-changed={head_path}");
+    }
+    if let Some(head_ref) = git_stdout(&["symbolic-ref", "-q", "HEAD"]) {
+        if let Some(ref_path) = git_stdout(&["rev-parse", "--git-path", &head_ref]) {
+            println!("cargo:rerun-if-changed={ref_path}");
+        }
+    }
+}
+
+fn git_stdout(args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/docs/legacy-runtime-distribution.md
+++ b/docs/legacy-runtime-distribution.md
@@ -1,0 +1,91 @@
+# Legacy Runtime Distribution
+
+## Purpose
+
+Shea Symphony temporarily ships two executables from the same `main` revision:
+
+- `shea-symphony`, the canonical Temporal worker;
+- `shea-symphony-legacy`, the compatibility CLI used by current App operator
+  surfaces.
+
+The split lets the App move off the protected `2606-MVP` build without changing
+the default runtime role or turning the old command graph into a second 2607
+architecture.
+
+## Identity Contract
+
+Each executable accepts exactly `--runtime-info` and emits versioned JSON with:
+
+- schema version and binary role;
+- CLI package version and source revision;
+- Rust target triple, platform, and architecture;
+- a versioned compatibility contract.
+
+The Temporal worker reports `temporal_worker` and
+`shea-temporal-worker-v1`. The Legacy CLI reports `legacy_cli` and
+`shea-legacy-cli-v1`. This output is credential-free build metadata. It is used
+for local role and integrity checks, not as a code-signing claim.
+
+## Bundle Pipeline
+
+Run the release pipeline from `app/`:
+
+```sh
+npm run bundle:legacy
+```
+
+`scripts/stage-legacy-sidecar.sh` resolves the Rust target, builds the Legacy
+binary with the root lockfile, stages the target-specific artifact under
+`app/src-tauri/binaries/`, and verifies that its role, compatibility contract,
+and embedded source revision match the checkout. The Tauri build then requires
+and embeds that staged sidecar in the supported local App bundle; installer,
+signing, and notarization flows remain out of scope. Generated binaries are
+ignored by Git.
+
+Use `scripts/stage-legacy-sidecar.sh --check` to test for the expected staged
+artifact without building it. Setting `SHEA_LEGACY_SIDECAR_TARGET` makes target
+selection explicit for cross-target packaging.
+
+## Discovery And Resolution
+
+At packaged App startup, the Tauri backend locates its bundled sidecar,
+validates the exact Legacy role and same-build identity, computes its SHA-256
+digest, and atomically publishes:
+
+```text
+~/.shea-symphony/runtime-discovery.json
+```
+
+Tests and controlled installs can override that path with
+`SHEA_SYMPHONY_RUNTIME_DISCOVERY_PATH`; packaging can provide an explicit
+sidecar path through `SHEA_SYMPHONY_BUNDLED_CLI_PATH`.
+
+The discovery record contains the executable path, digest, App and CLI
+versions, source revision, target, platform, architecture, role, and
+compatibility contract. Every automatic resolution rechecks the digest,
+executable identity, and record metadata. A missing, stale, mismatched,
+unmarked, tampered, or Temporal-role binary fails closed.
+
+The App resolves commands in this order:
+
+1. workspace `cli_path`;
+2. validated installed discovery;
+3. debug-only cargo runner for `shea-symphony-legacy`.
+
+Explicit `cli_path` is the only compatibility exception: an operator may point
+it at an unmarked protected-2606 binary while completing migration. If an
+explicit binary does expose identity, it must be the Legacy role. Release
+builds never silently fall back to Cargo or an unmarked discovery record.
+
+## Retirement
+
+Stop creating new protected-2606 App/CLI bootstrap builds after the `main`
+sidecar bundle is release-validated, current dogfood installs use it, and no
+2606-only operational blocker remains. Retain the protected branch as a
+recovery and behavior oracle until the Temporal product path covers the current
+operator surfaces and bootstrap-retirement work is complete.
+
+Remove `shea-symphony-legacy`, its discovery record, and the App sidecar only
+when the App no longer calls the legacy command graph and recovery procedures
+no longer depend on that executable. That removal must not delete the protected
+history or its acceptance evidence.

--- a/docs/milestones/2607-hardening/CODE-OWNERSHIP-MAP.md
+++ b/docs/milestones/2607-hardening/CODE-OWNERSHIP-MAP.md
@@ -58,6 +58,13 @@ These modules may be read to preserve proven tracker, handoff, review, merge,
 and recovery semantics. Do not add new 2607 runtime features there unless the
 issue explicitly says it is maintaining the protected MVP line.
 
+The issue #534 Legacy sidecar is the explicit migration exception. Its
+`src/legacy.rs` composition root may dispatch the existing command modules so
+the App can stop depending on a protected-branch binary. Changes there are
+limited to compatibility, packaging, identity, and migration safety. New 2607
+runtime behavior still belongs under `src/symphony/**`, and
+`shea-symphony-legacy` must never become a second orchestration spine.
+
 ## Context Preservation
 
 The old entrypoint and CLI behavior are not lost when the 2607 default binary

--- a/docs/milestones/2607-hardening/README.md
+++ b/docs/milestones/2607-hardening/README.md
@@ -40,6 +40,22 @@ Activity, Coordinator, Tauri, SQLite, and operator-action contracts; the
 vendored App/CLI bootstrap, Autoloop, lane/runtime ownership, and product CLI
 command graph are retired.
 
+Issue #534 establishes one bounded transition exception: `main` also builds a
+versioned `shea-symphony-legacy` executable for the current App's allowlisted
+operator commands. It reuses the already-present legacy CLI modules but is a
+separate composition root from the default `shea-symphony` Temporal worker.
+The App bundles and validates this sidecar; Temporal never invokes it. This
+exception replaces day-to-day App dependence on a protected-branch build and
+does not authorize new product behavior in the legacy command graph.
+
+Stop producing new protected-2606 bootstrap builds once the `main` Legacy
+sidecar and App bundle have passed release validation, the dogfood App has
+migrated to that bundle, and no 2606-only operational blocker remains. Keep the
+protected branch as a recovery and behavior oracle until the Temporal product
+path covers the operator surfaces and the remaining bootstrap-retirement work
+is closed. Delete the Legacy sidecar when those surfaces no longer call the old
+command graph and documented recovery no longer requires it.
+
 ## Milestone Goal
 
 Separate the reliable runtime named `Symphony` from the extension layer named
@@ -178,6 +194,7 @@ orchestration, and coverage at the new typed boundary.
 - `docs/milestones/2607-hardening/adr/0006-temporal-local-runtime-spine.md`
 - `docs/milestones/2607-hardening/adr/0007-local-state-db-read-model.md`
 - `docs/milestones/2608-workflow-graph-extension/README.md`
+- `docs/legacy-runtime-distribution.md`
 
 ## Open Questions
 

--- a/docs/milestones/2607-hardening/RUNTIME-ROLE-MAPPING.md
+++ b/docs/milestones/2607-hardening/RUNTIME-ROLE-MAPPING.md
@@ -35,6 +35,22 @@ The current repo already has useful seams:
 2607 should migrate these behaviors into Temporal-backed boundaries without
 renaming every existing concept first.
 
+## Executable Roles
+
+The crate has two explicit composition roots during migration:
+
+- `shea-symphony` has role `temporal_worker` and compatibility
+  `shea-temporal-worker-v1`;
+- `shea-symphony-legacy` has role `legacy_cli` and compatibility
+  `shea-legacy-cli-v1`.
+
+Both expose exact `--runtime-info` JSON containing schema, role, package
+version, source revision, target, platform, architecture, and compatibility.
+The shared build identity lets the App reject a Temporal worker, stale binary,
+wrong target, or mismatched Legacy sidecar before launching a command. The
+Legacy role is an App bootstrap boundary only: it does not own Temporal
+workflow durability and Temporal does not launch or wrap it.
+
 ## Temporal
 
 Temporal is the durable local control plane.

--- a/docs/milestones/2607-hardening/TEMPORAL-SPINE.md
+++ b/docs/milestones/2607-hardening/TEMPORAL-SPINE.md
@@ -18,6 +18,12 @@ loop as a compatibility or second durable runtime. This does not prohibit
 reviewed reuse of bounded Rust components that are extracted from that
 orchestration ownership and placed behind new typed boundaries.
 
+The transitional `shea-symphony-legacy` App sidecar is not part of this spine.
+It is a separately identified executable for the App surfaces that have not yet
+migrated, and it replaces their routine dependence on a protected-branch build.
+Neither `IssueWorkflow` nor any Activity may invoke it. The default
+`shea-symphony` executable remains exclusively the Temporal worker.
+
 ## Hard Decision
 
 Use Temporal local-first:

--- a/docs/milestones/2607-hardening/WORKSPACE-CONFIG.md
+++ b/docs/milestones/2607-hardening/WORKSPACE-CONFIG.md
@@ -11,7 +11,7 @@ for dogfood but is not the desired distribution or workspace model.
 
 Symphony binary:
 
-- resolved from local install location;
+- resolved from a validated local install record;
 - not vendored into target repositories.
 
 Canonical worktree:
@@ -39,6 +39,23 @@ Highest to lowest:
 2. repo `.shea/` team shared config;
 3. global `~/.shea/` config.
 
+## Transitional App CLI Resolution
+
+While the App still needs the legacy operator command graph, it resolves its
+CLI in this order:
+
+1. workspace `cli_path`;
+2. validated machine-local discovery at
+   `~/.shea-symphony/runtime-discovery.json`;
+3. debug-only `cargo run --bin shea-symphony-legacy` from the configured engine
+   checkout.
+
+The packaged App publishes the discovery record atomically from its bundled
+target-specific sidecar. Installed discovery requires the `legacy_cli` role,
+the `shea-legacy-cli-v1` contract, matching App build metadata, and a matching
+SHA-256 digest. Only an explicit `cli_path` may temporarily select an unmarked
+2606 executable; automatic discovery never does.
+
 ## Worktree Rule
 
 Symphony-created issue worktrees should live under the local runtime root by
@@ -46,7 +63,6 @@ default, not inside the canonical repository worktree.
 
 ## Open Questions
 
-- Exact install path lookup order for the Symphony binary.
 - Exact local runtime directory naming by owner/repo/profile.
 - Whether `.shea/workflow.md` replaces or augments root `WORKFLOW.md` in legacy
   repos.

--- a/docs/milestones/2607-hardening/adr/0005-workspace-and-config-layout.md
+++ b/docs/milestones/2607-hardening/adr/0005-workspace-and-config-layout.md
@@ -13,6 +13,12 @@ generated worktree ownership.
 Resolve the Symphony binary from the local install location. Do not vendor the
 binary into target repositories.
 
+During the App migration, package the versioned `shea-symphony-legacy` binary
+as an App sidecar. The App atomically publishes a machine-local discovery
+record only after validating the sidecar role, build identity, and digest.
+Workspace `cli_path` remains the highest-precedence explicit override;
+validated installed discovery is next; a cargo runner is debug-only.
+
 Use the target repository canonical worktree as the source checkout. Store
 tracked team shared config under repo `.shea/`, with `.shea/workflow.md` as the
 preferred workflow file.
@@ -31,9 +37,12 @@ Config precedence is:
 - Target repos can share workflow config without vendoring executables.
 - Generated worktrees stay out of canonical worktrees.
 - Local overrides remain possible.
+- Automatic resolution rejects the Temporal worker and stale or tampered
+  sidecars.
 
 ## Follow-Up
 
-- Define local install lookup order.
 - Define `~/.shea/` path layout.
 - Define migration behavior for repos with root `WORKFLOW.md`.
+- Remove the Legacy discovery and bundle path when the App no longer depends on
+  legacy product commands.

--- a/scripts/stage-legacy-sidecar.sh
+++ b/scripts/stage-legacy-sidecar.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+target=${SHEA_LEGACY_SIDECAR_TARGET:-}
+mode=stage
+
+if [ "${1:-}" = "--check" ]; then
+  mode=check
+elif [ -n "${1:-}" ]; then
+  echo "usage: scripts/stage-legacy-sidecar.sh [--check]" >&2
+  exit 2
+fi
+
+if [ -z "$target" ]; then
+  target=$(rustc -vV | sed -n 's/^host: //p')
+fi
+if [ -z "$target" ]; then
+  echo "could not resolve the Rust target triple" >&2
+  exit 1
+fi
+
+case "$target" in
+  *windows*) executable_suffix=.exe ;;
+  *) executable_suffix= ;;
+esac
+
+source_binary="$repository_root/target/$target/release/shea-symphony-legacy$executable_suffix"
+staging_dir="$repository_root/app/src-tauri/binaries"
+staged_binary="$staging_dir/shea-symphony-legacy-$target$executable_suffix"
+
+if [ "$mode" = check ]; then
+  if [ ! -f "$staged_binary" ]; then
+    echo "missing target-specific Legacy sidecar for $target: $staged_binary" >&2
+    exit 1
+  fi
+  echo "legacy_sidecar_check=ok target=$target path=$staged_binary"
+  exit 0
+fi
+
+cargo build \
+  --locked \
+  --release \
+  --manifest-path "$repository_root/Cargo.toml" \
+  --bin shea-symphony-legacy \
+  --target "$target"
+
+if [ ! -f "$source_binary" ]; then
+  echo "Legacy build completed without expected target artifact: $source_binary" >&2
+  exit 1
+fi
+
+mkdir -p "$staging_dir"
+temporary_binary="$staged_binary.tmp.$$"
+trap 'rm -f "$temporary_binary"' EXIT HUP INT TERM
+cp "$source_binary" "$temporary_binary"
+chmod 755 "$temporary_binary"
+mv "$temporary_binary" "$staged_binary"
+trap - EXIT HUP INT TERM
+
+runtime_json=$($staged_binary --runtime-info)
+expected_revision=$(git -C "$repository_root" rev-parse HEAD)
+RUNTIME_JSON="$runtime_json" EXPECTED_REVISION="$expected_revision" node -e '
+  const identity = JSON.parse(process.env.RUNTIME_JSON);
+  if (identity.schema_version !== 1 || identity.binary_role !== "legacy_cli") {
+    throw new Error("staged artifact is not a marked Legacy CLI");
+  }
+  if (identity.compatibility !== "shea-legacy-cli-v1") {
+    throw new Error("staged artifact has an incompatible Legacy contract");
+  }
+  if (identity.source_revision !== process.env.EXPECTED_REVISION) {
+    throw new Error("staged artifact source revision does not match the App checkout");
+  }
+'
+
+echo "legacy_sidecar_stage=ok target=$target revision=$expected_revision path=$staged_binary"

--- a/src/lanes/main_loop.rs
+++ b/src/lanes/main_loop.rs
@@ -45,18 +45,20 @@ pub(crate) use execution::{
 };
 pub(crate) use failure::{handle_run_loop_gate_failure, handle_run_loop_handoff_failure};
 #[cfg(test)]
+pub(crate) use handoff::run_handoff_verification;
+#[cfg(test)]
 pub(crate) use handoff::run_loop_apply_launch_workspace_report;
 #[cfg(test)]
 pub(crate) use handoff::run_loop_apply_recovery_workspace_report;
 pub(crate) use handoff::{
     apply_live_handoff_pr_link, compact_evidence, linked_pull_requests_contain,
-    native_linked_pull_requests_contain, pull_request_number_from_url, run_handoff_verification,
-    run_loop_agent_review_handoff_evidence, run_loop_apply_recovery_handoff,
-    run_loop_assignee_ownership_workpad, run_loop_handoff_failure_workpad, run_loop_handoff_plan,
-    run_loop_handoff_workpad, run_loop_live_handoff_enabled, run_loop_ownership_workpad,
-    run_loop_preflight_launch_workspace, run_loop_recovery_preflight_launch_workspace,
-    run_loop_runtime_ownership, run_loop_usage_limit_pause_workpad, HandoffVerification,
-    RunLoopLiveHandoff,
+    native_linked_pull_requests_contain, pull_request_number_from_url,
+    run_handoff_verification_with_runtime_profile, run_loop_agent_review_handoff_evidence,
+    run_loop_apply_recovery_handoff, run_loop_assignee_ownership_workpad,
+    run_loop_handoff_failure_workpad, run_loop_handoff_plan, run_loop_handoff_workpad,
+    run_loop_live_handoff_enabled, run_loop_ownership_workpad, run_loop_preflight_launch_workspace,
+    run_loop_recovery_preflight_launch_workspace, run_loop_runtime_ownership,
+    run_loop_usage_limit_pause_workpad, HandoffVerification, RunLoopLiveHandoff,
 };
 pub(crate) use preflight::{ensure_write_mode_main_agent_backend, main_app_server_smoke_gate};
 #[cfg(test)]

--- a/src/lanes/main_loop/handoff.rs
+++ b/src/lanes/main_loop/handoff.rs
@@ -16,9 +16,9 @@ use shea_symphony::lane_claim::LaneClaim;
 use shea_symphony::model::{LinkedPullRequest, TrackerIssue};
 use shea_symphony::ownership::{render_runtime_ownership_marker, RuntimeOwnershipMarker};
 use shea_symphony::profiles::selected_execution_profile;
-use shea_symphony::runtime_profile::{
-    apply_runtime_profile_environment, load_runtime_profile, RuntimeProfile,
-};
+#[cfg(test)]
+use shea_symphony::runtime_profile::load_runtime_profile;
+use shea_symphony::runtime_profile::{apply_runtime_profile_environment, RuntimeProfile};
 use shea_symphony::runtime_state::RuntimeState;
 use shea_symphony::tracker::TrackerAdapter;
 use shea_symphony::workpad_templates::{render_workpad_template, WorkpadTemplateId};
@@ -556,6 +556,7 @@ pub(crate) fn run_loop_live_handoff_enabled(config: &RuntimeConfig) -> bool {
     config.tracker.kind == "github_project_v2" && config.tracker.fixture_path.is_none()
 }
 
+#[cfg(test)]
 pub(crate) fn run_handoff_verification(
     workspace_path: &Path,
     config: &RuntimeConfig,

--- a/src/lanes/main_loop/session.rs
+++ b/src/lanes/main_loop/session.rs
@@ -154,7 +154,11 @@ fn claude_resume_session_for_state(
     let Some(worktree) = state.workspace_path.as_deref() else {
         return Ok(None);
     };
-    let Some(run_id) = state.run_id.as_deref().filter(|value| !value.trim().is_empty()) else {
+    let Some(run_id) = state
+        .run_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    else {
         return Ok(None);
     };
     let registry = load_session_registry(&session_registry_path(config))?;

--- a/src/lanes/review/automatic.rs
+++ b/src/lanes/review/automatic.rs
@@ -13,13 +13,14 @@ use shea_symphony::progress::{run_with_progress_heartbeat, ProgressHeartbeatSpec
 use shea_symphony::prompt::render_prompt;
 use shea_symphony::prompt_runtime::AUTOMATIC_HEADLESS_REVIEW_BOUNDARY;
 use shea_symphony::review::{
-    gemini_review_health_diagnostic, poll_review_job_until_terminal,
-    render_repeated_review_failure_workpad, render_review_workpad_with_workflow,
-    review_backend_from_config, review_backend_kind_from_config, review_failure_signature,
-    review_gate_decision_for_issue, review_run_eligibility, review_worker_key,
-    persist_review_job_ledger_record, transition_allowed_for_review_agent, FakeReviewBackend,
-    FakeReviewOutcome, GeminiReviewRecoveryPolicy, ReviewBackend, ReviewGateDecision, ReviewJob,
-    ReviewJobState, ReviewOutcome, ReviewRepeatedFailureEvidence, ReviewRequest, ReviewRunEligibility,
+    gemini_review_health_diagnostic, persist_review_job_ledger_record,
+    poll_review_job_until_terminal, render_repeated_review_failure_workpad,
+    render_review_workpad_with_workflow, review_backend_from_config,
+    review_backend_kind_from_config, review_failure_signature, review_gate_decision_for_issue,
+    review_run_eligibility, review_worker_key, transition_allowed_for_review_agent,
+    FakeReviewBackend, FakeReviewOutcome, GeminiReviewRecoveryPolicy, ReviewBackend,
+    ReviewGateDecision, ReviewJob, ReviewJobState, ReviewOutcome, ReviewRepeatedFailureEvidence,
+    ReviewRequest, ReviewRunEligibility,
 };
 use shea_symphony::rework::rework_transition_expected;
 #[cfg(test)]

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,0 +1,359 @@
+//! Transitional Legacy-compatible operator CLI composition root.
+//!
+//! This binary reuses the existing shared parser, commands, adapters, lanes,
+//! evidence, and readiness modules. It remains separate from the canonical
+//! Temporal worker entrypoint and never requires a Temporal connection merely
+//! to parse or execute a Legacy command.
+
+use cli::Command;
+use shea_symphony::runtime_identity::{print_if_requested, RuntimeRole};
+
+mod cli;
+mod commands;
+mod lanes;
+mod orchestration;
+
+use commands::autopilot::{autopilot_loop, autopilot_plan};
+use commands::clean::{clean_audit_command, cleanup_plan_command};
+use commands::debug::debug_report;
+use commands::doctor::{doctor, doctor_repair_human_review};
+use commands::follow_up::create_follow_up;
+use commands::forge::{
+    forge_create, forge_promote, forge_rework, forge_validate, ForgeCreateOptions,
+};
+use commands::gate::quality_gate;
+use commands::profiles::list_profiles;
+use commands::project::{
+    add_to_project, append_timeline_comment, link_pr, project_inspect, project_issue,
+    project_relationship_add_blocked_by, project_relationship_add_subissue,
+    project_relationship_list, project_relationship_verify, project_state, set_state,
+    upsert_workpad,
+};
+use commands::session::{
+    agent_session_attach, agent_session_list, agent_session_start, lane_claim_command,
+    legacy_agent_session_start, AgentSessionLaneArg,
+};
+use commands::skills::skills_status;
+use commands::status::{plan, status_api};
+use commands::target_runtime::{target_runtime_init, target_runtime_status};
+use commands::workflow::{inspect, validate};
+use commands::workspace::{
+    cleanup_workspaces, workspace_adopt, workspace_ensure, workspace_list, workspace_show,
+};
+use lanes::main_loop::{run_loop, run_once};
+use lanes::merge::{merge_loop, merge_once};
+use lanes::review::{
+    review_claim, review_clear_claim, review_fake, review_freshness, review_loop,
+    review_manual_pass, review_manual_reject, review_once, review_status,
+};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if print_if_requested(RuntimeRole::LegacyCli, &args)? {
+        return Ok(());
+    }
+    let command = Command::parse(args)?;
+
+    match command {
+        Command::Plan {
+            workflow_path,
+            json,
+        } => plan(workflow_path, json),
+        Command::AutopilotPlan {
+            workflow_path,
+            json,
+        } => autopilot_plan(workflow_path, json),
+        Command::AutopilotLoop { options } => autopilot_loop(options),
+        Command::StatusApi {
+            workflow_path,
+            bind,
+            once,
+        } => status_api(workflow_path, bind, once),
+        Command::Validate { workflow_path } => validate(workflow_path),
+        Command::Inspect {
+            workflow_path,
+            states,
+        } => inspect(workflow_path, states),
+        Command::ProjectState { options } => project_state(options),
+        Command::ProjectIssue {
+            workflow_path,
+            issue_ref,
+            json,
+        } => project_issue(workflow_path, issue_ref, json),
+        Command::ProjectInspect {
+            workflow_path,
+            issue_ref,
+            lane,
+        } => project_inspect(workflow_path, issue_ref, lane),
+        Command::ProjectRelationshipList {
+            workflow_path,
+            issue_ref,
+        } => project_relationship_list(workflow_path, issue_ref),
+        Command::ProjectRelationshipVerify {
+            workflow_path,
+            issue_ref,
+            blocked_by,
+            subissue,
+        } => project_relationship_verify(workflow_path, issue_ref, blocked_by, subissue),
+        Command::ProjectRelationshipAddBlockedBy {
+            workflow_path,
+            issue_ref,
+            blocker_ref,
+            write,
+            dry_run,
+        } => project_relationship_add_blocked_by(
+            workflow_path,
+            issue_ref,
+            blocker_ref,
+            write,
+            dry_run,
+        ),
+        Command::ProjectRelationshipAddSubissue {
+            workflow_path,
+            parent_ref,
+            subissue_ref,
+            write,
+            dry_run,
+        } => project_relationship_add_subissue(
+            workflow_path,
+            parent_ref,
+            subissue_ref,
+            write,
+            dry_run,
+        ),
+        Command::Doctor { options } => doctor(options),
+        Command::DoctorRepairHumanReview {
+            workflow_path,
+            write,
+        } => doctor_repair_human_review(workflow_path, write),
+        Command::SkillsStatus { input, json } => skills_status(input, json),
+        Command::Profiles { workflow_path } => list_profiles(workflow_path),
+        Command::Debug { workflow_path } => debug_report(workflow_path),
+        Command::TargetRuntimeStatus { path } => target_runtime_status(path),
+        Command::TargetRuntimeInit { path } => target_runtime_init(path),
+        Command::CleanupPlan { workflow_path } => cleanup_plan_command(workflow_path),
+        Command::CleanPlan { workflow_path } => cleanup_plan_command(workflow_path),
+        Command::CleanAudit { workflow_path } => clean_audit_command(workflow_path),
+        Command::RunOnce { workflow_path } => run_once(workflow_path),
+        Command::RunLoop { options } => run_loop(options),
+        Command::CleanupWorkspaces {
+            workflow_path,
+            write,
+        } => cleanup_workspaces(workflow_path, write),
+        Command::WorkspaceList { workflow_path } => workspace_list(workflow_path),
+        Command::WorkspaceShow {
+            workflow_path,
+            issue_ref,
+        } => workspace_show(workflow_path, issue_ref),
+        Command::WorkspaceAdopt {
+            workflow_path,
+            issue_ref,
+            path,
+            write,
+        } => workspace_adopt(workflow_path, issue_ref, path, write),
+        Command::WorkspaceEnsure {
+            workflow_path,
+            issue_ref,
+            pr_ref,
+            branch,
+            write,
+        } => workspace_ensure(workflow_path, issue_ref, pr_ref, branch, write),
+        Command::MergeOnce {
+            workflow_path,
+            write,
+        } => merge_once(workflow_path, write),
+        Command::MergeLoop { options } => merge_loop(options),
+        Command::SetState {
+            workflow_path,
+            issue_ref,
+            state,
+            write,
+        } => set_state(workflow_path, issue_ref, state, write),
+        Command::Workpad {
+            workflow_path,
+            issue_ref,
+            markdown_path,
+            write,
+        } => upsert_workpad(workflow_path, issue_ref, markdown_path, write),
+        Command::TimelineComment {
+            workflow_path,
+            issue_ref,
+            markdown_path,
+            write,
+        } => append_timeline_comment(workflow_path, issue_ref, markdown_path, write),
+        Command::LinkPr {
+            workflow_path,
+            issue_ref,
+            pr_ref,
+            write,
+        } => link_pr(workflow_path, issue_ref, pr_ref, write),
+        Command::CreateFollowUp {
+            workflow_path,
+            title,
+            body_path,
+            write,
+        } => create_follow_up(workflow_path, title, body_path, write),
+        Command::AddToProject {
+            workflow_path,
+            issue_id,
+            write,
+        } => add_to_project(workflow_path, issue_id, write),
+        Command::ReviewFake {
+            workflow_path,
+            issue_ref,
+            outcome,
+            write,
+        } => review_fake(workflow_path, issue_ref, outcome, write),
+        Command::ReviewOnce {
+            workflow_path,
+            issue_ref,
+            write,
+        } => review_once(workflow_path, issue_ref, write),
+        Command::ReviewClaim {
+            workflow_path,
+            issue_ref,
+            worker,
+            write,
+        } => review_claim(workflow_path, issue_ref, worker, write),
+        Command::LaneClaim {
+            workflow_path,
+            issue_ref,
+            lane,
+            worker,
+            source,
+            write,
+        } => lane_claim_command(workflow_path, issue_ref, lane, worker, source, write),
+        Command::ReviewClearClaim {
+            workflow_path,
+            issue_ref,
+            write,
+        } => review_clear_claim(workflow_path, issue_ref, write),
+        Command::ReviewPass {
+            workflow_path,
+            issue_ref,
+            evidence,
+            write,
+        } => review_manual_pass(workflow_path, issue_ref, evidence, write),
+        Command::ReviewReject {
+            workflow_path,
+            issue_ref,
+            evidence,
+            target_state,
+            write,
+        } => review_manual_reject(workflow_path, issue_ref, evidence, target_state, write),
+        Command::ReviewSession {
+            workflow_path,
+            issue_ref,
+            write,
+        } => {
+            legacy_agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Review, write)
+        }
+        Command::ReviewFreshness { input } => review_freshness(input),
+        Command::ReviewLoop { options } => review_loop(options),
+        Command::ReviewStatus { options } => review_status(options),
+        Command::MergeSession {
+            workflow_path,
+            issue_ref,
+            write,
+        } => {
+            legacy_agent_session_start(workflow_path, issue_ref, AgentSessionLaneArg::Merge, write)
+        }
+        Command::AgentSessionStart {
+            workflow_path,
+            issue_ref,
+            lane,
+            run_id,
+            write,
+        } => agent_session_start(workflow_path, issue_ref, lane, run_id, write),
+        Command::SessionStart {
+            workflow_path,
+            issue_ref,
+            lane,
+            run_id,
+            write,
+        } => agent_session_start(workflow_path, issue_ref, lane, Some(run_id), write),
+        Command::SessionList { workflow_path } => agent_session_list(workflow_path),
+        Command::SessionAttach {
+            workflow_path,
+            session,
+            exec,
+        } => agent_session_attach(workflow_path, session, exec),
+        Command::AgentSessionList { workflow_path } => agent_session_list(workflow_path),
+        Command::AgentSessionAttach {
+            workflow_path,
+            session,
+            exec,
+        } => agent_session_attach(workflow_path, session, exec),
+        Command::Gate {
+            workflow_path,
+            issue_ref,
+            apply,
+            write,
+        } => quality_gate(workflow_path, issue_ref, apply, write),
+        Command::ForgeValidate {
+            workflow_path,
+            status,
+            title,
+            markdown,
+            issue_ref,
+        } => forge_validate(workflow_path, status, title, markdown, issue_ref),
+        Command::ForgeCreate {
+            workflow_path,
+            title,
+            markdown,
+            status,
+            project,
+            project_fields,
+            assignees,
+            relationships,
+            write,
+            dry_run,
+        } => forge_create(ForgeCreateOptions {
+            workflow_path,
+            title,
+            markdown,
+            status,
+            project,
+            project_fields,
+            assignees,
+            relationships,
+            write,
+            dry_run,
+        }),
+        Command::ForgePromote {
+            workflow_path,
+            issue_ref,
+            title,
+            markdown,
+            promotion_note,
+            relationships,
+            write,
+            dry_run,
+        } => forge_promote(crate::commands::forge::ForgePromoteInput {
+            workflow_path,
+            issue_ref,
+            title,
+            markdown,
+            promotion_note,
+            relationships,
+            write,
+            dry_run,
+        }),
+        Command::ForgeRework { options } => forge_rework(options),
+        Command::Help(text) => {
+            print!("{text}");
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "main/tests.rs"]
+mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod quality_gate;
 pub mod review;
 pub mod review_status;
 pub mod rework;
+pub mod runtime_identity;
 pub mod runtime_profile;
 pub mod runtime_state;
 pub mod session_registry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,25 @@
 
 use std::path::PathBuf;
 
-use shea_symphony::{symphony::run_symphony_workers, RuntimeConfig, WorkflowStore};
+use shea_symphony::{
+    runtime_identity::{print_if_requested, RuntimeRole},
+    symphony::run_symphony_workers,
+    RuntimeConfig, WorkflowStore,
+};
 
 const DEFAULT_WORKFLOW_PATH: &str = ".shea/workflows/shea-symphony.md";
 const WORKFLOW_PATH_ENV: &str = "SHEA_WORKFLOW_PATH";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if print_if_requested(RuntimeRole::TemporalWorker, &args)? {
+        return Ok(());
+    }
+
     // In 2607 the default binary is the local Temporal worker runtime.
-    // Legacy CLI dogfooding remains pinned to the protected 2606-MVP branch.
+    // Transitional Legacy CLI dogfooding uses the separately identified
+    // shea-symphony-legacy sidecar; this composition root stays Temporal-only.
     let workflow_path = workflow_path();
     let workflow_store = WorkflowStore::load(&workflow_path)?;
     let config = RuntimeConfig::from_workflow(workflow_store.active(), &workflow_path)?;

--- a/src/main/tests/main_loop.rs
+++ b/src/main/tests/main_loop.rs
@@ -254,13 +254,20 @@ done
             ),
         )
         .unwrap();
-    let config = RuntimeConfig::from_workflow(&workflow, &workflow_path).unwrap();
+    let mut config = RuntimeConfig::from_workflow(&workflow, &workflow_path).unwrap();
     let mut first = tracker_issue_with_ref("#362", "Recover first", "In Progress");
     first.id = "ISSUE_362".into();
     first.description = Some(forge_contract());
     let mut second = tracker_issue_with_ref("#363", "Start second", "In Progress");
     second.id = "ISSUE_363".into();
     second.description = Some(forge_contract());
+    let fixture_path = temp.path().join("issues.json");
+    std::fs::write(
+        &fixture_path,
+        serde_json::to_string(&vec![first.clone(), second.clone()]).unwrap(),
+    )
+    .unwrap();
+    config.tracker.fixture_path = Some(fixture_path);
     let options = RunLoopOptions {
         workflow_path,
         max_iterations: Some(1),

--- a/src/main/tests/main_loop/handoff.rs
+++ b/src/main/tests/main_loop/handoff.rs
@@ -534,7 +534,10 @@ fn handoff_verification_runs_configured_commands() {
     let verification = run_handoff_verification(temp.path(), &config);
 
     assert!(verification.success);
-    assert_eq!(verification.summary, "passed:1 command(s)");
+    assert_eq!(
+        verification.summary,
+        "passed:1 command(s) runtime_profile=not_configured"
+    );
     assert_eq!(
         std::fs::read_to_string(temp.path().join("verification.txt")).unwrap(),
         "verified"

--- a/src/runtime_identity.rs
+++ b/src/runtime_identity.rs
@@ -1,0 +1,106 @@
+//! Machine-readable identity for Shea Symphony executable composition roots.
+//!
+//! The desktop App uses this contract to distinguish the transitional Legacy
+//! CLI from the canonical Temporal worker before it launches an operator
+//! command. It describes a build; it is not a publisher-signing mechanism.
+
+use serde::{Deserialize, Serialize};
+
+/// The only command-line flag shared by both executable composition roots.
+pub const RUNTIME_INFO_FLAG: &str = "--runtime-info";
+
+/// Schema version for [`RuntimeIdentity`] JSON output.
+pub const RUNTIME_IDENTITY_SCHEMA_VERSION: u32 = 1;
+
+/// The mutually exclusive runtime role owned by one executable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeRole {
+    /// The canonical 2607 Temporal worker entrypoint.
+    TemporalWorker,
+    /// The transitional Legacy operator CLI entrypoint.
+    LegacyCli,
+}
+
+/// Credential-free build and compatibility metadata emitted as JSON.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeIdentity {
+    /// Version of this JSON contract.
+    pub schema_version: u32,
+    /// Executable composition role.
+    pub binary_role: RuntimeRole,
+    /// Cargo package version shared by the two binaries.
+    pub cli_version: String,
+    /// Git revision embedded when the crate was built.
+    pub source_revision: String,
+    /// Rust compilation target triple.
+    pub target: String,
+    /// Operating system reported by the Rust target.
+    pub platform: String,
+    /// Processor architecture reported by the Rust target.
+    pub architecture: String,
+    /// Versioned compatibility contract implemented by this role.
+    pub compatibility: String,
+}
+
+impl RuntimeIdentity {
+    /// Builds identity metadata for one explicit executable role.
+    pub fn for_role(binary_role: RuntimeRole) -> Self {
+        let compatibility = match binary_role {
+            RuntimeRole::TemporalWorker => "shea-temporal-worker-v1",
+            RuntimeRole::LegacyCli => "shea-legacy-cli-v1",
+        };
+        Self {
+            schema_version: RUNTIME_IDENTITY_SCHEMA_VERSION,
+            binary_role,
+            cli_version: env!("CARGO_PKG_VERSION").into(),
+            source_revision: env!("SHEA_SOURCE_REVISION").into(),
+            target: env!("SHEA_TARGET_TRIPLE").into(),
+            platform: std::env::consts::OS.into(),
+            architecture: std::env::consts::ARCH.into(),
+            compatibility: compatibility.into(),
+        }
+    }
+}
+
+/// Prints identity JSON when `args` is exactly [`RUNTIME_INFO_FLAG`].
+pub fn print_if_requested(
+    binary_role: RuntimeRole,
+    args: &[String],
+) -> Result<bool, serde_json::Error> {
+    if args != [RUNTIME_INFO_FLAG] {
+        return Ok(false);
+    }
+    println!(
+        "{}",
+        serde_json::to_string(&RuntimeIdentity::for_role(binary_role))?
+    );
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roles_have_distinct_versioned_compatibility_contracts() {
+        let temporal = RuntimeIdentity::for_role(RuntimeRole::TemporalWorker);
+        let legacy = RuntimeIdentity::for_role(RuntimeRole::LegacyCli);
+
+        assert_eq!(temporal.schema_version, 1);
+        assert_eq!(legacy.schema_version, 1);
+        assert_ne!(temporal.binary_role, legacy.binary_role);
+        assert_ne!(temporal.compatibility, legacy.compatibility);
+        assert_eq!(temporal.source_revision, legacy.source_revision);
+        assert_eq!(temporal.target, legacy.target);
+    }
+
+    #[test]
+    fn identity_contract_round_trips_as_json() {
+        let expected = RuntimeIdentity::for_role(RuntimeRole::LegacyCli);
+        let json = serde_json::to_string(&expected).unwrap();
+        let actual: RuntimeIdentity = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/tests/runtime_identity.rs
+++ b/tests/runtime_identity.rs
@@ -1,0 +1,42 @@
+use std::process::{Command, Output};
+
+use shea_symphony::runtime_identity::{RuntimeIdentity, RuntimeRole};
+
+#[test]
+fn both_executables_report_distinct_roles_from_one_build() {
+    let temporal = runtime_identity(env!("CARGO_BIN_EXE_shea-symphony"));
+    let legacy = runtime_identity(env!("CARGO_BIN_EXE_shea-symphony-legacy"));
+
+    assert_eq!(temporal.binary_role, RuntimeRole::TemporalWorker);
+    assert_eq!(legacy.binary_role, RuntimeRole::LegacyCli);
+    assert_eq!(temporal.source_revision, legacy.source_revision);
+    assert_eq!(temporal.cli_version, legacy.cli_version);
+    assert_eq!(temporal.target, legacy.target);
+}
+
+#[test]
+fn legacy_help_does_not_require_temporal() {
+    let output = Command::new(env!("CARGO_BIN_EXE_shea-symphony-legacy"))
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Lane orchestration:"));
+    assert!(stdout.contains("Issue Forge:"));
+}
+
+fn runtime_identity(binary: &str) -> RuntimeIdentity {
+    let output = Command::new(binary).arg("--runtime-info").output().unwrap();
+    assert_success(&output);
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- add a separately identified `shea-symphony-legacy` composition root while keeping `shea-symphony` Temporal-only
- bundle a target-aware Legacy sidecar with the Tauri App and publish atomic, digest-checked machine-local discovery
- resolve App commands in explicit `cli_path`, validated installed Legacy, then debug Legacy Cargo-runner order, with fail-closed role checks
- document the protected-2606 transition, backport-stop condition, and Legacy deletion boundary

## Verification

- `cargo fmt --check`
- `cargo test --locked`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- explicit builds and machine-readable identity checks for both root binaries
- Legacy help oracle comparison, workflow validation, and read-only issue dry-run without Temporal
- App Rust format, 65 tests, and warning-clean Clippy
- `npm run check`, `npm test`, and `npm run build`
- target-aware staging plus `tauri build --bundles app`; embedded sidecar identity matches the final branch revision
- automated missing-artifact, Temporal-role, stale-metadata, digest-tamper, explicit-override, and debug-fallback coverage

Closes #534
