### PR TITLE
Establish a shared Workflow Capability contract

### DIFF
--- a/.shea/contracts/adapters/legacy-cli.v1.md
+++ b/.shea/contracts/adapters/legacy-cli.v1.md
@@ -1,0 +1,72 @@
+---
+kind: shea-workflow-capability-adapter
+adapter_id: legacy-cli-v1
+adapter_version: 1
+capability: ../workflow-capability.v1.md
+runtime_role: legacy_cli
+compatibility: shea-legacy-cli-v1
+---
+
+# Legacy CLI Adapter
+
+This adapter maps Workflow Capability v1 semantics to the current compatibility
+CLI and narrowly permitted GitHub content reads. The stable contract owns
+ordering, confirmation, uncertainty, and authority; this file owns only Legacy
+surface selection and syntax.
+
+Resolve the CLI and workflow paths from the active repository's app profile,
+then repository-local defaults. Verify the selected executable's runtime role
+and compatibility before use. Never embed a resolved machine path here.
+
+In the mappings below, `CLI`, `WORKFLOW`, `ISSUE`, `PR`, and Markdown paths are
+resolved inputs, not committed values.
+
+## Targeted Read Mappings
+
+| Semantic name | Legacy surface |
+| --- | --- |
+| `workflow.resolve` | Resolve the app profile, then validate `CLI WORKFLOW --help` and the workflow. |
+| `issue.read` | `CLI project issue WORKFLOW ISSUE --json` |
+| `issue.inspect` | `CLI project inspect WORKFLOW ISSUE --lane LANE` |
+| `evidence.read` | `CLI project issue WORKFLOW ISSUE --json`; use its canonical workpad and timeline evidence. |
+| `pull_request.read` | Use `issue.read` for exact linked-PR source and a targeted `gh pr view PR` only for raw PR content/readiness absent from normalized issue output. |
+| `relationships.read` | `CLI project relationship list WORKFLOW ISSUE` |
+
+Raw issue or PR reads do not replace normalized Project state, relationship,
+claim, workpad, or linked-PR readback.
+
+## Guarded Action Mappings
+
+All mappings first use their dry-run or read-only preparation surface when one
+exists, then add `--write` only during Execute.
+
+| Semantic name | Legacy Execute surface | Targeted readback |
+| --- | --- | --- |
+| `workspace.adopt` | `CLI workspace adopt WORKFLOW ISSUE PATH --write` | `CLI workspace show WORKFLOW ISSUE` |
+| `lane.claim` | `CLI LANE claim WORKFLOW ISSUE --worker WORKER --write` | `issue.read` |
+| `workpad.upsert` | `CLI project workpad WORKFLOW ISSUE MARKDOWN --write` | `evidence.read` |
+| `timeline.append` | `CLI project timeline-comment WORKFLOW ISSUE MARKDOWN --write` | `evidence.read` |
+| `issue.transition` | `CLI project set-state WORKFLOW ISSUE STATE --write` | `issue.read` |
+| `pull_request.link` | `CLI project link-pr WORKFLOW ISSUE PR --write` | `issue.read` and preserve the exact reported link source |
+| `relationship.add_blocked_by` | `CLI project relationship add-blocked-by WORKFLOW ISSUE BLOCKER --write` | `relationships.read` |
+| `relationship.add_subissue` | `CLI project relationship add-subissue WORKFLOW PARENT CHILD --write` | `relationships.read` for both issues |
+| `issue.create` | `CLI forge create --workflow WORKFLOW` with the prepared contract and `--write` | `issue.read` for the returned issue |
+| `issue.promote` | `CLI forge promote ISSUE --workflow WORKFLOW` with the prepared contract, confirmation evidence, and `--write` | `issue.read` |
+| `issue.rework` | `CLI forge rework ISSUE --workflow WORKFLOW` with the prepared contract, review evidence, confirmation, and `--write` | `issue.read` |
+
+The Legacy adapter additionally supports `CLI forge validate` as the read-only
+quality preparation surface for create, promote, and rework decisions.
+
+## Legacy Failure Mapping
+
+- Nonzero exit before a mutation request is sent maps to `not_applied` when the
+  diagnostic explicitly proves no tracker mutation occurred.
+- A validation, eligibility, authority, or canonical-checkout refusal maps to
+  `rejected` with the emitted reason.
+- Network failure, process interruption, recovery marker, or missing response
+  after a write attempt maps to `uncertain`.
+- On `uncertain`, invoke only the mapped targeted readback. Do not repeat a
+  relationship addition, comment append, claim, state transition, or Forge
+  mutation until readback proves `not_applied` and preparation still matches.
+- Preserve recovery markers and exact linked-PR source values as evidence; do
+  not upgrade diagnostic fallback evidence to native linkage.

