### PR TITLE
Fail closed on missing legacy Review verdicts

### DIFF
--- a/src/review.rs
+++ b/src/review.rs
@@ -2238,6 +2238,73 @@ mod tests {
     }
 
     #[test]
+    fn quoted_future_pass_after_sandbox_denial_keeps_issue_in_agent_review() {
+        let job = completed_gemini_review(
+            "I reviewed the Workpad because the workspace is outside the sandbox.\n\nOnce you approve the plan, I will output the final result (`Review Result: PASS` with checklist evidence).",
+        );
+
+        let decision = review_gate_decision(&job);
+
+        assert_eq!(decision.outcome, ReviewOutcome::BackendUnavailable);
+        assert_eq!(decision.target_state, Some("agent_review"));
+        assert!(decision
+            .message
+            .contains("sandbox could not access the issue workspace"));
+        assert!(transition_allowed_for_review_agent(
+            "agent_review",
+            &decision
+        ));
+        assert!(!transition_allowed_for_review_agent("rework", &decision));
+    }
+
+    #[test]
+    fn leading_prose_and_confirmed_finding_without_result_cannot_route_to_rework() {
+        let job = completed_gemini_review(
+            "Review could not be completed.\n[Confirmed] Bug: broken\nReview Result: REWORK",
+        );
+
+        let decision = review_gate_decision(&job);
+
+        assert_eq!(decision.outcome, ReviewOutcome::BackendUnavailable);
+        assert_eq!(decision.target_state, Some("agent_review"));
+        assert!(!transition_allowed_for_review_agent("rework", &decision));
+    }
+
+    #[test]
+    fn missing_legacy_result_keeps_issue_in_agent_review() {
+        let job = completed_gemini_review("Review completed without a terminal result.");
+
+        let decision = review_gate_decision(&job);
+
+        assert_eq!(decision.outcome, ReviewOutcome::BackendUnavailable);
+        assert_eq!(decision.target_state, Some("agent_review"));
+    }
+
+    #[test]
+    fn exact_first_line_pass_still_routes_to_human_review() {
+        let job = completed_gemini_review(
+            "Review Result: PASS\n\nThe diff and required verification were independently inspected.",
+        );
+
+        let decision = review_gate_decision(&job);
+
+        assert_eq!(decision.outcome, ReviewOutcome::PassedToHumanReview);
+        assert_eq!(decision.target_state, Some("human_review"));
+    }
+
+    #[test]
+    fn exact_first_line_needs_context_still_routes_to_rework() {
+        let job = completed_gemini_review(
+            "Review Result: NEEDS_CONTEXT\n\nThe linked PR could not be inspected.",
+        );
+
+        let decision = review_gate_decision(&job);
+
+        assert_eq!(decision.outcome, ReviewOutcome::InconclusiveNeedsRework);
+        assert_eq!(decision.target_state, Some("rework"));
+    }
+
+    #[test]
     fn human_owned_uat_finding_does_not_block_agent_review_pass() {
         let job = completed_gemini_review(
             "Review Result: REWORK\n\n[Confirmed] Missing UAT: Live UAT with `main loop --write` was not run.",
@@ -2849,7 +2916,7 @@ mod tests {
     }
 
     #[test]
-    fn completed_review_with_missing_workspace_routes_to_rework() {
+    fn completed_legacy_review_with_missing_workspace_stays_in_agent_review() {
         let job = completed_gemini_review(
             "I could not complete the review because the workspace is empty.",
         );
@@ -2858,29 +2925,33 @@ mod tests {
         let record = review_job_ledger_record(&issue(), &job, "/tmp/review-ledger.json".into());
         let workpad = render_review_workpad(&issue(), &job);
 
-        assert_eq!(decision.outcome, ReviewOutcome::InconclusiveNeedsRework);
-        assert_eq!(decision.target_state, Some("rework"));
+        assert_eq!(decision.outcome, ReviewOutcome::BackendUnavailable);
+        assert_eq!(decision.target_state, Some("agent_review"));
+        assert_eq!(record.decision_outcome, ReviewOutcome::BackendUnavailable);
         assert_eq!(
-            record.decision_outcome,
-            ReviewOutcome::InconclusiveNeedsRework
+            record.decision_target_state.as_deref(),
+            Some("agent_review")
         );
-        assert_eq!(record.decision_target_state.as_deref(), Some("rework"));
         assert!(workpad.contains("### Inconclusive Review Diagnostic"));
         assert!(workpad.contains("workspace is empty"));
         assert!(!workpad.contains("Review pass evidence: `recorded`"));
     }
 
     #[test]
-    fn completed_review_with_missing_pr_evidence_routes_to_rework() {
+    fn completed_legacy_review_with_missing_pr_evidence_stays_in_agent_review() {
         let job = completed_gemini_review(
             "Review could not be completed: expected code changes and PR evidence were missing from the workspace.",
         );
 
         let decision = review_gate_decision(&job);
 
-        assert_eq!(decision.outcome, ReviewOutcome::InconclusiveNeedsRework);
-        assert_eq!(decision.target_state, Some("rework"));
-        assert!(transition_allowed_for_review_agent("rework", &decision));
+        assert_eq!(decision.outcome, ReviewOutcome::BackendUnavailable);
+        assert_eq!(decision.target_state, Some("agent_review"));
+        assert!(transition_allowed_for_review_agent(
+            "agent_review",
+            &decision
+        ));
+        assert!(!transition_allowed_for_review_agent("rework", &decision));
         assert!(!transition_allowed_for_review_agent(
             "human_review",
             &decision
@@ -2888,15 +2959,15 @@ mod tests {
     }
 
     #[test]
-    fn completed_review_that_cannot_inspect_pr_routes_to_rework() {
+    fn completed_legacy_review_that_cannot_inspect_pr_stays_in_agent_review() {
         let job = completed_gemini_review(
             "Unable to inspect the PR or required handoff evidence, so this review is inconclusive.",
         );
 
         let decision = review_gate_decision(&job);
 
-        assert_eq!(decision.outcome, ReviewOutcome::InconclusiveNeedsRework);
-        assert_eq!(decision.target_state, Some("rework"));
+        assert_eq!(decision.outcome, ReviewOutcome::BackendUnavailable);
+        assert_eq!(decision.target_state, Some("agent_review"));
     }
 
     #[test]

--- a/src/review/decision.rs
+++ b/src/review/decision.rs
@@ -85,6 +85,20 @@ pub fn review_gate_decision_for_actor(job: &ReviewJob, actor: ReviewActor) -> Re
             message: "Agent review is still running; issue remains in Agent Review.".into(),
         },
         ReviewJobState::Completed => match &job.report {
+            // Legacy text findings are advisory until an exact first-line result
+            // proves that the backend produced a terminal Review verdict.
+            Some(report) if report.legacy_backend_missing_review_result() => {
+                ReviewGateDecision {
+                    outcome: ReviewOutcome::BackendUnavailable,
+                    target_state: Some("agent_review"),
+                    message: format!(
+                        "Review backend is unavailable: {}; issue remains in Agent Review because no terminal review verdict was produced.",
+                        report.legacy_backend_access_failure_reason().unwrap_or(
+                            "legacy review backend did not start with a required Review Result line"
+                        )
+                    ),
+                }
+            }
             Some(report) if report.blocks_progress() => ReviewGateDecision {
                 outcome: ReviewOutcome::NeedsRework,
                 target_state: Some("rework"),

--- a/src/review/report.rs
+++ b/src/review/report.rs
@@ -61,14 +61,44 @@ pub struct AgentReviewReport {
 
 impl AgentReviewReport {
     pub(crate) fn has_parsed_review_result(&self) -> bool {
-        [
+        [self.summary.as_deref(), self.stdout.as_deref()]
+            .into_iter()
+            .flatten()
+            .any(|text| parse_review_result(text).is_some())
+    }
+
+    pub(crate) fn legacy_backend_access_failure_reason(&self) -> Option<&'static str> {
+        if !self.legacy_backend_missing_review_result() {
+            return None;
+        }
+
+        let text = [
             self.summary.as_deref(),
             self.stdout.as_deref(),
             self.stderr.as_deref(),
         ]
         .into_iter()
         .flatten()
-        .any(|text| parse_review_result(text).is_some())
+        .collect::<Vec<_>>()
+        .join("\n")
+        .to_ascii_lowercase();
+
+        [
+            "workspace is outside the sandbox",
+            "workspace was outside the sandbox",
+            "workspace is outside sandbox",
+            "workspace was outside sandbox",
+            "sandbox denied access to the workspace",
+            "sandbox prevented access to the workspace",
+        ]
+        .iter()
+        .any(|pattern| text.contains(pattern))
+        .then_some("review backend sandbox could not access the issue workspace")
+    }
+
+    pub(crate) fn legacy_backend_missing_review_result(&self) -> bool {
+        matches!(self.reviewer_backend.as_str(), "agy-cli" | "gemini-cli")
+            && !self.has_parsed_review_result()
     }
 
     /// Returns whether a confirmed non-UAT finding requires implementation rework.
@@ -89,6 +119,13 @@ impl AgentReviewReport {
             .any(|finding| finding.class == ReviewFindingClass::NeedsContext)
         {
             return Some("review produced Needs Context findings".into());
+        }
+
+        if self.legacy_backend_missing_review_result() {
+            return Some(
+                "legacy review backend did not start with a required terminal Review Result line"
+                    .into(),
+            );
         }
 
         let text = [
@@ -237,26 +274,21 @@ enum ParsedReviewResult {
 }
 
 fn parse_review_result(output: &str) -> Option<ParsedReviewResult> {
-    output.lines().find_map(|line| {
-        let normalized = line
-            .trim()
-            .trim_matches(|ch: char| ch == '*' || ch == '_' || ch == '`')
-            .to_ascii_lowercase();
-        let (_, value) = normalized.split_once("review result:")?;
-        let value = value.trim();
-        if value.starts_with("pass") {
-            Some(ParsedReviewResult::Pass)
-        } else if value.starts_with("rework") {
-            Some(ParsedReviewResult::Rework)
-        } else if value.starts_with("needs_context")
-            || value.starts_with("needs context")
-            || value.starts_with("need context")
-        {
-            Some(ParsedReviewResult::NeedsContext)
-        } else {
-            None
-        }
-    })
+    let line = output
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())?;
+    let normalized = line
+        .trim_matches(|ch: char| ch == '*' || ch == '_' || ch == '`')
+        .to_ascii_lowercase();
+    match normalized.as_str() {
+        "review result: pass" => Some(ParsedReviewResult::Pass),
+        "review result: rework" => Some(ParsedReviewResult::Rework),
+        "review result: needs_context"
+        | "review result: needs context"
+        | "review result: need context" => Some(ParsedReviewResult::NeedsContext),
+        _ => None,
+    }
 }
 
 fn parse_loose_finding_line(line: &str) -> Option<ReviewFinding> {
@@ -407,4 +439,45 @@ fn inconclusive_review_text_reason(text: &str) -> Option<String> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_review_result, ParsedReviewResult};
+
+    #[test]
+    fn parses_exact_supported_result_on_first_non_empty_line() {
+        assert_eq!(
+            parse_review_result("\nReview Result: PASS\nEvidence follows."),
+            Some(ParsedReviewResult::Pass)
+        );
+        assert_eq!(
+            parse_review_result("Review Result: REWORK\n[Confirmed] Bug: broken"),
+            Some(ParsedReviewResult::Rework)
+        );
+        assert_eq!(
+            parse_review_result("Review Result: NEEDS_CONTEXT\nMissing workspace."),
+            Some(ParsedReviewResult::NeedsContext)
+        );
+    }
+
+    #[test]
+    fn rejects_non_terminal_or_missing_result_text() {
+        assert_eq!(
+            parse_review_result("I could not inspect the workspace.\nReview Result: PASS"),
+            None
+        );
+        assert_eq!(
+            parse_review_result("I will later output (`Review Result: PASS`) after approval."),
+            None
+        );
+        assert_eq!(
+            parse_review_result("Review completed without a result."),
+            None
+        );
+        assert_eq!(
+            parse_review_result("Review Result: PASS with caveats"),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- require legacy AGY/Gemini Review output to begin with an exact supported terminal result
- keep every legacy no-verdict completion in Agent Review, including recognized workspace sandbox denial and findings that would otherwise imply Rework
- preserve exact PASS, REWORK, and NEEDS_CONTEXT routing and leave structured Codex/Claude transports unchanged

## Validation

- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo test review:: (100 passed, 1 explicit live-backend test ignored)
- git diff --check

## Main-lane evidence

- Run: `20260815T1948Z-issue540-main-d0a8`
- Target/default base: `main` / `main`
- Main implementation stops at `Agent Review`; independent Review owns the next gate.

Closes #540