--- a/.shea/contracts/workflow-capability.v1.md
+++ b/.shea/contracts/workflow-capability.v1.md
@@ -1,0 +1,90 @@
+---
+kind: shea-workflow-capability
+contract_version: 1
+active_workflow: ../workflows/shea-symphony.md
+adapters:
+  - id: legacy-cli-v1
+    path: adapters/legacy-cli.v1.md
+---
+
+# Workflow Capability
+
+This contract gives Shea skills one target-neutral vocabulary for reading and
+acting on an active workflow. It is an authority and navigation surface, not a
+permission grant or a command runbook.
+
+## Ownership
+
+- The active workflow owns repository, tracker, state, lane, workspace,
+  verification, and backend policy.
+- Machine-local profiles own executable paths and environment requirements.
+- An adapter maps these semantics to a runtime surface and reports which
+  capabilities it supports.
+- A consuming skill owns its lane or operator policy and may use only the
+  subset allowed by that policy.
+
+Consumers resolve `active_workflow`, select one listed adapter, and fail closed
+when either reference is missing, stale, or unsupported. They do not copy
+resolved workflow or profile values into this contract.
+
+## Targeted Reads
+
+- `workflow.resolve`: resolve the active workflow and selected adapter.
+- `issue.read`: read one issue's normalized state, fields, and issue contract.
+- `issue.inspect`: read one issue's lane-specific eligibility and quality gate.
+- `evidence.read`: read one issue's canonical workpad and append-only evidence.
+- `pull_request.read`: read one pull request and its exact issue-link source.
+- `relationships.read`: read blockers, parent, and native subissues for one issue.
+
+Prefer the narrowest read that answers the current question. A Project-wide
+scan is not a substitute for a targeted read.
+
+## Guarded Actions
+
+- `workspace.adopt`: record the selected canonical issue workspace.
+- `lane.claim`: record one lane's ownership after eligibility and readiness.
+- `workpad.upsert`: replace only the canonical lane workpad section.
+- `timeline.append`: add immutable evidence outside the canonical workpad.
+- `issue.transition`: request one allowed workflow state transition.
+- `pull_request.link`: record or verify the issue's pull request relationship.
+- `relationship.add_blocked_by`: add one native blocker relationship.
+- `relationship.add_subissue`: add one native parent/subissue relationship.
+- `issue.create`: create one validated issue contract.
+- `issue.promote`: replace one Backlog seed with a validated executable contract.
+- `issue.rework`: replace one Human Review contract with confirmed Rework scope.
+
+These names describe intent. The selected adapter owns implementation syntax;
+the active workflow and consumer policy still decide whether an action is
+available in the current state.
+
+## Mutation Protocol
+
+Every guarded action follows the same four phases:
+
+1. **Prepare** — perform targeted reads, validate authority and preconditions,
+   and render the exact intended effect without writing.
+2. **Confirm** — obtain an explicit confirmation bound to that prepared effect.
+   A supervised lane may carry pre-authorized confirmation only when its launch
+   contract names the exact issue, lane, and allowed action.
+3. **Execute** — invoke the selected adapter once with the confirmed inputs.
+4. **Targeted readback** — reread the affected issue, evidence, relationship, or
+   pull request and compare the observed effect with the prepared effect.
+
+Do not broaden a confirmation, infer it from a read-only request, or treat
+adapter success output as readback. When a phase changes workflow state, state
+is the final mutation after its supporting evidence is durable.
+
+## Failure And Uncertain Writes
+
+- A failure before Execute is `not_applied`; repair or prepare again.
+- An authoritative rejection is `rejected`; preserve the reason and stop.
+- A timeout, interrupted connection, or malformed result after Execute is
+  `uncertain`; do not retry blindly.
+- For `uncertain`, perform the targeted readback once and classify the effect as
+  `applied`, `not_applied`, or `ambiguous`.
+- Continue after `applied`. Re-prepare before retrying `not_applied`.
+- Stop for recovery or human direction on `ambiguous`, conflicting ownership,
+  stale confirmation, or changed preconditions.
+
+Adapters may document idempotent recovery mechanics, but cannot weaken these
+classification, confirmation, or readback rules.

--- a/docs/workflow-capability-contract.md
+++ b/docs/workflow-capability-contract.md
@@ -1,0 +1,28 @@
+# Workflow Capability Contract
+
+The repository-owned Workflow Capability contract lives at
+`.shea/contracts/workflow-capability.v1.md`. It gives Shea skills stable names
+for targeted reads and guarded actions plus one prepare, confirm, execute, and
+readback protocol. Concrete runtime syntax lives in a separately versioned
+adapter under `.shea/contracts/adapters/`.
+
+This is the authoritative skill-suite ownership note for that shared contract;
+skill installation and distribution remain documented separately.
+
+## Ownership Boundary
+
+- Workflow configuration owns target repository, tracker, state mapping,
+  workspace, lane backend, and verification policy.
+- Machine-local profiles own resolved executables and environment requirements.
+- The Workflow Capability contract owns stable semantic names and mutation
+  safety rules without copying those values.
+- Adapters own runtime-specific mappings without redefining stable semantics.
+- Skills own conversational and lane authority and declare only the semantic
+  subset they consume.
+
+The contract is not a second workflow file, an action registry, or a permission
+grant. Consumers must resolve its active workflow and adapter references, honor
+their own narrower authority, and fail closed when references or readback are
+uncertain. Representative Manual Main and Reflect fixtures under
+`tests/fixtures/workflow-capability/` demonstrate consumption without changing
+the live skills.

--- a/tests/fixtures/workflow-capability/manual-main.md
+++ b/tests/fixtures/workflow-capability/manual-main.md
@@ -1,0 +1,41 @@
+---
+kind: shea-workflow-capability-consumer-fixture
+fixture_version: 1
+consumer: manual-main
+capability: .shea/contracts/workflow-capability.v1.md
+adapter: .shea/contracts/adapters/legacy-cli.v1.md
+required_reads:
+  - workflow.resolve
+  - issue.read
+  - issue.inspect
+  - evidence.read
+  - pull_request.read
+  - relationships.read
+guarded_actions:
+  - workspace.adopt
+  - lane.claim
+  - workpad.upsert
+  - issue.transition
+  - pull_request.link
+---
+
+# Manual Main Consumer
+
+The capability contract owns mutation ordering and uncertainty handling. The
+Manual Main policy supplies narrower authority: one eligible operator-selected
+issue, one canonical workspace and branch, and a stop at Agent Review.
+
+1. Resolve the active workflow and adapter, then perform the targeted issue,
+   evidence, relationship, and workspace reads required by Main policy.
+2. Prepare workspace adoption and claim only after the issue's selection gates
+   pass; use the operator-selected Main invocation as confirmation for those
+   exact issue-scoped actions.
+3. Record the plan, implement accepted scope, and keep verification evidence in
+   the canonical workpad.
+4. Prepare and execute the ready pull-request linkage only after verification,
+   then require exact linkage readback.
+5. Make the Agent Review transition the last mutation and stop after targeted
+   issue readback.
+
+This fixture intentionally contains no adapter command syntax and does not
+change the live Manual Main skill.

--- a/tests/fixtures/workflow-capability/reflect.md
+++ b/tests/fixtures/workflow-capability/reflect.md
@@ -1,0 +1,33 @@
+---
+kind: shea-workflow-capability-consumer-fixture
+fixture_version: 1
+consumer: reflect
+capability: .shea/contracts/workflow-capability.v1.md
+adapter: .shea/contracts/adapters/legacy-cli.v1.md
+required_reads:
+  - workflow.resolve
+  - issue.read
+  - evidence.read
+  - pull_request.read
+  - relationships.read
+guarded_actions:
+  - issue.create
+  - issue.promote
+---
+
+# Reflect Consumer
+
+The capability contract owns mutation ordering and uncertainty handling.
+Reflect policy remains advisory until the operator confirms one exact issue
+creation or promotion prepared from current evidence.
+
+1. Resolve the active workflow and adapter, then use targeted issue, evidence,
+   pull-request, and relationship reads for the selected reflection window.
+2. Keep observations and candidate drafts read-only while discussing scope,
+   duplicates, dependencies, and intended status.
+3. Prepare one validated create or promotion effect and show it to the operator.
+4. Execute only the explicitly confirmed effect, perform targeted issue and
+   relationship readback, and preserve uncertainty instead of guessing.
+
+This fixture intentionally contains no adapter command syntax and does not
+change the live Reflect skill.

--- a/tests/workflow_capability_contract.rs
+++ b/tests/workflow_capability_contract.rs
@@ -1,0 +1,316 @@
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+const READS: &[&str] = &[
+    "workflow.resolve",
+    "issue.read",
+    "issue.inspect",
+    "evidence.read",
+    "pull_request.read",
+    "relationships.read",
+];
+
+const ACTIONS: &[&str] = &[
+    "workspace.adopt",
+    "lane.claim",
+    "workpad.upsert",
+    "timeline.append",
+    "issue.transition",
+    "pull_request.link",
+    "relationship.add_blocked_by",
+    "relationship.add_subissue",
+    "issue.create",
+    "issue.promote",
+    "issue.rework",
+];
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CapabilityMetadata {
+    kind: String,
+    contract_version: u64,
+    active_workflow: String,
+    adapters: Vec<AdapterReference>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AdapterReference {
+    id: String,
+    path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AdapterMetadata {
+    kind: String,
+    adapter_id: String,
+    adapter_version: u64,
+    capability: String,
+    runtime_role: String,
+    compatibility: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ConsumerFixtureMetadata {
+    kind: String,
+    fixture_version: u64,
+    consumer: String,
+    capability: String,
+    adapter: String,
+    required_reads: Vec<String>,
+    guarded_actions: Vec<String>,
+}
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn repo_file(path: &str) -> String {
+    fs::read_to_string(repo_root().join(path))
+        .unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+}
+
+fn front_matter<T: for<'de> Deserialize<'de>>(source: &str) -> Result<(T, &str), String> {
+    let source = source
+        .strip_prefix("---\n")
+        .ok_or_else(|| "missing YAML front matter".to_string())?;
+    let (yaml, body) = source
+        .split_once("\n---\n")
+        .ok_or_else(|| "unterminated YAML front matter".to_string())?;
+    let metadata = serde_yaml::from_str(yaml).map_err(|error| error.to_string())?;
+    Ok((metadata, body))
+}
+
+fn reject_target_or_owned_values(source: &str) -> Result<(), String> {
+    for forbidden in [
+        "Alive24/",
+        "github.com/",
+        "/Users/",
+        "/home/",
+        "C:\\\\",
+        "project_number:",
+        "base_branch:",
+        "cli_path:",
+        "verification.commands",
+    ] {
+        if source.contains(forbidden) {
+            return Err(format!(
+                "contract duplicates workflow/profile ownership or target identity: {forbidden}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_capability(source: &str) -> Result<CapabilityMetadata, String> {
+    let (metadata, body): (CapabilityMetadata, _) = front_matter(source)?;
+    if metadata.kind != "shea-workflow-capability" || metadata.contract_version != 1 {
+        return Err("unsupported or missing capability version".into());
+    }
+    if metadata.active_workflow.is_empty() || Path::new(&metadata.active_workflow).is_absolute() {
+        return Err("active workflow reference must be relative".into());
+    }
+    if metadata.adapters.is_empty() {
+        return Err("capability must reference at least one adapter".into());
+    }
+    reject_target_or_owned_values(source)?;
+    if body.lines().count() > 130 {
+        return Err("stable contract is oversized".into());
+    }
+    for name in READS.iter().chain(ACTIONS) {
+        if !body.contains(&format!("`{name}`")) {
+            return Err(format!("stable contract is missing semantic name {name}"));
+        }
+    }
+    for phase in [
+        "**Prepare**",
+        "**Confirm**",
+        "**Execute**",
+        "**Targeted readback**",
+    ] {
+        if !body.contains(phase) {
+            return Err(format!("stable contract is missing mutation phase {phase}"));
+        }
+    }
+    for classification in [
+        "`applied`",
+        "`not_applied`",
+        "`rejected`",
+        "`uncertain`",
+        "`ambiguous`",
+    ] {
+        if !body.contains(classification) {
+            return Err(format!("stable contract is missing {classification}"));
+        }
+    }
+    for legacy_syntax in ["`CLI ", "`gh ", "--write", "`project ", "`forge "] {
+        if body.contains(legacy_syntax) {
+            return Err(format!(
+                "stable contract contains adapter syntax: {legacy_syntax}"
+            ));
+        }
+    }
+    Ok(metadata)
+}
+
+fn validate_adapter(source: &str) -> Result<AdapterMetadata, String> {
+    let (metadata, body): (AdapterMetadata, _) = front_matter(source)?;
+    if metadata.kind != "shea-workflow-capability-adapter"
+        || metadata.adapter_id != "legacy-cli-v1"
+        || metadata.adapter_version != 1
+        || metadata.runtime_role != "legacy_cli"
+        || metadata.compatibility != "shea-legacy-cli-v1"
+    {
+        return Err("unsupported or missing adapter identity".into());
+    }
+    reject_target_or_owned_values(source)?;
+    if body.lines().count() > 150 {
+        return Err("Legacy adapter is oversized".into());
+    }
+    if !body.contains("The stable contract owns") {
+        return Err("adapter must preserve stable-contract ownership".into());
+    }
+    for name in READS.iter().chain(ACTIONS) {
+        if !body.contains(&format!("`{name}`")) {
+            return Err(format!("adapter is missing mapping for {name}"));
+        }
+    }
+    for expected in [
+        "project issue",
+        "project inspect",
+        "project relationship list",
+        "project workpad",
+        "project set-state",
+        "project link-pr",
+        "forge validate",
+        "--write",
+    ] {
+        if !body.contains(expected) {
+            return Err(format!("adapter is missing Legacy surface {expected}"));
+        }
+    }
+    Ok(metadata)
+}
+
+fn validate_fixture(source: &str) -> Result<ConsumerFixtureMetadata, String> {
+    let (metadata, body): (ConsumerFixtureMetadata, _) = front_matter(source)?;
+    if metadata.kind != "shea-workflow-capability-consumer-fixture" || metadata.fixture_version != 1
+    {
+        return Err("unsupported or missing consumer fixture version".into());
+    }
+    reject_target_or_owned_values(source)?;
+    if body.lines().count() > 45 {
+        return Err("consumer fixture is an oversized runbook".into());
+    }
+    for name in &metadata.required_reads {
+        if !READS.contains(&name.as_str()) {
+            return Err(format!("fixture uses unknown read {name}"));
+        }
+    }
+    for name in &metadata.guarded_actions {
+        if !ACTIONS.contains(&name.as_str()) {
+            return Err(format!("fixture uses unknown action {name}"));
+        }
+    }
+    for runbook_syntax in ["project issue", "forge create", "--write", "gh pr view"] {
+        if body.contains(runbook_syntax) {
+            return Err(format!(
+                "fixture duplicates adapter syntax: {runbook_syntax}"
+            ));
+        }
+    }
+    if !body.contains("capability contract owns mutation ordering and uncertainty handling") {
+        return Err("fixture must defer shared mutation semantics to the contract".into());
+    }
+    Ok(metadata)
+}
+
+#[test]
+fn workflow_capability_and_legacy_adapter_are_versioned_and_cross_referenced() {
+    let capability_path = repo_root().join(".shea/contracts/workflow-capability.v1.md");
+    let adapter_path = repo_root().join(".shea/contracts/adapters/legacy-cli.v1.md");
+    let capability_source = repo_file(".shea/contracts/workflow-capability.v1.md");
+    let adapter_source = repo_file(".shea/contracts/adapters/legacy-cli.v1.md");
+
+    let capability = validate_capability(&capability_source).expect("valid stable capability");
+    let adapter = validate_adapter(&adapter_source).expect("valid Legacy adapter");
+
+    assert!(capability_path
+        .parent()
+        .unwrap()
+        .join(&capability.active_workflow)
+        .is_file());
+    let adapter_refs: BTreeSet<_> = capability
+        .adapters
+        .iter()
+        .map(|entry| entry.id.as_str())
+        .collect();
+    assert_eq!(adapter_refs, BTreeSet::from(["legacy-cli-v1"]));
+    assert!(capability_path
+        .parent()
+        .unwrap()
+        .join(&capability.adapters[0].path)
+        .is_file());
+    assert_eq!(
+        fs::canonicalize(adapter_path.parent().unwrap().join(&adapter.capability)).unwrap(),
+        fs::canonicalize(capability_path).unwrap()
+    );
+}
+
+#[test]
+fn representative_consumers_reference_shared_contracts_without_commands() {
+    for (path, consumer) in [
+        (
+            "tests/fixtures/workflow-capability/manual-main.md",
+            "manual-main",
+        ),
+        ("tests/fixtures/workflow-capability/reflect.md", "reflect"),
+    ] {
+        let fixture = validate_fixture(&repo_file(path)).expect("valid consumer fixture");
+        assert_eq!(fixture.consumer, consumer);
+        assert!(repo_root().join(&fixture.capability).is_file());
+        assert!(repo_root().join(&fixture.adapter).is_file());
+        assert!(!fixture.required_reads.is_empty());
+        assert!(!fixture.guarded_actions.is_empty());
+    }
+}
+
+#[test]
+fn structural_validation_rejects_missing_refs_duplicated_ownership_and_runbooks() {
+    let capability = repo_file(".shea/contracts/workflow-capability.v1.md");
+    let fixture = repo_file("tests/fixtures/workflow-capability/manual-main.md");
+
+    assert!(validate_capability(&capability.replace("contract_version: 1\n", "")).is_err());
+    assert!(validate_capability(&capability.replace(
+        "adapters:\n  - id: legacy-cli-v1\n    path: adapters/legacy-cli.v1.md",
+        "adapters: []",
+    ))
+    .is_err());
+    assert!(validate_capability(&format!("{capability}\nproject_number: 9")).is_err());
+    assert!(validate_capability(&format!("{capability}\nAlive24/shea-symphony")).is_err());
+    assert!(validate_capability(&format!("{capability}\n/Users/example/tool")).is_err());
+
+    let oversized = format!("{fixture}\n{}", "- duplicated procedure\n".repeat(60));
+    assert!(validate_fixture(&oversized).is_err());
+    assert!(validate_fixture(&format!("{fixture}\nproject issue WORKFLOW ISSUE")).is_err());
+}
+
+#[test]
+fn documentation_keeps_workflow_profile_adapter_and_skill_ownership_separate() {
+    let docs = repo_file("docs/workflow-capability-contract.md");
+    for owner in [
+        "Workflow configuration owns",
+        "Machine-local profiles own",
+        "Workflow Capability contract owns",
+        "Adapters own",
+        "Skills own",
+    ] {
+        assert!(docs.contains(owner), "missing ownership boundary: {owner}");
+    }
+    assert!(docs.contains("not a second workflow file"));
+}


### PR DESCRIPTION
## Summary

- add a concise, versioned Workflow Capability contract with targeted reads, semantic guarded actions, and prepare/confirm/execute/readback handling
- separate current Legacy CLI mappings from stable semantics
- add command-free Manual Main and Reflect fixtures plus structural validation and an ownership note

## Verification

- `cargo fmt --check`
- `cargo test --test workflow_capability_contract`
- `cargo test`

Closes #538